### PR TITLE
Build arm instead of armv7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -833,7 +833,7 @@ jobs:
       - name: Build, run android wrapper tests, and publish artifacts
         uses: ./.github/actions/publish-android
         with:
-          abis: "armv7 arm64"
+          abis: "arm arm64"
           docker-img-name: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_ANDROID }}
           full-version-name: ${{ env.FULL_VERSION_NAME }}
 

--- a/wrappers/java/ci/setup.android.env.sh
+++ b/wrappers/java/ci/setup.android.env.sh
@@ -133,7 +133,7 @@ download_and_unzip_if_missed() {
     if [ ! -d "${target_dir}" ] ; then
         echo "${GREEN}Downloading ${fname}${RESET} from url ${url}"
         wget -q ${url}
-        unzip -qq ${fname}
+        unzip -qqo ${fname}
         rm ${fname}
         echo "${GREEN}Done!${RESET}"
     else


### PR DESCRIPTION
32bit armv7 devices are discontinued, older 64bit armv8 (surprisingly) build with `arm-linux-androideabi` triplet

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>