### PR TITLE
Revert rename of decrypted_payload to decrypted_msg in Message

### DIFF
--- a/libvcx/src/aries/handlers/connection/mod.rs
+++ b/libvcx/src/aries/handlers/connection/mod.rs
@@ -31,6 +31,7 @@ pub mod tests {
         use aries::test::{Alice, Faber};
 
         use super::*;
+        use serde_json::Value;
 
         #[test]
         #[cfg(feature = "aries")]
@@ -147,8 +148,9 @@ pub mod tests {
 
                 let messages: Vec<MessageByConnection> = download_messages_noauth(None, Some(vec!["MS-103".to_string()]), None).unwrap();
                 let message: Message = messages[0].msgs[0].clone();
-                let decrypted_msg = message.decrypted_payload.unwrap();
-                let _payload: aries::messages::issuance::credential_offer::CredentialOffer = ::serde_json::from_str(&decrypted_msg).unwrap();
+                let msg_wrapper: Value = ::serde_json::from_str(&message.decrypted_payload.unwrap()).unwrap();
+                let msg_aries = msg_wrapper["@msg"].as_str().unwrap();
+                let _payload: aries::messages::issuance::credential_offer::CredentialOffer = ::serde_json::from_str(msg_aries).unwrap();
 
                 ::connection::update_message_status(alice.connection_handle, message.uid).unwrap();
             }

--- a/libvcx/src/aries/handlers/connection/mod.rs
+++ b/libvcx/src/aries/handlers/connection/mod.rs
@@ -147,7 +147,7 @@ pub mod tests {
 
                 let messages: Vec<MessageByConnection> = download_messages_noauth(None, Some(vec!["MS-103".to_string()]), None).unwrap();
                 let message: Message = messages[0].msgs[0].clone();
-                let decrypted_msg = message.decrypted_msg.unwrap();
+                let decrypted_msg = message.decrypted_payload.unwrap();
                 let _payload: aries::messages::issuance::credential_offer::CredentialOffer = ::serde_json::from_str(&decrypted_msg).unwrap();
 
                 ::connection::update_message_status(alice.connection_handle, message.uid).unwrap();

--- a/libvcx/src/aries/mod.rs
+++ b/libvcx/src/aries/mod.rs
@@ -18,6 +18,7 @@ pub mod test {
     use utils::plugins::init_plugin;
     use aries::messages::a2a::A2AMessage;
     use error::{VcxResult, VcxErrorKind, VcxError};
+    use serde_json::Value;
 
     pub fn source_id() -> String {
         String::from("test source id")
@@ -131,24 +132,21 @@ pub mod test {
         )
     }
 
-    fn str_message_to_payload_type(message: &str) -> VcxResult<PayloadKinds> {
-        let a2a_message = str_message_to_a2a_message(message)?;
-        Ok(determine_message_type(a2a_message))
-    }
-
-
     fn download_message(did: String, filter_msg_type: PayloadKinds) -> VcxAgencyMessage {
         let mut messages = ::messages::get_message::download_messages_noauth(Some(vec![did]), Some(vec![String::from("MS-103")]), None).unwrap();
         assert_eq!(1, messages.len());
         let messages = messages.pop().unwrap();
 
         for message in messages.msgs.into_iter() {
-            let decrypted_msg = &message.decrypted_payload.unwrap();
-            let msg_type = str_message_to_payload_type(decrypted_msg).unwrap();
+            let decrypted_payload = &message.decrypted_payload.unwrap();
+            let msg_wrapper: Value = serde_json::from_str(decrypted_payload).unwrap();
+            let msg_content = msg_wrapper["@msg"].as_str().unwrap();
+            let a2a_message = str_message_to_a2a_message(msg_content).unwrap();
+            let msg_type = determine_message_type(a2a_message);
             if filter_msg_type == msg_type {
                 return VcxAgencyMessage {
                     uid: message.uid,
-                    decrypted_payload: decrypted_msg.clone(),
+                    decrypted_payload: msg_content.into(),
                 };
             }
         }

--- a/libvcx/src/aries/mod.rs
+++ b/libvcx/src/aries/mod.rs
@@ -143,7 +143,7 @@ pub mod test {
         let messages = messages.pop().unwrap();
 
         for message in messages.msgs.into_iter() {
-            let decrypted_msg = &message.decrypted_msg.unwrap();
+            let decrypted_msg = &message.decrypted_payload.unwrap();
             let msg_type = str_message_to_payload_type(decrypted_msg).unwrap();
             if filter_msg_type == msg_type {
                 return VcxAgencyMessage {

--- a/libvcx/src/connection.rs
+++ b/libvcx/src/connection.rs
@@ -637,21 +637,21 @@ pub mod tests {
         let all_messages = download_messages_noauth(None, None, None).unwrap();
         assert_eq!(all_messages.len(), 1);
         assert_eq!(all_messages[0].msgs.len(), 3);
-        assert!(all_messages[0].msgs[0].decrypted_msg.is_some());
-        assert!(all_messages[0].msgs[1].decrypted_msg.is_some());
+        assert!(all_messages[0].msgs[0].decrypted_payload.is_some());
+        assert!(all_messages[0].msgs[1].decrypted_payload.is_some());
 
         let received = download_messages_noauth(None, Some(vec![MessageStatusCode::Received.to_string()]), None).unwrap();
         assert_eq!(received.len(), 1);
         assert_eq!(received[0].msgs.len(), 2);
-        assert!(received[0].msgs[0].decrypted_msg.is_some());
+        assert!(received[0].msgs[0].decrypted_payload.is_some());
         assert_eq!(received[0].msgs[0].status_code, MessageStatusCode::Received);
-        assert!(received[0].msgs[1].decrypted_msg.is_some());
+        assert!(received[0].msgs[1].decrypted_payload.is_some());
 
         // there should be messages in "Reviewed" status connections/1.0/response from Aries-Faber connection protocol
         let reviewed = download_messages_noauth(None, Some(vec![MessageStatusCode::Reviewed.to_string()]), None).unwrap();
         assert_eq!(reviewed.len(), 1);
         assert_eq!(reviewed[0].msgs.len(), 1);
-        assert!(reviewed[0].msgs[0].decrypted_msg.is_some());
+        assert!(reviewed[0].msgs[0].decrypted_payload.is_some());
         assert_eq!(reviewed[0].msgs[0].status_code, MessageStatusCode::Reviewed);
 
         let rejected = download_messages_noauth(None, Some(vec![MessageStatusCode::Rejected.to_string()]), None).unwrap();

--- a/libvcx/src/connection.rs
+++ b/libvcx/src/connection.rs
@@ -661,6 +661,14 @@ pub mod tests {
         let specific = download_messages_noauth(None, None, Some(vec![received[0].msgs[0].uid.clone()])).unwrap();
         assert_eq!(specific.len(), 1);
         assert_eq!(specific[0].msgs.len(), 1);
+        let msg = specific[0].msgs[0].decrypted_payload.clone().unwrap();
+        let msg_wrapper_value: Value = serde_json::from_str(&msg).unwrap();
+        assert!(msg_wrapper_value["@msg"].is_string());
+        let msg_aries_value: Value = serde_json::from_str(&msg_wrapper_value["@msg"].as_str().unwrap()).unwrap();
+        assert!(msg_aries_value.is_object());
+        assert!(msg_aries_value["@id"].is_string());
+        assert!(msg_aries_value["@type"].is_string());
+        assert!(msg_aries_value["content"].is_string());
 
         let unknown_did = "CmrXdgpTXsZqLQtGpX5Yee".to_string();
         let empty = download_messages_noauth(Some(vec![unknown_did]), None, None).unwrap();

--- a/libvcx/src/messages/get_message.rs
+++ b/libvcx/src/messages/get_message.rs
@@ -299,7 +299,9 @@ impl Message {
 
     fn _decrypt_v3_message(&self) -> VcxResult<String> {
         let a2a_message = EncryptionEnvelope::anon_unpack(self.payload()?)?;
-        Ok(json!(&a2a_message).to_string())
+        // todo: this awkward return value is here just to keep backwards comptability
+        // todo: we should make breaking change and simplify content of Message.decrypted_payload
+        Ok(json!({"@msg": json!(a2a_message).to_string()}).to_string())
     }
 }
 

--- a/libvcx/src/messages/get_message.rs
+++ b/libvcx/src/messages/get_message.rs
@@ -268,7 +268,7 @@ pub struct Message {
     #[serde(skip_deserializing)]
     pub delivery_details: Vec<DeliveryDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub decrypted_msg: Option<String>,
+    pub decrypted_payload: Option<String>,
 }
 
 #[macro_export]
@@ -289,9 +289,9 @@ impl Message {
     pub fn decrypt_noauth(&self) -> Message {
         let mut new_message = self.clone();
         if let Ok(decrypted_msg) = self._decrypt_v3_message() {
-            new_message.decrypted_msg = Some(decrypted_msg);
+            new_message.decrypted_payload = Some(decrypted_msg);
         } else {
-            new_message.decrypted_msg = None;
+            new_message.decrypted_payload = None;
         }
         new_message.payload = None;
         new_message


### PR DESCRIPTION
This reverts breaking change introduced in https://github.com/hyperledger/aries-vcx/pull/134

Specifically the unintended breaking changes were:
- rename of `decrypted_payload` to `decrypted_msg`
- change in content format of `decrypted_payload`/`decrypted_msg` . Originally these were json strings such:
`{"@msg": <StringifiedAriesJsonMessage>}`, but the PR 134 changed this to simply `<StringifiedAriesJsonMessage>`



Signed-off-by: Patrik Stas <patrik.stas@absa.africa>