### PR TITLE
Rename proofGetAttributes to proofGetProofRequestAttachment in iOS headers

### DIFF
--- a/wrappers/ios/vcx/ConnectMeVcx.h
+++ b/wrappers/ios/vcx/ConnectMeVcx.h
@@ -234,8 +234,8 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
 - (void) proofGetRequests:(NSInteger)connectionHandle
               completion:(void (^)(NSError *error, NSString *requests))completion;
 
-- (void) proofGetAttributes:(NSInteger)connectionHandle
-              completion:(void (^)(NSError *error, NSString *attrs))completion;
+- (void) proofGetProofRequestAttachment:(NSInteger)proofHandle
+              completion:(void (^)(NSError *error, NSString *attach))completion;
 
 - (void) proofRetrieveCredentials:(vcx_proof_handle_t)proofHandle
                    withCompletion:(void (^)(NSError *error, NSString *matchingCredentials))completion;

--- a/wrappers/ios/vcx/ConnectMeVcx.m
+++ b/wrappers/ios/vcx/ConnectMeVcx.m
@@ -1150,12 +1150,12 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)proofGetProofRequestAttachment:(NSInteger)connectionHandle
-                   completion:(void (^)(NSError *error, NSString *attrs))completion{
+- (void)proofGetProofRequestAttachment:(NSInteger)proofHandle
+                   completion:(void (^)(NSError *error, NSString *attach))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_disclosed_proof_get_proof_request_attachment(handle,connectionHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_disclosed_proof_get_proof_request_attachment(handle, proofHandle, VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {


### PR DESCRIPTION
Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>