### PR TITLE
Ci/remove apk repo

### DIFF
--- a/ci/alpine_core.dockerfile
+++ b/ci/alpine_core.dockerfile
@@ -36,6 +36,10 @@ ENV PATH_LIBINDY=$INDYSDK_PATH/libindy
 ENV PATH_LIBNULLPAY=$INDYSDK_PATH/libnullpay
 ENV PATH_LIBPGWALLET=$INDYSDK_PATH/experimental/plugins/postgres_storage
 RUN cargo build --release --manifest-path=$PATH_LIBINDY/Cargo.toml --target-dir=$PATH_LIBINDY/target
+RUN ls -lh
+RUN ls -lh $PATH_LIBINDY
+RUN ls -lh $PATH_LIBINDY/target
+RUN ls -lh $PATH_LIBINDY/target/release
 
 USER root
 RUN mv $PATH_LIBINDY/target/release/libindy.so /usr/lib

--- a/ci/alpine_core.dockerfile
+++ b/ci/alpine_core.dockerfile
@@ -26,7 +26,13 @@ USER indy
 ARG RUST_VER="1.45.2"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
 ENV PATH="/home/indy/.cargo/bin:${PATH}"
+
+# https://github.com/rust-lang/rust/pull/58575
+ENV RUSTFLAGS='-C target-feature=-crt-static'
 RUN cargo --version
+RUN rustc --print cfg
+RUN rustup show
+RUN rustup target list
 
 WORKDIR /home/indy
 
@@ -36,6 +42,8 @@ ENV PATH_LIBINDY=$INDYSDK_PATH/libindy
 ENV PATH_LIBNULLPAY=$INDYSDK_PATH/libnullpay
 ENV PATH_LIBPGWALLET=$INDYSDK_PATH/experimental/plugins/postgres_storage
 RUN cargo build --release --manifest-path=$PATH_LIBINDY/Cargo.toml --target-dir=$PATH_LIBINDY/target
+
+RUN rustc --print cfg
 RUN ls -lh
 RUN ls -lh $PATH_LIBINDY
 RUN ls -lh $PATH_LIBINDY/target

--- a/ci/alpine_core.dockerfile
+++ b/ci/alpine_core.dockerfile
@@ -15,17 +15,19 @@ RUN addgroup -g $GID indy && adduser -u $UID -D -G indy indy
 RUN apk update && apk upgrade && \
     apk add --no-cache \
         build-base \
-        cargo \
         git \
+        curl \
         libsodium-dev \
         libzmq \
         openssl-dev \
         zeromq-dev
 
+USER indy
 ARG RUST_VER="1.45.2"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
+ENV PATH="/home/indy/.cargo/bin:${PATH}"
+RUN cargo --version
 
-USER indy
 WORKDIR /home/indy
 
 RUN git clone $INDYSDK_REPO && cd indy-sdk && git checkout $INDYSDK_REVISION

--- a/ci/alpine_core.dockerfile
+++ b/ci/alpine_core.dockerfile
@@ -32,15 +32,18 @@ WORKDIR /home/indy
 
 RUN git clone $INDYSDK_REPO && cd indy-sdk && git checkout $INDYSDK_REVISION
 
-RUN cargo build --release --manifest-path=$INDYSDK_PATH/libindy/Cargo.toml
+ENV PATH_LIBINDY=$INDYSDK_PATH/libindy
+ENV PATH_LIBNULLPAY=$INDYSDK_PATH/libnullpay
+ENV PATH_LIBPGWALLET=$INDYSDK_PATH/experimental/plugins/postgres_storage
+RUN cargo build --release --manifest-path=$PATH_LIBINDY/Cargo.toml --target-dir=$PATH_LIBINDY/target
 
 USER root
-RUN mv $INDYSDK_PATH/libindy/target/release/libindy.so /usr/lib
+RUN mv $PATH_LIBINDY/target/release/libindy.so /usr/lib
 
 USER indy
-RUN cargo build --release --manifest-path=$INDYSDK_PATH/libnullpay/Cargo.toml
-RUN cargo build --release --manifest-path=$INDYSDK_PATH/experimental/plugins/postgres_storage/Cargo.toml
+RUN cargo build --release --manifest-path=$PATH_LIBNULLPAY/Cargo.toml --target-dir=$PATH_LIBNULLPAY/target
+RUN cargo build --release --manifest-path=$PATH_LIBPGWALLET/Cargo.toml --target-dir=$PATH_LIBPGWALLET/target
 
 USER root
-RUN mv $INDYSDK_PATH/libnullpay/target/release/libnullpay.so .
-RUN mv $INDYSDK_PATH/experimental/plugins/postgres_storage/target/release/libindystrgpostgres.so .
+RUN mv $PATH_LIBNULLPAY/target/release/libnullpay.so .
+RUN mv $PATH_LIBPGWALLET/target/release/libindystrgpostgres.so .

--- a/ci/libvcx.dockerfile
+++ b/ci/libvcx.dockerfile
@@ -29,7 +29,6 @@ COPY --chown=node ./agents/node ./agents/node
 RUN apk update && apk upgrade
 RUN apk add --no-cache \
         bash \
-        cargo \
         g++ \
         gcc \
         git \
@@ -38,11 +37,13 @@ RUN apk add --no-cache \
         nodejs \
         npm \
         make \
+        curl \
         openssl-dev \
         python2 \
         zeromq-dev
 
+USER node
 ARG RUST_VER="1.45.2"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
-
-USER node
+ENV PATH="/home/node/.cargo/bin:${PATH}"
+RUN cargo --version

--- a/ci/libvcx.dockerfile
+++ b/ci/libvcx.dockerfile
@@ -26,8 +26,6 @@ COPY --chown=node ./agency_client ./agency_client
 COPY --chown=node ./wrappers/node ./wrappers/node
 COPY --chown=node ./agents/node ./agents/node
 
-RUN echo '@alpine38 http://dl-cdn.alpinelinux.org/alpine/v3.8/main' >> /etc/apk/repositories
-
 RUN apk update && apk upgrade
 RUN apk add --no-cache \
         bash \

--- a/ci/libvcx.dockerfile
+++ b/ci/libvcx.dockerfile
@@ -46,4 +46,8 @@ USER node
 ARG RUST_VER="1.45.2"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
 ENV PATH="/home/node/.cargo/bin:${PATH}"
+ENV RUSTFLAGS='-C target-feature=-crt-static'
 RUN cargo --version
+RUN rustc --print cfg
+RUN rustup show
+RUN rustup target list


### PR DESCRIPTION
This PR changes way `cargo` is installed on alpine image. Previously cargo was installed from apk repo, but that limits our selection of cargo version. 

One problem I've encountered doing this was that using rustup installation, dynamic libraries were not being built (`.so` files), instead only static (`.a`).

The reason is different `rustc` configuration. 

The default `rustc` configuration when using `apk` installation
```
#11 [8/17] RUN rustc --print cfg
#11 0.370 debug_assertions
#11 0.370 target_arch="x86_64"
#11 0.370 target_endian="little"
#11 0.370 target_env="musl"
#11 0.370 target_family="unix"
#11 0.370 target_feature="fxsr"
#11 0.370 target_feature="sse"
#11 0.370 target_feature="sse2"
#11 0.370 target_os="linux"
#11 0.370 target_pointer_width="64"
#11 0.370 target_vendor="alpine"
#11 0.370 unix
#11 DONE 0.4s
```

Default `rustc` configuration when using `rustup` installation.
```
#13 [10/20] RUN rustc --print cfg
#13 0.289 debug_assertions
#13 0.289 target_arch="x86_64"
#13 0.289 target_endian="little"
#13 0.289 target_env="musl"
#13 0.289 target_family="unix"
#13 0.289 target_feature="crt-static"
#13 0.289 target_feature="fxsr"
#13 0.289 target_feature="sse"
#13 0.289 target_feature="sse2"
#13 0.289 target_os="linux"
#13 0.289 target_pointer_width="64"
#13 0.289 target_vendor="unknown"
#13 0.289 unix
```

The key difference seems to be presence of `target_feature="crt-static"` feature in rustup installation. In order to disable this feature while building some libraries, we need to export following env variable
```
ENV RUSTFLAGS='-C target-feature=-crt-static'
```
I didn't found how I could configure `rustc` to disable that feature by default.

Additionally I also had to export `ENV PATH="/home/indy/.cargo/bin:${PATH}"` in Dockerfile, otherwise cargo would not be visible to docker while container build time.


## Notes
- we probably can also change `target_env="musl"` as this ensure the built library can be used in any linux distribution. We don't need this, changing this ?might? improve built time.
- we probably can change `target_vendor` to value `alpine`
