### PR TITLE
Fix CI build for iOS wrapper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -703,6 +703,10 @@ jobs:
     - name: Load env. variables
       run: |
         echo ::set-env name=PUBLISH_VERSION::${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
+    - name: Switch to xcode version 11
+      run: |
+        sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
+        xcodebuild -version
     - name: Build iOS wrapper
       run: |
           ./wrappers/ios/ci/build.sh


### PR DESCRIPTION
Github Actions started by default using xcode 12 which causes us some issue when building for ios https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios

Solved in this PR by switching back to xcode 11

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>