### PR TITLE
Remove usage of deprecated set-env Github Action feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
   workflow-setup:
     runs-on: ubuntu-latest
     outputs:
-      GITHUB_REPOSITORY_LOWERCASE: ${{ steps.mainstep.outputs.GITHUB_REPOSITORY_LOWERCASE }}
       CACHE_KEY_POOL: ${{ steps.mainstep.outputs.CACHE_KEY_POOL }}
       CACHE_KEY_ANDROID: ${{ steps.mainstep.outputs.CACHE_KEY_ANDROID }}
       CACHE_KEY_LIBVCX: ${{ steps.mainstep.outputs.CACHE_KEY_LIBVCX }}
@@ -32,11 +31,10 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.45.2
-      - name: Set custom env variables
+      - name: Set outputs
+        id: mainstep
         run: |
           set -x
-          GITHUB_REPOSITORY_LOWERCASE=`echo $GITHUB_REPOSITORY | awk '{print tolower($0)}'`
-          echo ::set-env name=GITHUB_REPOSITORY_LOWERCASE::$(echo $GITHUB_REPOSITORY_LOWERCASE)
 
           if [[ -z "$GITHUB_HEAD_REF" ]] # is set only if pipeline run is triggered as pull request
           then
@@ -48,7 +46,6 @@ jobs:
           fi
 
           BRANCH_NAME=`echo $BRANCH_NAME | sed "s/[^[:alnum:]-]//g" | tr '[:upper:]' '[:lower:]'` # lowercase, only alphanumeric and dash
-          echo ::set-env name=BRANCH_NAME::$(echo $BRANCH_NAME)
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]
           then
@@ -104,45 +101,31 @@ jobs:
           ANDROID_HASH=${LIBVCX_SOURCE_HASH:0:15}-${JAVA_WRAPPERS_HASH:0:15}
           POOL_HASH=${POOL_DOCKERFILE_HASH:0:15}
 
-          echo ::set-env name=PUBLISH_VERSION::$PUBLISH_VERSION
-          echo ::set-env name=RELEASE::$RELEASE
-          echo ::set-env name=CACHE_KEY_LIBVCX::$LIBVCX_HASH
-          echo ::set-env name=CACHE_KEY_CODECOV::$CODECOV_HASH
-          echo ::set-env name=CACHE_KEY_ANDROID::$ANDROID_HASH
-          echo ::set-env name=CACHE_KEY_POOL::$POOL_HASH
-          echo ::set-env name=CACHE_KEY_ALPINE_CORE::$ALPINE_CORE_HASH
-
-      - name: Set and print outputs
-        id: mainstep
-        run: |
           set -x
           echo "::set-output name=PUBLISH_VERSION::$PUBLISH_VERSION"
           echo "::set-output name=RELEASE::$RELEASE"
 
-          echo "::set-output name=GITHUB_REPOSITORY_LOWERCASE::$GITHUB_REPOSITORY_LOWERCASE"
-          echo "::set-output name=CACHE_KEY_LIBVCX::$CACHE_KEY_LIBVCX"
-          echo "::set-output name=CACHE_KEY_CODECOV::$CACHE_KEY_CODECOV"
-          echo "::set-output name=CACHE_KEY_ANDROID::$CACHE_KEY_ANDROID"
-          echo "::set-output name=CACHE_KEY_POOL::$CACHE_KEY_POOL"
-          echo "::set-output name=CACHE_KEY_ALPINE_CORE::$CACHE_KEY_ALPINE_CORE"
+          echo "::set-output name=CACHE_KEY_LIBVCX::$LIBVCX_HASH"
+          echo "::set-output name=CACHE_KEY_CODECOV::$CODECOV_HASH"
+          echo "::set-output name=CACHE_KEY_ANDROID::$ANDROID_HASH"
+          echo "::set-output name=CACHE_KEY_POOL::$POOL_HASH"
+          echo "::set-output name=CACHE_KEY_ALPINE_CORE::$ALPINE_CORE_HASH"
 
           echo "::set-output name=DOCKER_IMG_NAME_ALPINE_CORE::alpine-core"
           echo "::set-output name=DOCKER_IMG_NAME_AGENCY::docker.pkg.github.com/absaoss/vcxagencynode/vcxagency-node:0.1.2"
           echo "::set-output name=DOCKER_IMG_NAME_ANDROID::android-test"
-          echo "::set-output name=DOCKER_IMG_NAME_LIBVCX::libvcx:$CACHE_KEY_LIBVCX"
-          echo "::set-output name=DOCKER_IMG_NAME_CODECOV::codecov:$CACHE_KEY_CODECOV"
-          echo "::set-output name=DOCKER_IMG_NAME_POOL::indypool:$CACHE_KEY_POOL"
+          echo "::set-output name=DOCKER_IMG_NAME_LIBVCX::libvcx:$LIBVCX_HASH"
+          echo "::set-output name=DOCKER_IMG_NAME_CODECOV::codecov:$CODECOV_HASH"
+          echo "::set-output name=DOCKER_IMG_NAME_POOL::indypool:$POOL_HASH"
 
   build-image-indypool:
     needs: workflow-setup
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_POOL: ${{ needs.workflow-setup.outputs.CACHE_KEY_POOL }}
+      DOCKER_IMG_NAME_POOL: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL }}
     steps:
-      - name: Load up custom variables
-        run: |
-          echo ::set-env name=CACHE_KEY_POOL::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_POOL}})
-          echo ::set-env name=DOCKER_IMG_NAME_POOL::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL}})
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Try load from cache.
@@ -172,11 +155,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_ALPINE_CORE: ${{ needs.workflow-setup.outputs.CACHE_KEY_ALPINE_CORE }}
+      DOCKER_IMG_NAME_ALPINE_CORE: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_ALPINE_CORE }}
     steps:
-      - name: Load up custom variables
-        run: |
-          echo ::set-env name=CACHE_KEY_ALPINE_CORE::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_ALPINE_CORE}})
-          echo ::set-env name=DOCKER_IMG_NAME_ALPINE_CORE::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_ALPINE_CORE}})
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Try load from cache.
@@ -208,13 +189,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_LIBVCX: ${{ needs.workflow-setup.outputs.CACHE_KEY_LIBVCX }}
+      DOCKER_IMG_NAME_LIBVCX: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX }}
+      CACHE_KEY_ALPINE_CORE: ${{ needs.workflow-setup.outputs.CACHE_KEY_ALPINE_CORE }}
+      DOCKER_IMG_NAME_ALPINE_CORE: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_ALPINE_CORE }}
     steps:
-      - name: Load up custom variables
-        run: |
-          echo ::set-env name=CACHE_KEY_LIBVCX::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}})
-          echo ::set-env name=DOCKER_IMG_NAME_LIBVCX::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}})
-          echo ::set-env name=CACHE_KEY_ALPINE_CORE::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_ALPINE_CORE}})
-          echo ::set-env name=DOCKER_IMG_NAME_ALPINE_CORE::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_ALPINE_CORE}})
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Try load from cache.
@@ -259,11 +238,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_CODECOV: ${{ needs.workflow-setup.outputs.CACHE_KEY_CODECOV }}
+      DOCKER_IMG_NAME_CODECOV: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV }}
     steps:
-      - name: Load up custom variables
-        run: |
-          echo ::set-env name=CACHE_KEY_CODECOV::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_CODECOV}})
-          echo ::set-env name=DOCKER_IMG_NAME_CODECOV::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV}})
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Try load from cache.
@@ -294,14 +271,11 @@ jobs:
     needs: [workflow-setup, build-image-codecov]
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_CODECOV: ${{ needs.workflow-setup.outputs.CACHE_KEY_CODECOV }}
+      DOCKER_IMG_NAME_CODECOV: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Docker setup
-        run: |
-          echo ::set-env name=CACHE_KEY_CODECOV::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_CODECOV}})
-          echo ::set-env name=DOCKER_IMG_NAME_CODECOV::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV}})
-
       - name: Load codecov image cache
         id: load-cached-codecov-image
         uses: actions/cache@v2
@@ -340,17 +314,14 @@ jobs:
     needs: [workflow-setup, build-image-codecov, build-image-indypool]
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_POOL: ${{ needs.workflow-setup.outputs.CACHE_KEY_POOL }}
+      CACHE_KEY_CODECOV: ${{ needs.workflow-setup.outputs.CACHE_KEY_CODECOV }}
+      DOCKER_IMG_NAME_POOL: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL }}
+      DOCKER_IMG_NAME_AGENCY: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_AGENCY }}
+      DOCKER_IMG_NAME_CODECOV: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Docker setup
-        run: |
-          echo ::set-env name=CACHE_KEY_POOL::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_POOL}})
-          echo ::set-env name=CACHE_KEY_CODECOV::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_CODECOV}})
-          echo ::set-env name=DOCKER_IMG_NAME_POOL::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL}})
-          echo ::set-env name=DOCKER_IMG_NAME_AGENCY::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_AGENCY}})
-          echo ::set-env name=DOCKER_IMG_NAME_CODECOV::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_CODECOV}})
-
       - name: Load indy-pool image
         id: load-cached-pool-image
         uses: actions/cache@v2
@@ -410,11 +381,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_ANDROID: ${{needs.workflow-setup.outputs.CACHE_KEY_ANDROID}}
+      DOCKER_IMG_NAME_ANDROID: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_ANDROID}}
     steps:
-      - name: Load up custom variables
-        run: |
-          echo ::set-env name=CACHE_KEY_ANDROID::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_ANDROID}})
-          echo ::set-env name=DOCKER_IMG_NAME_ANDROID::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_ANDROID}})
       - name: Git checkout
         uses: actions/checkout@v2
 
@@ -445,13 +414,11 @@ jobs:
     needs: [workflow-setup, build-image-indypool, build-image-libvcx]
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_LIBVCX: ${{ needs.workflow-setup.outputs.CACHE_KEY_LIBVCX }}
+      DOCKER_IMG_NAME_LIBVCX: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Docker setup
-        run: |
-          echo ::set-env name=CACHE_KEY_LIBVCX::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}})
-          echo ::set-env name=DOCKER_IMG_NAME_LIBVCX::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}})
       - name: Load libvcx image cache
         id: load-cached-libvcx-image
         uses: actions/cache@v2
@@ -478,16 +445,14 @@ jobs:
     needs: [workflow-setup, build-image-indypool, build-image-libvcx]
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_POOL: ${{needs.workflow-setup.outputs.CACHE_KEY_POOL}}
+      CACHE_KEY_LIBVCX: ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}}
+      DOCKER_IMG_NAME_POOL: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL}}
+      DOCKER_IMG_NAME_AGENCY: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_AGENCY}}
+      DOCKER_IMG_NAME_LIBVCX: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}}
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Docker setup
-        run: |
-          echo ::set-env name=CACHE_KEY_POOL::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_POOL}})
-          echo ::set-env name=CACHE_KEY_LIBVCX::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}})
-          echo ::set-env name=DOCKER_IMG_NAME_POOL::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL}})
-          echo ::set-env name=DOCKER_IMG_NAME_AGENCY::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_AGENCY}})
-          echo ::set-env name=DOCKER_IMG_NAME_LIBVCX::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}})
       - name: Load indy-pool image
         id: load-cached-pool-image
         uses: actions/cache@v2
@@ -540,16 +505,14 @@ jobs:
     needs: [workflow-setup, build-image-indypool, build-image-libvcx]
     env:
       DOCKER_BUILDKIT: 1
+      CACHE_KEY_POOL: ${{needs.workflow-setup.outputs.CACHE_KEY_POOL}}
+      CACHE_KEY_LIBVCX: ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}}
+      DOCKER_IMG_NAME_POOL: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL}}
+      DOCKER_IMG_NAME_AGENCY: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_AGENCY}}
+      DOCKER_IMG_NAME_LIBVCX: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}}
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Docker setup
-        run: |
-          echo ::set-env name=CACHE_KEY_POOL::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_POOL}})
-          echo ::set-env name=CACHE_KEY_LIBVCX::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}})
-          echo ::set-env name=DOCKER_IMG_NAME_POOL::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL}})
-          echo ::set-env name=DOCKER_IMG_NAME_AGENCY::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_AGENCY}})
-          echo ::set-env name=DOCKER_IMG_NAME_LIBVCX::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}})
       - name: Load indy-pool image
         id: load-cached-pool-image
         uses: actions/cache@v2
@@ -601,11 +564,9 @@ jobs:
     needs: [workflow-setup, build-image-android]
     env:
       DOCKER_BUILDKIT: 1
+      DOCKER_IMG_NAME_ANDROID: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_ANDROID}}
+      CACHE_KEY_ANDROID: ${{needs.workflow-setup.outputs.CACHE_KEY_ANDROID}}
     steps:
-      - name: Docker setup
-        run: |
-          echo ::set-env name=DOCKER_IMG_NAME_ANDROID::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_ANDROID}})
-          echo ::set-env name=CACHE_KEY_ANDROID::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_ANDROID}})
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Load android image cache
@@ -631,11 +592,9 @@ jobs:
     env:
       DOCKER_BUILDKIT: 1
       NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+      CACHE_KEY_LIBVCX: ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}}
+      DOCKER_IMG_NAME_LIBVCX: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}}
     steps:
-      - name: Load up custom variables
-        run: |
-          echo ::set-env name=CACHE_KEY_LIBVCX::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}})
-          echo ::set-env name=DOCKER_IMG_NAME_LIBVCX::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}})
       - name: Git checkout
         uses: actions/checkout@v2
 
@@ -668,17 +627,14 @@ jobs:
     env:
       DOCKER_BUILDKIT: 1
       NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+      CACHE_KEY_POOL: ${{ needs.workflow-setup.outputs.CACHE_KEY_POOL }}
+      CACHE_KEY_LIBVCX: ${{ needs.workflow-setup.outputs.CACHE_KEY_LIBVCX }}
+      DOCKER_IMG_NAME_POOL: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL }}
+      DOCKER_IMG_NAME_AGENCY: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_AGENCY }}
+      DOCKER_IMG_NAME_LIBVCX: ${{ needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX }}
     steps:
-      - name: Load up custom variables
-        run: |
-          echo ::set-env name=CACHE_KEY_POOL::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_POOL}})
-          echo ::set-env name=CACHE_KEY_LIBVCX::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}})
-          echo ::set-env name=DOCKER_IMG_NAME_POOL::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_POOL}})
-          echo ::set-env name=DOCKER_IMG_NAME_AGENCY::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_AGENCY}})
-          echo ::set-env name=DOCKER_IMG_NAME_LIBVCX::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}})
       - name: Git checkout
         uses: actions/checkout@v2
-
       - name: Load indy-pool image
         id: load-cached-pool-image
         uses: actions/cache@v2
@@ -750,12 +706,10 @@ jobs:
     runs-on: macos-10.15
     env:
       LIBVCX_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
+      PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
     steps:
     - name: Git checkout
       uses: actions/checkout@v2
-    - name: Load env. variables
-      run: |
-        echo ::set-env name=PUBLISH_VERSION::${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
     - name: Switch to xcode version 11
       run: |
         sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
@@ -777,11 +731,9 @@ jobs:
   #   needs: [workflow-setup, build-image-android]
   #   env:
   #     DOCKER_BUILDKIT: 1
+  #     CACHE_KEY_ANDROID: ${{needs.workflow-setup.outputs.CACHE_KEY_ANDROID}}
+  #     DOCKER_IMG_NAME_ANDROID: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_ANDROID}}
   #   steps:
-  #     - name: Load up custom variables
-  #       run: |
-  #         echo ::set-env name=CACHE_KEY_ANDROID::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_ANDROID}})
-  #         echo ::set-env name=DOCKER_IMG_NAME_ANDROID::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_ANDROID}})
   #     - name: Git checkout
   #       uses: actions/checkout@v2
 
@@ -808,13 +760,10 @@ jobs:
     needs: [workflow-setup, build-image-android]
     env:
       DOCKER_BUILDKIT: 1
+      FULL_VERSION_NAME: ${{needs.workflow-setup.outputs.PUBLISH_VERSION}}-device
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-
-      - name: Load env. variables
-        run: |
-          echo ::set-env name=FULL_VERSION_NAME::libvcx-android-${{needs.workflow-setup.outputs.PUBLISH_VERSION}}-device
 
       - name: Load android image cache
         id: load-cached-android-image
@@ -849,13 +798,10 @@ jobs:
     needs: [workflow-setup, build-image-android]
     env:
       DOCKER_BUILDKIT: 1
+      FULL_VERSION_NAME: libvcx-android-${{needs.workflow-setup.outputs.PUBLISH_VERSION}}-emulator
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-
-      - name: Load env. variables
-        run: |
-          echo ::set-env name=FULL_VERSION_NAME::libvcx-android-${{needs.workflow-setup.outputs.PUBLISH_VERSION}}-emulator
 
       - name: Load android image cache
         id: load-cached-android-image
@@ -888,14 +834,11 @@ jobs:
   publish-libvcx:
     runs-on: ubuntu-16.04
     needs: [workflow-setup, build-image-indypool, build-image-libvcx, test-libvcx-image-general_test, test-libvcx-image-pool_tests, test-libvcx-image-agency_pool_tests, test-node-wrapper, test-integration-node-wrapper]
+    env:
+      CACHE_KEY_LIBVCX: ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}}
+      DOCKER_IMG_NAME_LIBVCX: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}}
+      PUBLISH_VERSION: ${{needs.workflow-setup.outputs.PUBLISH_VERSION}}
     steps:
-      - name: Load env. variables
-        run: |
-          echo ::set-env name=CACHE_KEY_LIBVCX::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}})
-          echo ::set-env name=DOCKER_IMG_NAME_LIBVCX::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}})
-          echo ::set-env name=GITHUB_REPOSITORY_LOWERCASE::$(echo ${{needs.workflow-setup.outputs.GITHUB_REPOSITORY_LOWERCASE}})
-          echo ::set-env name=PUBLISH_VERSION::$(echo ${{needs.workflow-setup.outputs.PUBLISH_VERSION}})
-
       - name: Git checkout
         uses: actions/checkout@v2
 
@@ -928,6 +871,7 @@ jobs:
           then
             IFS=$':' read -a arr <<< $DOCKER_IMG_NAME_LIBVCX
             DOCKER_IMG_NAME_TAGLESS=${arr[0]}
+            GITHUB_REPOSITORY_LOWERCASE=`echo $GITHUB_REPOSITORY | awk '{print tolower($0)}'`
             REMOTE_DOCKER_IMG_NAME_LIBVCX="docker.pkg.github.com/${GITHUB_REPOSITORY_LOWERCASE}/${DOCKER_IMG_NAME_TAGLESS}:${PUBLISH_VERSION}"
             echo "Releasing libvcx docker image version $PUBLISH_VERSION, tagged $REMOTE_DOCKER_IMG_NAME_LIBVCX"
             docker tag "$DOCKER_IMG_NAME_LIBVCX" "$REMOTE_DOCKER_IMG_NAME_LIBVCX"
@@ -941,12 +885,10 @@ jobs:
     needs: [workflow-setup, build-image-indypool, build-image-libvcx, test-libvcx-image-general_test, test-libvcx-image-pool_tests, test-libvcx-image-agency_pool_tests, test-node-wrapper, test-integration-node-wrapper]
     env:
       NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+      CACHE_KEY_LIBVCX: ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}}
+      DOCKER_IMG_NAME_LIBVCX: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}}
+      PUBLISH_VERSION: ${{needs.workflow-setup.outputs.PUBLISH_VERSION}}
     steps:
-      - name: Load env. variables
-        run: |
-          echo ::set-env name=CACHE_KEY_LIBVCX::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}})
-          echo ::set-env name=DOCKER_IMG_NAME_LIBVCX::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}})
-          echo ::set-env name=PUBLISH_VERSION::$(echo ${{needs.workflow-setup.outputs.PUBLISH_VERSION}})
       - name: Git checkout
         uses: actions/checkout@v2
 
@@ -991,12 +933,10 @@ jobs:
     needs: [workflow-setup, build-image-indypool, build-image-libvcx, test-libvcx-image-general_test, test-libvcx-image-pool_tests, test-libvcx-image-agency_pool_tests, test-node-wrapper, test-integration-node-wrapper]
     env:
       NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+      CACHE_KEY_LIBVCX: ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}}
+      DOCKER_IMG_NAME_LIBVCX: ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}}
+      PUBLISH_VERSION: ${{needs.workflow-setup.outputs.PUBLISH_VERSION}}
     steps:
-      - name: Load env. variables
-        run: |
-          echo ::set-env name=CACHE_KEY_LIBVCX::$(echo ${{needs.workflow-setup.outputs.CACHE_KEY_LIBVCX}})
-          echo ::set-env name=DOCKER_IMG_NAME_LIBVCX::$(echo ${{needs.workflow-setup.outputs.DOCKER_IMG_NAME_LIBVCX}})
-          echo ::set-env name=PUBLISH_VERSION::$(echo ${{needs.workflow-setup.outputs.PUBLISH_VERSION}})
       - name: Git checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
They've turned off `set-env` :-) CI looks better without it though! 

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>