### PR TITLE
Remove deprecated cred update functions, refactor cred FSM

### DIFF
--- a/agents/node/vcxagent-core/demo/faber.js
+++ b/agents/node/vcxagent-core/demo/faber.js
@@ -85,12 +85,12 @@ async function runFaber (options) {
     await vcxProof.requestProof(connectionToAlice)
 
     logger.info('#21 Poll agency and wait for alice to provide proof')
-    let proofProtocolState = await vcxProof.updateState()
+    let proofProtocolState = await vcxProof.updateStateV2(connectionToAlice)
     logger.debug(`vcxProof = ${JSON.stringify(vcxProof)}`)
     logger.debug(`proofState = ${proofProtocolState}`)
     while (proofProtocolState !== StateType.Accepted) { // even if revoked credential was used, state should in final state be StateType.Accepted
       await sleepPromise(2000)
-      proofProtocolState = await vcxProof.updateState()
+      proofProtocolState = await vcxProof.updateStateV2(connectionToAlice)
       logger.info(`proofState=${proofProtocolState}`)
       if (proofProtocolState === StateType.None) {
         logger.error(`Faber proof protocol state is ${StateType.None} which an error has ocurred.`)

--- a/agents/node/vcxagent-core/src/services/service-cred-issuer.js
+++ b/agents/node/vcxagent-core/src/services/service-cred-issuer.js
@@ -90,14 +90,6 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
     return state
   }
 
-  // deprecated
-  async function credentialUpdateV1 (issuerCredId) {
-    const issuerCred = await loadIssuerCredential(issuerCredId)
-    const state = await issuerCred.updateState()
-    await saveIssuerCredential(issuerCredId, issuerCred)
-    return state
-  }
-
   async function getState (issuerCredentialId) {
     const issuerCredential = await loadIssuerCredential(issuerCredentialId)
     return issuerCredential.getState()
@@ -127,7 +119,6 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
     sendOfferAndCredential,
     revokeCredential,
     credentialUpdate,
-    credentialUpdateV1,
     getVcxCredentialIssuer,
 
     listIds,

--- a/agents/node/vcxagent-core/src/services/service-prover.js
+++ b/agents/node/vcxagent-core/src/services/service-prover.js
@@ -19,7 +19,7 @@ module.exports.createServiceProver = function createServiceProver ({ logger, loa
       }
     }
 
-    const [error] = await pollFunction(progressToAcceptedState, `Progress CredentialSM to one of states ${JSON.stringify(targetStates)}`, logger, attemptsThreshold, timeoutMs)
+    const [error] = await pollFunction(progressToAcceptedState, `Progress ProofSM to one of states ${JSON.stringify(targetStates)}`, logger, attemptsThreshold, timeoutMs)
     if (error) {
       throw Error(`Couldn't progress credential to Accepted state. ${error}`)
     }

--- a/agents/node/vcxagent-core/test/update-state-v2.spec.js
+++ b/agents/node/vcxagent-core/test/update-state-v2.spec.js
@@ -12,21 +12,6 @@ beforeAll(async () => {
 })
 
 describe('test update state', () => {
-  it('Faber should fail to update state of the their credential via V1 API', async () => {
-    try {
-      const { alice, faber } = await createPairedAliceAndFaber()
-
-      await faber.sendCredentialOffer()
-      await alice.acceptCredentialOffer()
-      await expect(faber.updateStateCredentialV1()).rejects.toThrow('Obj was not found with handle')
-      await shutdownVcx()
-    } catch (err) {
-      console.error(`err = ${err.message} stack = ${err.stack}`)
-      await sleep(2000)
-      throw Error(err)
-    }
-  })
-
   it('Faber should send credential to Alice', async () => {
     try {
       const { alice, faber } = await createPairedAliceAndFaber()

--- a/agents/node/vcxagent-core/test/utils/faber.js
+++ b/agents/node/vcxagent-core/test/utils/faber.js
@@ -77,16 +77,6 @@ module.exports.createFaber = async function createFaber () {
     await vcxAgent.agentShutdownVcx()
   }
 
-  async function updateStateCredentialV1 () {
-    logger.info('Issuer updating state of credential')
-    await vcxAgent.agentInitVcx()
-
-    logger.info('Issuer updating state of credential with connection')
-    await vcxAgent.serviceCredIssuer.credentialUpdateV1(issuerCredId)
-
-    await vcxAgent.agentShutdownVcx()
-  }
-
   async function updateStateCredentialV2 (expectedState) {
     await vcxAgent.agentInitVcx()
 
@@ -200,7 +190,6 @@ module.exports.createFaber = async function createFaber () {
     updateConnection,
     sendConnectionResponse,
     sendCredentialOffer,
-    updateStateCredentialV1,
     updateStateCredentialV2,
     sendCredential,
     requestProofFromAlice,

--- a/libvcx/src/api/credential.rs
+++ b/libvcx/src/api/credential.rs
@@ -629,63 +629,13 @@ pub extern fn vcx_credential_get_offers(command_handle: CommandHandle,
     error::SUCCESS.code_num
 }
 
-/// Query the agency for the received messages.
-/// Checks for any messages changing state in the credential object and updates the state attribute.
-/// If it detects a credential it will store the credential in the wallet.
-///
-/// #Params
-/// command_handle: command handle to map callback to user context.
-///
-/// credential_handle: Credential handle that was provided during creation. Used to identify credential object
-///
-/// cb: Callback that provides most current state of the credential and error status of request
-///
-/// #Returns
-/// Error code as a u32
 #[no_mangle]
 #[deprecated(since = "0.12.0", note = "Use vcx_v2_credential_update_state instead.")]
-pub extern fn vcx_credential_update_state(command_handle: CommandHandle,
-                                          credential_handle: u32,
-                                          cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, state: u32)>) -> u32 {
-    info!("vcx_credential_update_state >>>");
-
-    check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
-
-    if !credential::is_valid_handle(credential_handle) {
-        return VcxError::from(VcxErrorKind::InvalidCredentialHandle).into();
-    }
-
-    let source_id = credential::get_source_id(credential_handle).unwrap_or_default();
-    trace!("vcx_credential_update_state(command_handle: {}, credential_handle: {}), source_id: {:?}",
-           command_handle, credential_handle, source_id);
-
-    spawn(move || {
-        match credential::update_state(credential_handle, None, None) {
-            Ok(_) => (),
-            Err(e) => {
-                error!("vcx_credential_update_state_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
-            }
-        }
-
-        match credential::get_state(credential_handle) {
-            Ok(s) => {
-                trace!("vcx_credential_update_state_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, error::SUCCESS.message, s, source_id);
-                cb(command_handle, error::SUCCESS.code_num, s)
-            }
-            Err(e) => {
-                error!("vcx_credential_update_state_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
-            }
-        };
-
-        Ok(())
-    });
-
-    error::SUCCESS.code_num
+pub extern fn vcx_credential_update_state(_command_handle: CommandHandle,
+                                          _credential_handle: u32,
+                                          _cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, state: u32)>) -> u32 {
+    error!("vcx_credential_update_state >>> operation not supported");
+    error::ACTION_NOT_SUPPORTED.code_num
 }
 
 /// Query the agency for the received messages.
@@ -697,7 +647,7 @@ pub extern fn vcx_credential_update_state(command_handle: CommandHandle,
 ///
 /// credential_handle: Credential handle that was provided during creation. Used to identify credential object
 ///
-/// connection_handle: Connection handle associated with the credential object.
+/// connection_handle: Connection handle of the credential interaction is associated with.
 ///
 /// cb: Callback that provides most current state of the credential and error status of request
 ///
@@ -725,7 +675,7 @@ pub extern fn vcx_v2_credential_update_state(command_handle: CommandHandle,
            command_handle, credential_handle, connection_handle, source_id);
 
     spawn(move || {
-        match credential::update_state(credential_handle, None, Some(connection_handle)) {
+        match credential::update_state(credential_handle, None, connection_handle) {
             Ok(_) => (),
             Err(e) => {
                 error!("vcx_v2_credential_update_state_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
@@ -753,65 +703,14 @@ pub extern fn vcx_v2_credential_update_state(command_handle: CommandHandle,
     error::SUCCESS.code_num
 }
 
-/// Update the state of the credential based on the given message.
-///
-/// #Params
-/// command_handle: command handle to map callback to user context.
-///
-/// credential_handle: Credential handle that was provided during creation. Used to identify credential object
-///
-/// message: message to process for state changes
-///
-/// cb: Callback that provides most current state of the credential and error status of request
-///
-/// #Returns
-/// Error code as a u32
 #[no_mangle]
 #[deprecated(since = "0.15.0", note = "Use vcx_v2_credential_update_state_with_message instead.")]
-pub extern fn vcx_credential_update_state_with_message(command_handle: CommandHandle,
-                                                       credential_handle: u32,
-                                                       message: *const c_char,
-                                                       cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, state: u32)>) -> u32 {
-    info!("vcx_credential_update_state_with_message >>>");
-
-    check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
-    check_useful_c_str!(message, VcxErrorKind::InvalidOption);
-
-    if !credential::is_valid_handle(credential_handle) {
-        return VcxError::from(VcxErrorKind::InvalidCredentialHandle).into();
-    }
-
-    let source_id = credential::get_source_id(credential_handle).unwrap_or_default();
-    trace!("vcx_credential_update_state_with_message(command_handle: {}, credential_handle: {}), source_id: {:?}",
-           command_handle, credential_handle, source_id);
-
-    spawn(move || {
-        match credential::update_state(credential_handle, Some(&message), None) {
-            Ok(_) => (),
-            Err(e) => {
-                error!("vcx_credential_update_state_with_message_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
-            }
-        }
-
-        match credential::get_state(credential_handle) {
-            Ok(s) => {
-                trace!("vcx_credential_update_state_with_message_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, error::SUCCESS.message, s, source_id);
-                cb(command_handle, error::SUCCESS.code_num, s)
-            }
-            Err(e) => {
-                error!("vcx_credential_update_state_with_message_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
-            }
-        };
-
-        Ok(())
-    });
-
-    error::SUCCESS.code_num
+pub extern fn vcx_credential_update_state_with_message(_command_handle: CommandHandle,
+                                                       _credential_handle: u32,
+                                                       _message: *const c_char,
+                                                       _cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, state: u32)>) -> u32 {
+    info!("vcx_credential_update_state_with_message >>> operation not supported");
+    error::ACTION_NOT_SUPPORTED.code_num
 }
 
 
@@ -821,6 +720,8 @@ pub extern fn vcx_credential_update_state_with_message(command_handle: CommandHa
 /// command_handle: command handle to map callback to user context.
 ///
 /// credential_handle: Credential handle that was provided during creation. Used to identify credential object
+///
+/// connection_handle: Connection handle of the credential interaction is associated with.
 ///
 /// message: message to process for state changes
 ///
@@ -852,7 +753,7 @@ pub extern fn vcx_v2_credential_update_state_with_message(command_handle: Comman
            command_handle, credential_handle, source_id);
 
     spawn(move || {
-        match credential::update_state(credential_handle, Some(&message), Some(connection_handle)) {
+        match credential::update_state(credential_handle, Some(&message), connection_handle) {
             Ok(_) => (),
             Err(e) => {
                 error!("vcx_v2_credential_update_state_with_message_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
@@ -1225,7 +1126,7 @@ mod tests {
         AgencyMockDecrypted::set_next_decrypted_response(GET_MESSAGES_DECRYPTED_RESPONSE);
         AgencyMockDecrypted::set_next_decrypted_message(ARIES_CREDENTIAL_RESPONSE);
         let cb = return_types_u32::Return_U32_U32::new().unwrap();
-        assert_eq!(vcx_credential_update_state(cb.command_handle, handle_cred, Some(cb.get_callback())), error::SUCCESS.code_num);
+        assert_eq!(vcx_v2_credential_update_state(cb.command_handle, handle_cred, handle_conn, Some(cb.get_callback())), error::SUCCESS.code_num);
         cb.receive(TimeoutUtils::some_medium()).unwrap();
         assert_eq!(credential::get_state(handle_cred).unwrap(), VcxStateType::VcxStateAccepted as u32);
 

--- a/libvcx/src/api/disclosed_proof.rs
+++ b/libvcx/src/api/disclosed_proof.rs
@@ -487,51 +487,12 @@ pub extern fn vcx_disclosed_proof_get_proof_request_attachment(command_handle: C
     error::SUCCESS.code_num
 }
 
-/// Checks for any state change in the disclosed proof and updates the state attribute
-///
-/// #Params
-/// command_handle: command handle to map callback to user context.
-///
-/// proof_handle: Credential handle that was provided during creation. Used to identify disclosed proof object
-///
-/// cb: Callback that provides most current state of the disclosed proof and error status of request
-///
-/// #Returns
-/// Error code as a u32
 #[no_mangle]
 #[deprecated(since = "0.12.0", note = "Use vcx_v2_disclosed_proof_update_state instead.")]
-pub extern fn vcx_disclosed_proof_update_state(command_handle: CommandHandle,
-                                               proof_handle: u32,
-                                               cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, state: u32)>) -> u32 {
+pub extern fn vcx_disclosed_proof_update_state(_command_handle: CommandHandle,
+                                               _proof_handle: u32,
+                                               _cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, state: u32)>) -> u32 {
     info!("vcx_disclosed_proof_update_state >>>");
-
-    check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
-
-    if !disclosed_proof::is_valid_handle(proof_handle) {
-        return VcxError::from(VcxErrorKind::InvalidDisclosedProofHandle).into();
-    }
-
-    let source_id = disclosed_proof::get_source_id(proof_handle).unwrap_or_default();
-    trace!("vcx_disclosed_proof_update_state(command_handle: {}, proof_handle: {}) source_id: {}",
-           command_handle, proof_handle, source_id);
-
-    spawn(move || {
-        match disclosed_proof::update_state(proof_handle, None, None) {
-            Ok(s) => {
-                trace!("vcx_disclosed_proof_update_state_cb(command_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, s, source_id);
-                cb(command_handle, error::SUCCESS.code_num, s)
-            }
-            Err(e) => {
-                error!("vcx_disclosed_proof_update_state_cb(command_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
-            }
-        };
-
-        Ok(())
-    });
-
     error::SUCCESS.code_num
 }
 
@@ -557,7 +518,7 @@ pub extern fn vcx_v2_disclosed_proof_update_state(command_handle: CommandHandle,
            command_handle, proof_handle, connection_handle, source_id);
 
     spawn(move || {
-        match disclosed_proof::update_state(proof_handle, None, Some(connection_handle)) {
+        match disclosed_proof::update_state(proof_handle, None, connection_handle) {
             Ok(s) => {
                 trace!("vcx_v2_disclosed_proof_update_state_cb(command_handle: {}, rc: {}, state: {}) source_id: {}",
                        command_handle, error::SUCCESS.message, s, source_id);
@@ -576,55 +537,13 @@ pub extern fn vcx_v2_disclosed_proof_update_state(command_handle: CommandHandle,
     error::SUCCESS.code_num
 }
 
-/// Checks for any state change from the given message and updates the state attribute
-///
-/// #Params
-/// command_handle: command handle to map callback to user context.
-///
-/// proof_handle: Credential handle that was provided during creation. Used to identify disclosed proof object
-///
-/// message: message to process for state changes
-///
-/// cb: Callback that provides most current state of the disclosed proof and error status of request
-///
-/// #Returns
-/// Error code as a u32
 #[no_mangle]
 #[deprecated(since = "0.15.0", note = "Use vcx_v2_disclosed_proof_update_state_with_message instead.")]
-pub extern fn vcx_disclosed_proof_update_state_with_message(command_handle: CommandHandle,
-                                                            proof_handle: u32,
-                                                            message: *const c_char,
-                                                            cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, state: u32)>) -> u32 {
+pub extern fn vcx_disclosed_proof_update_state_with_message(_command_handle: CommandHandle,
+                                                            _proof_handle: u32,
+                                                            _message: *const c_char,
+                                                            _cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, state: u32)>) -> u32 {
     info!("vcx_disclosed_proof_update_state_with_message >>>");
-
-    check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
-    check_useful_c_str!(message, VcxErrorKind::InvalidOption);
-
-    if !disclosed_proof::is_valid_handle(proof_handle) {
-        return VcxError::from(VcxErrorKind::InvalidDisclosedProofHandle).into();
-    }
-
-    let source_id = disclosed_proof::get_source_id(proof_handle).unwrap_or_default();
-    trace!("vcx_disclosed_proof_update_state_with_message(command_handle: {}, proof_handle: {}) source_id: {}",
-           command_handle, proof_handle, source_id);
-
-    spawn(move || {
-        match disclosed_proof::update_state(proof_handle, Some(&message), None) {
-            Ok(state) => {
-                trace!("vcx_disclosed_proof_update_state__with_message_cb(command_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, state, source_id);
-                cb(command_handle, error::SUCCESS.code_num, state)
-            }
-            Err(e) => {
-                error!("vcx_disclosed_proof_update_state_with_message_cb(command_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
-            }
-        };
-
-        Ok(())
-    });
-
     error::SUCCESS.code_num
 }
 
@@ -668,7 +587,7 @@ pub extern fn vcx_v2_disclosed_proof_update_state_with_message(command_handle: C
            command_handle, proof_handle, source_id);
 
     spawn(move || {
-        match disclosed_proof::update_state(proof_handle, Some(&message), Some(connection_handle)) {
+        match disclosed_proof::update_state(proof_handle, Some(&message), connection_handle) {
             Ok(state) => {
                 trace!("vcx_v2_disclosed_proof_update_state_with_message_cb(command_handle: {}, rc: {}, state: {}) source_id: {}",
                        command_handle, error::SUCCESS.message, state, source_id);

--- a/libvcx/src/aries/handlers/issuance/holder/holder.rs
+++ b/libvcx/src/aries/handlers/issuance/holder/holder.rs
@@ -22,13 +22,7 @@ impl Holder {
     }
 
     pub fn send_request(&mut self, connection_handle: u32) -> VcxResult<()> {
-        self.step(CredentialIssuanceMessage::CredentialRequestSend(connection_handle))
-    }
-
-    pub fn maybe_update_connection_handle(&mut self, connection_handle: Option<u32>) -> u32 {
-        let conn_handle = connection_handle.unwrap_or(self.holder_sm.get_connection_handle());
-        self.holder_sm.set_connection_handle(conn_handle);
-        conn_handle
+        self.step(CredentialIssuanceMessage::CredentialRequestSend(), connection_handle)
     }
 
     pub fn is_terminal_state(&self) -> bool {
@@ -79,8 +73,8 @@ impl Holder {
         Ok(self.holder_sm.credential_status())
     }
 
-    pub fn step(&mut self, message: CredentialIssuanceMessage) -> VcxResult<()> {
-        self.holder_sm = self.holder_sm.clone().handle_message(message)?;
+    pub fn step(&mut self, message: CredentialIssuanceMessage, connection_handle: u32) -> VcxResult<()> {
+        self.holder_sm = self.holder_sm.clone().handle_message(message, connection_handle)?;
         Ok(())
     }
 

--- a/libvcx/src/aries/handlers/issuance/holder/states/offer_received.rs
+++ b/libvcx/src/aries/handlers/issuance/holder/states/offer_received.rs
@@ -10,13 +10,12 @@ pub struct OfferReceivedState {
     pub offer: CredentialOffer
 }
 
-impl From<(OfferReceivedState, String, String, u32)> for RequestSentState {
-    fn from((_state, req_meta, cred_def_json, connection_handle): (OfferReceivedState, String, String, u32)) -> Self {
+impl From<(OfferReceivedState, String, String)> for RequestSentState {
+    fn from((_state, req_meta, cred_def_json): (OfferReceivedState, String, String)) -> Self {
         trace!("SM is now in RequestSent state");
         RequestSentState {
             req_meta,
-            cred_def_json,
-            connection_handle,
+            cred_def_json
         }
     }
 }

--- a/libvcx/src/aries/handlers/issuance/holder/states/request_sent.rs
+++ b/libvcx/src/aries/handlers/issuance/holder/states/request_sent.rs
@@ -6,8 +6,7 @@ use crate::aries::messages::status::Status;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RequestSentState {
     pub req_meta: String,
-    pub cred_def_json: String,
-    pub connection_handle: u32,
+    pub cred_def_json: String
 }
 
 impl From<(RequestSentState, String, Credential, Option<String>)> for FinishedHolderState {

--- a/libvcx/src/aries/handlers/issuance/issuer/issuer.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/issuer.rs
@@ -23,11 +23,11 @@ impl Issuer {
     }
 
     pub fn send_credential_offer(&mut self, connection_handle: u32, comment: Option<String>) -> VcxResult<()> {
-        self.step(CredentialIssuanceMessage::CredentialInit(connection_handle, comment))
+        self.step(CredentialIssuanceMessage::CredentialInit(comment), connection_handle)
     }
 
     pub fn send_credential(&mut self, connection_handle: u32) -> VcxResult<()> {
-        self.step(CredentialIssuanceMessage::CredentialSend(connection_handle))
+        self.step(CredentialIssuanceMessage::CredentialSend(), connection_handle)
     }
 
     pub fn get_state(&self) -> VcxResult<u32> {
@@ -54,18 +54,12 @@ impl Issuer {
         self.issuer_sm.get_rev_reg_id()
     }
 
-    pub fn maybe_update_connection_handle(&mut self, connection_handle: Option<u32>) -> u32 {
-        let conn_handle = connection_handle.unwrap_or(self.issuer_sm.get_connection_handle());
-        self.issuer_sm.set_connection_handle(conn_handle);
-        conn_handle
-    }
-
     pub fn get_credential_status(&self) -> VcxResult<u32> {
         Ok(self.issuer_sm.credential_status())
     }
 
-    pub fn step(&mut self, message: CredentialIssuanceMessage) -> VcxResult<()> {
-        self.issuer_sm = self.issuer_sm.clone().handle_message(message)?;
+    pub fn step(&mut self, message: CredentialIssuanceMessage, connection_handle: u32) -> VcxResult<()> {
+        self.issuer_sm = self.issuer_sm.clone().handle_message(message, connection_handle)?;
         Ok(())
     }
 }

--- a/libvcx/src/aries/handlers/issuance/issuer/state_machine.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/state_machine.rs
@@ -514,7 +514,6 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            let conn_handle = mock_connection();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), mock_connection()).unwrap();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), mock_connection()).unwrap();

--- a/libvcx/src/aries/handlers/issuance/issuer/state_machine.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/state_machine.rs
@@ -37,25 +37,6 @@ pub struct RevocationInfoV1 {
 }
 
 impl IssuerState {
-    pub fn get_connection_handle(&self) -> u32 {
-        match self {
-            IssuerState::Initial(_) => 0,
-            IssuerState::OfferSent(state) => state.connection_handle,
-            IssuerState::RequestReceived(state) => state.connection_handle,
-            IssuerState::CredentialSent(state) => state.connection_handle,
-            IssuerState::Finished(_) => 0
-        }
-    }
-
-    pub fn set_connection_handle(&mut self, connection_handle: u32) {
-        match self {
-            IssuerState::OfferSent(state) => { state.connection_handle = connection_handle; }
-            IssuerState::RequestReceived(state) => { state.connection_handle = connection_handle; }
-            IssuerState::CredentialSent(state) => { state.connection_handle = connection_handle; }
-            _ => {}
-        }
-    }
-
     pub fn thread_id(&self) -> String {
         match self {
             IssuerState::Initial(_) => String::new(),
@@ -132,14 +113,6 @@ impl IssuerSM {
         rev_registry.ok_or(VcxError::from_msg(VcxErrorKind::InvalidState, "No revocation registry id found on revocation info - is this credential revokable?"))
     }
 
-    pub fn get_connection_handle(&self) -> u32 {
-        self.state.get_connection_handle()
-    }
-
-    pub fn set_connection_handle(&mut self, conn_handle: u32) {
-        self.state.set_connection_handle(conn_handle)
-    }
-
     pub fn find_message_to_handle(&self, messages: HashMap<String, A2AMessage>) -> Option<(String, A2AMessage)> {
         trace!("Issuer::find_message_to_handle >>> messages: {:?}", messages);
 
@@ -212,20 +185,20 @@ impl IssuerSM {
         }
     }
 
-    pub fn handle_message(self, cim: CredentialIssuanceMessage) -> VcxResult<IssuerSM> {
+    pub fn handle_message(self, cim: CredentialIssuanceMessage, connection_handle: u32) -> VcxResult<IssuerSM> {
         trace!("IssuerSM::handle_message >>> cim: {:?}", cim);
 
         let IssuerSM { state, source_id } = self;
         let state = match state {
             IssuerState::Initial(state_data) => match cim {
-                CredentialIssuanceMessage::CredentialInit(connection_handle, comment) => {
+                CredentialIssuanceMessage::CredentialInit(comment) => {
                     let cred_offer = libindy_issuer_create_credential_offer(&state_data.cred_def_id)?;
                     let cred_offer_msg = CredentialOffer::create()
                         .set_offers_attach(&cred_offer)?
                         .set_comment(comment);
                     let cred_offer_msg = _append_credential_preview(cred_offer_msg, &state_data.credential_json)?;
                     send_message(connection_handle, cred_offer_msg.to_a2a_message())?;
-                    IssuerState::OfferSent((state_data, cred_offer, connection_handle, cred_offer_msg.id).into())
+                    IssuerState::OfferSent((state_data, cred_offer, cred_offer_msg.id).into())
                 }
                 _ => {
                     warn!("Credential Issuance can only start on issuer side with init");
@@ -241,7 +214,7 @@ impl IssuerSM {
                         .set_comment(String::from("CredentialProposal is not supported"))
                         .set_thread_id(&state_data.thread_id);
 
-                    send_message(state_data.connection_handle, problem_report.to_a2a_message())?;
+                    send_message(connection_handle, problem_report.to_a2a_message())?;
                     IssuerState::Finished((state_data, problem_report).into())
                 }
                 CredentialIssuanceMessage::ProblemReport(problem_report) => {
@@ -253,7 +226,7 @@ impl IssuerSM {
                 }
             },
             IssuerState::RequestReceived(state_data) => match cim {
-                CredentialIssuanceMessage::CredentialSend(connection_handle) => {
+                CredentialIssuanceMessage::CredentialSend() => {
                     let credential_msg = _create_credential(&state_data.request, &state_data.rev_reg_id, &state_data.tails_file, &state_data.offer, &state_data.cred_data);
                     match credential_msg {
                         Ok((credential_msg, cred_rev_id)) => {
@@ -266,7 +239,7 @@ impl IssuerSM {
                                 .set_comment(err.to_string())
                                 .set_thread_id(&state_data.thread_id);
 
-                            send_message(state_data.connection_handle, problem_report.to_a2a_message())?;
+                            send_message(connection_handle, problem_report.to_a2a_message())?;
                             IssuerState::Finished((state_data, problem_report).into())
                         }
                     }
@@ -383,21 +356,21 @@ pub mod test {
 
     impl IssuerSM {
         fn to_offer_sent_state(mut self) -> IssuerSM {
-            self = self.handle_message(CredentialIssuanceMessage::CredentialInit(mock_connection(), None)).unwrap();
+            self = self.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
             self
         }
 
         fn to_request_received_state(mut self) -> IssuerSM {
-            self = self.handle_message(CredentialIssuanceMessage::CredentialInit(mock_connection(), None)).unwrap();
-            self = self.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request())).unwrap();
+            self = self.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            self = self.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), mock_connection()).unwrap();
             self
         }
 
         fn to_finished_state(mut self) -> IssuerSM {
             let conn_handle = mock_connection();
-            self = self.handle_message(CredentialIssuanceMessage::CredentialInit(conn_handle, None)).unwrap();
-            self = self.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request())).unwrap();
-            self = self.handle_message(CredentialIssuanceMessage::CredentialSend(conn_handle)).unwrap();
+            self = self.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            self = self.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), mock_connection()).unwrap();
+            self = self.handle_message(CredentialIssuanceMessage::CredentialSend(), mock_connection()).unwrap();
             self
         }
     }
@@ -436,7 +409,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(mock_connection(), None)).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
 
             assert_match!(IssuerState::OfferSent(_), issuer_sm.state);
         }
@@ -448,10 +421,10 @@ pub mod test {
 
             let mut issuer_sm = _issuer_sm();
 
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::Credential(_credential())).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::Credential(_credential()), mock_connection()).unwrap();
             assert_match!(IssuerState::Initial(_), issuer_sm.state);
 
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request())).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), mock_connection()).unwrap();
             assert_match!(IssuerState::Initial(_), issuer_sm.state);
         }
 
@@ -461,8 +434,8 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(mock_connection(), None)).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request())).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), mock_connection()).unwrap();
 
             assert_match!(IssuerState::RequestReceived(_), issuer_sm.state);
         }
@@ -473,8 +446,8 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(mock_connection(), None)).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialProposal(_credential_proposal())).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialProposal(_credential_proposal()), mock_connection()).unwrap();
 
             assert_match!(IssuerState::Finished(_), issuer_sm.state);
             assert_eq!(Status::Failed(ProblemReport::default()).code(), issuer_sm.credential_status());
@@ -486,8 +459,8 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(mock_connection(), None)).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::ProblemReport(_problem_report())).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::ProblemReport(_problem_report()), mock_connection()).unwrap();
 
             assert_match!(IssuerState::Finished(_), issuer_sm.state);
             assert_eq!(Status::Failed(ProblemReport::default()).code(), issuer_sm.credential_status());
@@ -499,8 +472,8 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(mock_connection(), None)).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::Credential(_credential())).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::Credential(_credential()), mock_connection()).unwrap();
 
             assert_match!(IssuerState::OfferSent(_), issuer_sm.state);
         }
@@ -512,9 +485,9 @@ pub mod test {
 
             let mut issuer_sm = _issuer_sm();
             let conn_handle = mock_connection();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(conn_handle, None)).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request())).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(conn_handle)).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), mock_connection()).unwrap();
 
             assert_match!(IssuerState::Finished(_), issuer_sm.state);
             assert_eq!(Status::Success.code(), issuer_sm.credential_status());
@@ -527,9 +500,9 @@ pub mod test {
 
             let mut issuer_sm = _issuer_sm();
             let conn_handle = mock_connection();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(conn_handle, None)).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(CredentialRequest::create())).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(conn_handle)).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(CredentialRequest::create()), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), mock_connection()).unwrap();
 
             assert_match!(IssuerState::Finished(_), issuer_sm.state);
             assert_eq!(Status::Failed(ProblemReport::default()).code(), issuer_sm.credential_status());
@@ -542,14 +515,14 @@ pub mod test {
 
             let mut issuer_sm = _issuer_sm();
             let conn_handle = mock_connection();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(conn_handle, None)).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request())).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(conn_handle)).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), mock_connection()).unwrap();
 
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(conn_handle)).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), mock_connection()).unwrap();
             assert_match!(IssuerState::Finished(_), issuer_sm.state);
 
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialAck(_ack())).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialAck(_ack()), mock_connection()).unwrap();
             assert_match!(IssuerState::Finished(_), issuer_sm.state);
         }
 
@@ -562,17 +535,17 @@ pub mod test {
 
             let mut issuer_sm = _issuer_sm();
             let conn_handle = mock_connection();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(conn_handle, None)).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request())).unwrap();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(conn_handle)).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), mock_connection()).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), mock_connection()).unwrap();
 
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(mock_connection(), None)).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialInit(None), mock_connection()).unwrap();
             assert_match!(IssuerState::Finished(_), issuer_sm.state);
 
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request())).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), mock_connection()).unwrap();
             assert_match!(IssuerState::Finished(_), issuer_sm.state);
 
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::Credential(_credential())).unwrap();
+            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::Credential(_credential()), mock_connection()).unwrap();
             assert_match!(IssuerState::Finished(_), issuer_sm.state);
         }
     }

--- a/libvcx/src/aries/handlers/issuance/issuer/states/credential_sent.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/states/credential_sent.rs
@@ -4,7 +4,6 @@ use crate::aries::messages::status::Status;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CredentialSentState {
-    pub connection_handle: u32,
     pub revocation_info_v1: Option<RevocationInfoV1>,
     pub thread_id: String,
 }

--- a/libvcx/src/aries/handlers/issuance/issuer/states/initial.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/states/initial.rs
@@ -34,15 +34,14 @@ impl From<InitialState> for FinishedState {
     }
 }
 
-impl From<(InitialState, String, u32, MessageId)> for OfferSentState {
-    fn from((state, offer, connection_handle, sent_id): (InitialState, String, u32, MessageId)) -> Self {
+impl From<(InitialState, String, MessageId)> for OfferSentState {
+    fn from((state, offer, sent_id): (InitialState, String, MessageId)) -> Self {
         trace!("SM is now in OfferSent state");
         OfferSentState {
             offer,
             cred_data: state.credential_json,
             rev_reg_id: state.rev_reg_id,
             tails_file: state.tails_file,
-            connection_handle,
             thread_id: sent_id.0,
         }
     }

--- a/libvcx/src/aries/handlers/issuance/issuer/states/offer_sent.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/states/offer_sent.rs
@@ -11,7 +11,6 @@ pub struct OfferSentState {
     pub cred_data: String,
     pub rev_reg_id: Option<String>,
     pub tails_file: Option<String>,
-    pub connection_handle: u32,
     pub thread_id: String,
 }
 
@@ -39,7 +38,6 @@ impl From<(OfferSentState, CredentialRequest)> for RequestReceivedState {
             cred_data: state.cred_data,
             rev_reg_id: state.rev_reg_id,
             tails_file: state.tails_file,
-            connection_handle: state.connection_handle,
             request,
             thread_id: state.thread_id,
         }

--- a/libvcx/src/aries/handlers/issuance/issuer/states/requested_received.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/states/requested_received.rs
@@ -12,7 +12,6 @@ pub struct RequestReceivedState {
     pub cred_data: String,
     pub rev_reg_id: Option<String>,
     pub tails_file: Option<String>,
-    pub connection_handle: u32,
     pub request: CredentialRequest,
     pub thread_id: String,
 }
@@ -21,7 +20,6 @@ impl From<(RequestReceivedState, MessageId)> for CredentialSentState {
     fn from((state, _sent_id): (RequestReceivedState, MessageId)) -> Self {
         trace!("SM is now in CredentialSent state");
         CredentialSentState {
-            connection_handle: state.connection_handle,
             revocation_info_v1: Some(RevocationInfoV1 {
                 cred_rev_id: None,
                 rev_reg_id: state.rev_reg_id,

--- a/libvcx/src/aries/handlers/issuance/messages.rs
+++ b/libvcx/src/aries/handlers/issuance/messages.rs
@@ -8,11 +8,11 @@ use crate::aries::messages::issuance::credential_request::CredentialRequest;
 
 #[derive(Debug, Clone)]
 pub enum CredentialIssuanceMessage {
-    CredentialInit(u32, Option<String>),
-    CredentialSend(u32),
+    CredentialInit(Option<String>),
+    CredentialSend(),
     CredentialProposal(CredentialProposal),
     CredentialOffer(CredentialOffer),
-    CredentialRequestSend(u32),
+    CredentialRequestSend(),
     CredentialRequest(CredentialRequest),
     Credential(Credential),
     CredentialAck(CredentialAck),

--- a/libvcx/src/aries/handlers/proof_presentation/prover/messages.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/messages.rs
@@ -8,13 +8,13 @@ use crate::aries::messages::proof_presentation::presentation_request::Presentati
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub enum ProverMessages {
     PresentationRequestReceived(PresentationRequestData),
-    RejectPresentationRequest((u32, String)),
+    RejectPresentationRequest(String),
     SetPresentation(Presentation),
     PreparePresentation((String, String)),
-    SendPresentation(u32),
+    SendPresentation,
     PresentationAckReceived(PresentationAck),
     PresentationRejectReceived(ProblemReport),
-    ProposePresentation((u32, PresentationPreview)),
+    ProposePresentation(PresentationPreview),
     Unknown,
 }
 

--- a/libvcx/src/aries/handlers/proof_presentation/prover/states/finished.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/states/finished.rs
@@ -5,7 +5,6 @@ use crate::aries::handlers::proof_presentation::prover::states::initial::Initial
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FinishedState {
-    pub connection_handle: u32,
     pub presentation_request: PresentationRequest,
     pub presentation: Presentation,
     pub status: Status,
@@ -16,7 +15,6 @@ impl From<InitialState> for FinishedState {
     fn from(state: InitialState) -> Self {
         trace!("transit state from InitialState to FinishedState");
         FinishedState {
-            connection_handle: 0,
             presentation_request: state.presentation_request,
             presentation: Default::default(),
             status: Status::Declined,

--- a/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_prepared.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_prepared.rs
@@ -10,13 +10,12 @@ pub struct PresentationPreparedState {
     pub presentation: Presentation,
 }
 
-impl From<(PresentationPreparedState, u32)> for PresentationSentState {
-    fn from((state, connection_handle): (PresentationPreparedState, u32)) -> Self {
+impl From<(PresentationPreparedState)> for PresentationSentState {
+    fn from((state): (PresentationPreparedState)) -> Self {
         trace!("transit state from PresentationPreparedState to PresentationSentState");
         PresentationSentState {
             presentation_request: state.presentation_request,
             presentation: state.presentation,
-            connection_handle,
         }
     }
 }
@@ -25,7 +24,6 @@ impl From<PresentationPreparedState> for FinishedState {
     fn from(state: PresentationPreparedState) -> Self {
         trace!("transit state from PresentationPreparedState to FinishedState");
         FinishedState {
-            connection_handle: 0,
             presentation_request: state.presentation_request,
             presentation: Default::default(),
             status: Status::Declined,

--- a/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_prepared_failed.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_prepared_failed.rs
@@ -10,13 +10,12 @@ pub struct PresentationPreparationFailedState {
     pub problem_report: ProblemReport,
 }
 
-impl From<(PresentationPreparationFailedState, u32)> for FinishedState {
-    fn from((state, connection_handle): (PresentationPreparationFailedState, u32)) -> Self {
+impl From<(PresentationPreparationFailedState)> for FinishedState {
+    fn from((state): (PresentationPreparationFailedState)) -> Self {
         trace!("transit state from PresentationPreparationFailedState to FinishedState");
         FinishedState {
             presentation_request: state.presentation_request,
             presentation: Presentation::create(),
-            connection_handle,
             status: Status::Failed(state.problem_report),
         }
     }

--- a/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_sent.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_sent.rs
@@ -7,7 +7,6 @@ use crate::aries::messages::status::Status;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PresentationSentState {
-    pub connection_handle: u32,
     pub presentation_request: PresentationRequest,
     pub presentation: Presentation,
 }
@@ -16,7 +15,6 @@ impl From<(PresentationSentState, PresentationAck)> for FinishedState {
     fn from((state, _ack): (PresentationSentState, PresentationAck)) -> Self {
         trace!("transit state from PresentationSentState to FinishedState");
         FinishedState {
-            connection_handle: state.connection_handle,
             presentation_request: state.presentation_request,
             presentation: state.presentation,
             status: Status::Success,
@@ -28,7 +26,6 @@ impl From<(PresentationSentState, ProblemReport)> for FinishedState {
     fn from((state, problem_report): (PresentationSentState, ProblemReport)) -> Self {
         trace!("transit state from PresentationSentState to FinishedState");
         FinishedState {
-            connection_handle: state.connection_handle,
             presentation_request: state.presentation_request,
             presentation: state.presentation,
             status: Status::Failed(problem_report),

--- a/libvcx/src/aries/handlers/proof_presentation/verifier/messages.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/verifier/messages.rs
@@ -5,7 +5,7 @@ use crate::aries::messages::proof_presentation::presentation_proposal::Presentat
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub enum VerifierMessages {
-    SendPresentationRequest(u32),
+    SendPresentationRequest,
     VerifyPresentation(Presentation),
     PresentationProposalReceived(PresentationProposal),
     PresentationRejectReceived(ProblemReport),

--- a/libvcx/src/aries/handlers/proof_presentation/verifier/states/finished.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/verifier/states/finished.rs
@@ -5,7 +5,6 @@ use crate::aries::messages::status::Status;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FinishedState {
-    pub connection_handle: u32,
     pub presentation_request: PresentationRequest,
     pub presentation: Option<Presentation>,
     pub status: Status,

--- a/libvcx/src/aries/handlers/proof_presentation/verifier/states/initial.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/verifier/states/initial.rs
@@ -6,9 +6,9 @@ pub struct InitialState {
     pub presentation_request_data: PresentationRequestData
 }
 
-impl From<(InitialState, PresentationRequest, u32)> for PresentationRequestSentState {
-    fn from((_state, presentation_request, connection_handle): (InitialState, PresentationRequest, u32)) -> Self {
+impl From<(InitialState, PresentationRequest)> for PresentationRequestSentState {
+    fn from((_state, presentation_request): (InitialState, PresentationRequest)) -> Self {
         trace!("transit state from InitialState to PresentationRequestSentState");
-        PresentationRequestSentState { connection_handle, presentation_request }
+        PresentationRequestSentState { presentation_request }
     }
 }

--- a/libvcx/src/aries/mod.rs
+++ b/libvcx/src/aries/mod.rs
@@ -240,17 +240,17 @@ pub mod test {
                                                                                  credential_data,
                                                                                  0).unwrap();
             issuer_credential::send_credential_offer(self.credential_handle, self.connection_handle, None).unwrap();
-            issuer_credential::update_state(self.credential_handle, None, None).unwrap();
+            issuer_credential::update_state(self.credential_handle, None, self.connection_handle).unwrap();
             assert_eq!(2, issuer_credential::get_state(self.credential_handle).unwrap());
         }
 
         pub fn send_credential(&self) {
             self.activate();
-            issuer_credential::update_state(self.credential_handle, None, None).unwrap();
+            issuer_credential::update_state(self.credential_handle, None, self.connection_handle).unwrap();
             assert_eq!(3, issuer_credential::get_state(self.credential_handle).unwrap());
 
             issuer_credential::send_credential(self.credential_handle, self.connection_handle).unwrap();
-            issuer_credential::update_state(self.credential_handle, None, None).unwrap();
+            issuer_credential::update_state(self.credential_handle, None, self.connection_handle).unwrap();
             assert_eq!(4, issuer_credential::get_state(self.credential_handle).unwrap());
             assert_eq!(aries::messages::status::Status::Success.code(), issuer_credential::get_credential_status(self.credential_handle).unwrap());
         }
@@ -376,7 +376,7 @@ pub mod test {
 
         pub fn accept_credential(&self) {
             self.activate();
-            credential::update_state(self.credential_handle, None, None).unwrap();
+            credential::update_state(self.credential_handle, None, self.connection_handle).unwrap();
             assert_eq!(4, credential::get_state(self.credential_handle).unwrap());
             assert_eq!(aries::messages::status::Status::Success.code(), credential::get_credential_status(self.credential_handle).unwrap());
         }

--- a/libvcx/src/aries/mod.rs
+++ b/libvcx/src/aries/mod.rs
@@ -261,7 +261,7 @@ pub mod test {
             assert_eq!(1, proof::get_state(self.presentation_handle).unwrap());
 
             proof::send_proof_request(self.presentation_handle, self.connection_handle).unwrap();
-            proof::update_state(self.presentation_handle, None, None).unwrap();
+            proof::update_state(self.presentation_handle, None, self.connection_handle).unwrap();
 
             assert_eq!(2, proof::get_state(self.presentation_handle).unwrap());
         }
@@ -274,7 +274,7 @@ pub mod test {
         pub fn update_proof_state(&self, expected_state: u32, expected_status: u32) {
             self.activate();
 
-            proof::update_state(self.presentation_handle, None, None).unwrap();
+            proof::update_state(self.presentation_handle, None, self.connection_handle).unwrap();
             assert_eq!(expected_state, proof::get_state(self.presentation_handle).unwrap());
             assert_eq!(expected_status, proof::get_proof_state(self.presentation_handle).unwrap());
         }
@@ -451,7 +451,7 @@ pub mod test {
 
         pub fn ensure_presentation_verified(&self) {
             self.activate();
-            disclosed_proof::update_state(self.presentation_handle, None, None).unwrap();
+            disclosed_proof::update_state(self.presentation_handle, None, self.connection_handle).unwrap();
             assert_eq!(aries::messages::status::Status::Success.code(), disclosed_proof::get_presentation_status(self.presentation_handle).unwrap());
         }
     }

--- a/libvcx/src/credential.rs
+++ b/libvcx/src/credential.rs
@@ -83,7 +83,7 @@ pub fn credential_create_with_msgid(source_id: &str, connection_handle: u32, msg
     Ok((handle, offer))
 }
 
-pub fn update_state(handle: u32, message: Option<&str>, connection_handle: Option<u32>) -> VcxResult<u32> {
+pub fn update_state(handle: u32, message: Option<&str>, connection_handle: u32) -> VcxResult<u32> {
     HANDLE_MAP.get_mut(handle, |credential| {
         trace!("credential::update_state >>> ");
 
@@ -93,18 +93,16 @@ pub fn update_state(handle: u32, message: Option<&str>, connection_handle: Optio
             let message: A2AMessage = serde_json::from_str(&message)
                 .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidOption, format!("Cannot update state: Message deserialization failed: {:?}", err)))?;
 
-            credential.step(message.into())?;
+            credential.step(message.into(), connection_handle)?;
             return Ok(credential.get_status());
         }
 
-        let conn_handle = credential.maybe_update_connection_handle(connection_handle);
-
-        let messages = connection::get_messages(conn_handle)?;
+        let messages = connection::get_messages(connection_handle)?;
 
         match credential.find_message_to_handle(messages) {
             Some((uid, msg)) => {
-                credential.step(msg.into())?;
-                connection::update_message_status(conn_handle, uid)?;
+                credential.step(msg.into(), connection_handle)?;
+                connection::update_message_status(connection_handle, uid)?;
                 Ok(credential.get_status())
             }
             None => Ok(credential.get_status())
@@ -274,7 +272,7 @@ pub mod tests {
     use crate::credential::{credential_create_with_offer, get_attributes, get_credential, send_credential_request};
     use crate::error::VcxErrorKind;
     use crate::utils::devsetup::*;
-    use crate::utils::mockdata::mockdata_credex::{ARIES_CREDENTIAL_OFFER, ARIES_CREDENTIAL_RESPONSE, CREDENTIAL_SM_FINISHED};
+    use crate::utils::mockdata::mockdata_credex::{ARIES_CREDENTIAL_OFFER, ARIES_CREDENTIAL_RESPONSE, CREDENTIAL_SM_FINISHED, CREDENTIAL_SM_OFFER_RECEIVED};
     use crate::utils::mockdata::mockdata_credex;
 
     use super::*;
@@ -354,7 +352,7 @@ pub mod tests {
         AgencyMockDecrypted::set_next_decrypted_message(ARIES_CREDENTIAL_RESPONSE);
 
         info!("full_credential_test:: going to update_state, should receive credential");
-        update_state(handle_cred, None, Some(handle_conn)).unwrap();
+        update_state(handle_cred, None, handle_conn).unwrap();
         assert_eq!(get_state(handle_cred).unwrap(), VcxStateType::VcxStateAccepted as u32);
 
         info!("full_credential_test:: going to get_credential");

--- a/libvcx/src/lib.rs
+++ b/libvcx/src/lib.rs
@@ -329,10 +329,10 @@ mod tests {
         send_proof_request(alice, &requested_attrs_string, "[]", "{}", institution_handle, request_name)
     }
 
-    fn _prover_select_credentials_and_send_proof(faber: u32, consumer_handle: Option<u32>, request_name: Option<&str>, requested_values: Option<&str>) {
+    fn _prover_select_credentials_and_send_proof(consumer_to_institution: u32, consumer_handle: Option<u32>, request_name: Option<&str>, requested_values: Option<&str>) {
         set_consumer(consumer_handle);
         info!("Prover :: Going to create proof");
-        let proof_handle_prover = create_proof(faber, consumer_handle, request_name);
+        let proof_handle_prover = create_proof(consumer_to_institution, consumer_handle, request_name);
         info!("Prover :: Retrieving matching credentials");
         let retrieved_credentials = disclosed_proof::retrieve_credentials(proof_handle_prover).unwrap();
         info!("Prover :: Based on proof, retrieved credentials: {}", &retrieved_credentials);
@@ -345,7 +345,7 @@ mod tests {
         };
         let selected_credentials_str = serde_json::to_string(&selected_credentials_value).unwrap();
         info!("Prover :: Retrieved credential converted to selected: {}", &selected_credentials_str);
-        generate_and_send_proof(proof_handle_prover, faber, &selected_credentials_str, consumer_handle);
+        generate_and_send_proof(proof_handle_prover, consumer_to_institution, &selected_credentials_str, consumer_handle);
     }
 
     #[cfg(feature = "agency_pool_tests")]
@@ -354,8 +354,8 @@ mod tests {
         let _setup = SetupLibraryAgencyV2::init();
 
         let institution_did = settings::get_config_value(settings::CONFIG_INSTITUTION_DID).unwrap();
-        let (faber, alice) = connection::tests::create_connected_connections(None, None);
-        let (schema_id, cred_def_id, rev_reg_id, _cred_def_handle, credential_handle) = _issue_address_credential(faber, alice, None);
+        let (consumer_to_institution, institution_to_consumer) = connection::tests::create_connected_connections(None, None);
+        let (schema_id, cred_def_id, rev_reg_id, _cred_def_handle, credential_handle) = _issue_address_credential(consumer_to_institution, institution_to_consumer, None);
 
         let time_before_revocation = time::get_time().sec as u64;
         info!("test_basic_revocation :: verifier :: Going to revoke credential");
@@ -368,13 +368,13 @@ mod tests {
         let requested_attrs_string = serde_json::to_string(&_requested_attrs).unwrap();
 
         info!("test_basic_revocation :: Going to seng proof request with attributes {}", &requested_attrs_string);
-        let proof_handle_verifier = send_proof_request(alice, &requested_attrs_string, "[]", &interval, None, None);
+        let proof_handle_verifier = send_proof_request(institution_to_consumer, &requested_attrs_string, "[]", &interval, None, None);
 
-        _prover_select_credentials_and_send_proof(faber, None, None, None);
+        _prover_select_credentials_and_send_proof(consumer_to_institution, None, None, None);
 
         info!("test_basic_revocation :: verifier :: going to verify proof");
         set_institution(None);
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, institution_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofInvalid as u32);
     }
 
@@ -394,7 +394,7 @@ mod tests {
         _prover_select_credentials_and_send_proof(consumer_to_institution, None, request_name1, None);
 
         set_institution(None);
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, institution_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
 
         publish_revocation(rev_reg_id.clone().unwrap());
@@ -403,7 +403,7 @@ mod tests {
         _prover_select_credentials_and_send_proof(consumer_to_institution, None, request_name2, None);
 
         set_institution(None);
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, institution_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofInvalid as u32);
     }
 
@@ -432,14 +432,14 @@ mod tests {
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer1, Some(verifier), request_name1);
         _prover_select_credentials_and_send_proof(consumer1_to_verifier, Some(consumer1), None, None);
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer1).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
 
         let request_name2 = Some("request2");
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer2, Some(verifier), request_name2);
         _prover_select_credentials_and_send_proof(consumer2_to_verifier, Some(consumer2), None, None);
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer2).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
     }
 
@@ -459,14 +459,14 @@ mod tests {
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), request_name1);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), request_name1, None);
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
 
         let request_name2 = Some("request2");
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), request_name2);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), request_name2, None);
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
     }
 
@@ -487,14 +487,14 @@ mod tests {
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, institution_to_consumer, None, request_name1);
         _prover_select_credentials_and_send_proof(consumer_to_institution, None, request_name1, None);
         set_institution(None);
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, institution_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
 
         let request_name2 = Some("request2");
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, institution_to_consumer, None, request_name2);
         _prover_select_credentials_and_send_proof(consumer_to_institution, None, request_name2, None);
         set_institution(None);
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, institution_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
     }
 
@@ -540,9 +540,9 @@ mod tests {
         _prover_select_credentials_and_send_proof(consumer_to_institution3, Some(consumer3), request_name1, None);
 
         set_institution(None);
-        proof::update_state(proof_handle_verifier1, None, None).unwrap();
-        proof::update_state(proof_handle_verifier2, None, None).unwrap();
-        proof::update_state(proof_handle_verifier3, None, None).unwrap();
+        proof::update_state(proof_handle_verifier1, None, institution_to_consumer1).unwrap();
+        proof::update_state(proof_handle_verifier2, None, institution_to_consumer2).unwrap();
+        proof::update_state(proof_handle_verifier3, None, institution_to_consumer3).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier1).unwrap(), ProofStateType::ProofValidated as u32);
         assert_eq!(proof::get_proof_state(proof_handle_verifier2).unwrap(), ProofStateType::ProofValidated as u32);
         assert_eq!(proof::get_proof_state(proof_handle_verifier3).unwrap(), ProofStateType::ProofValidated as u32);
@@ -562,9 +562,9 @@ mod tests {
         assert_ne!(proof_handle_verifier2, proof_handle_verifier3);
 
         set_institution(None);
-        proof::update_state(proof_handle_verifier1, None, None).unwrap();
-        proof::update_state(proof_handle_verifier2, None, None).unwrap();
-        proof::update_state(proof_handle_verifier3, None, None).unwrap();
+        proof::update_state(proof_handle_verifier1, None, institution_to_consumer1).unwrap();
+        proof::update_state(proof_handle_verifier2, None, institution_to_consumer2).unwrap();
+        proof::update_state(proof_handle_verifier3, None, institution_to_consumer3).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier1).unwrap(), ProofStateType::ProofInvalid as u32);
         assert_eq!(proof::get_proof_state(proof_handle_verifier2).unwrap(), ProofStateType::ProofInvalid as u32);
         assert_eq!(proof::get_proof_state(proof_handle_verifier3).unwrap(), ProofStateType::ProofValidated as u32);
@@ -576,8 +576,8 @@ mod tests {
         let _setup = SetupLibraryAgencyV2::init();
 
         let institution_did = settings::get_config_value(settings::CONFIG_INSTITUTION_DID).unwrap();
-        let (faber, alice) = connection::tests::create_connected_connections(None, None);
-        let (schema_id, cred_def_id, rev_reg_id, _cred_def_handle, credential_handle) = _issue_address_credential(faber, alice, None);
+        let (consumer_to_institution, institution_to_consumer) = connection::tests::create_connected_connections(None, None);
+        let (schema_id, cred_def_id, rev_reg_id, _cred_def_handle, credential_handle) = _issue_address_credential(consumer_to_institution, institution_to_consumer, None);
 
         thread::sleep(Duration::from_millis(1000));
         let time_before_revocation = time::get_time().sec as u64;
@@ -593,10 +593,10 @@ mod tests {
         let requested_attrs_string = serde_json::to_string(&_requested_attrs).unwrap();
 
         info!("test_revoked_credential_might_still_work :: Going to seng proof request with attributes {}", &requested_attrs_string);
-        let proof_handle_verifier = send_proof_request(alice, &requested_attrs_string, "[]", &interval, None, None);
+        let proof_handle_verifier = send_proof_request(institution_to_consumer, &requested_attrs_string, "[]", &interval, None, None);
 
         info!("test_revoked_credential_might_still_work :: Going to create proof");
-        let proof_handle_prover = create_proof(faber, None, None);
+        let proof_handle_prover = create_proof(consumer_to_institution, None, None);
         info!("test_revoked_credential_might_still_work :: retrieving matching credentials");
 
         let retrieved_credentials = disclosed_proof::retrieve_credentials(proof_handle_prover).unwrap();
@@ -605,11 +605,11 @@ mod tests {
         let selected_credentials_value = retrieved_to_selected_credentials_simple(&retrieved_credentials, true);
         let selected_credentials_str = serde_json::to_string(&selected_credentials_value).unwrap();
         info!("test_revoked_credential_might_still_work :: prover :: retrieved credential converted to selected: {}", &selected_credentials_str);
-        generate_and_send_proof(proof_handle_prover, faber, &selected_credentials_str, None);
+        generate_and_send_proof(proof_handle_prover, consumer_to_institution, &selected_credentials_str, None);
 
         info!("test_revoked_credential_might_still_work :: verifier :: going to verify proof");
         set_institution(None);
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, institution_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
     }
 
@@ -719,7 +719,7 @@ mod tests {
 
         info!("test_real_proof :: AS INSTITUTION VALIDATE PROOF");
         set_institution(None);
-        proof::update_state(proof_req_handle, None, None).unwrap();
+        proof::update_state(proof_req_handle, None,  issuer_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_req_handle).unwrap(), ProofStateType::ProofValidated as u32);
     }
 
@@ -745,13 +745,13 @@ mod tests {
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req1);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req1, Some(&credential_data1));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
 
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req2);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req2, Some(&credential_data2));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
     }
 
@@ -779,13 +779,13 @@ mod tests {
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req1);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req1, Some(&credential_data1));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofInvalid as u32);
 
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req2);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req2, Some(&credential_data2));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
     }
 
@@ -813,13 +813,13 @@ mod tests {
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req1);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req1, Some(&credential_data1));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
 
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req2);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req2, Some(&credential_data2));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofInvalid as u32);
     }
 
@@ -846,13 +846,13 @@ mod tests {
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req1);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req1, Some(&credential_data1));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
 
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req2);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req2, Some(&credential_data2));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
     }
 
@@ -881,13 +881,13 @@ mod tests {
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req1);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req1, Some(&credential_data1));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofInvalid as u32);
 
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req2);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req2, Some(&credential_data2));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
     }
 
@@ -916,13 +916,13 @@ mod tests {
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req1);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req1, Some(&credential_data1));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofValidated as u32);
 
         let proof_handle_verifier = _verifier_create_proof_and_send_request(&institution_did, &schema_id, &cred_def_id, verifier_to_consumer, Some(verifier), req2);
         _prover_select_credentials_and_send_proof(consumer_to_verifier, Some(consumer), req2, Some(&credential_data2));
         set_institution(Some(verifier));
-        proof::update_state(proof_handle_verifier, None, None).unwrap();
+        proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofInvalid as u32);
     }
 }

--- a/wrappers/node/test/suite1/ariesvcx-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-credential.test.ts
@@ -3,12 +3,13 @@ import '../module-resolver-helper';
 import { assert } from 'chai';
 import { validatePaymentTxn } from 'helpers/asserts';
 import {
+  connectionCreateInviterNull,
   createConnectionInviterRequested,
   credentialCreateWithMsgId,
   credentialCreateWithOffer,
   dataCredentialCreateWithMsgId,
   dataCredentialCreateWithOffer,
-} from 'helpers/entities';
+} from 'helpers/entities'
 import { initVcxTestMode, shouldThrow } from 'helpers/utils';
 import {
   Credential,
@@ -89,14 +90,6 @@ describe('Credential:', () => {
   });
 
   describe('updateState:', () => {
-    it(`returns ${StateType.None}: not initialized`, async () => {
-      const credential = new Credential(null as any);
-      const state1 = await credential.updateState();
-      const state2 = await credential.getState();
-      assert.equal(state1, state2);
-      assert.equal(state2, StateType.None);
-    });
-
     it(`returns status requestReceived`, async () => {
       const connection = await createConnectionInviterRequested();
       const data = await dataCredentialCreateWithOffer();
@@ -120,27 +113,6 @@ describe('Credential:', () => {
       const credential = await credentialCreateWithMsgId(data);
       await credential.sendRequest({ connection: data.connection, payment: 0 });
       assert.equal(await credential.getState(), StateType.OfferSent);
-    });
-
-    // todo : restore for aries
-    it.skip('success: get request message', async () => {
-      const data = await dataCredentialCreateWithOffer();
-      const credential = await credentialCreateWithOffer(data);
-      const pwDid = await data.connection.getPwDid();
-      const msg = await credential.getRequestMessage({ myPwDid: pwDid, payment: 0 });
-      assert(msg.length > 0);
-    });
-
-    // todo : restore for aries
-    it.skip('success: issued', async () => {
-      const data = await dataCredentialCreateWithOffer();
-      const credential = await credentialCreateWithOffer(data);
-      await credential.sendRequest({ connection: data.connection, payment: 0 });
-      assert.equal(await credential.getState(), StateType.OfferSent);
-      VCXMock.setVcxMock(VCXMockMessage.CredentialResponse);
-      VCXMock.setVcxMock(VCXMockMessage.UpdateIssuerCredential);
-      await credential.updateState();
-      assert.equal(await credential.getState(), StateType.Accepted);
     });
   });
 
@@ -201,30 +173,6 @@ describe('Credential:', () => {
       const credential = await credentialCreateWithOffer();
       const paymentInfo = await credential.getPaymentInfo();
       assert.ok(paymentInfo);
-    });
-  });
-
-  // todo: ?restore for aries?
-  describe('paymentManager:', () => {
-    it.skip('exists', async () => {
-      const credential = await credentialCreateWithOffer();
-      assert.instanceOf(credential.paymentManager, CredentialPaymentManager);
-      assert.equal(credential.paymentManager.handle, credential.handle);
-    });
-
-    describe('getPaymentTxn:', () => {
-      it.skip('success', async () => {
-        const data = await dataCredentialCreateWithOffer();
-        const credential = await credentialCreateWithOffer(data);
-        await credential.sendRequest({ connection: data.connection, payment: 0 });
-        assert.equal(await credential.getState(), StateType.OfferSent);
-        VCXMock.setVcxMock(VCXMockMessage.CredentialResponse);
-        VCXMock.setVcxMock(VCXMockMessage.UpdateIssuerCredential);
-        await credential.updateState();
-        assert.equal(await credential.getState(), StateType.Accepted);
-        const paymentTxn = await credential.paymentManager.getPaymentTxn();
-        validatePaymentTxn(paymentTxn);
-      });
     });
   });
 

--- a/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
@@ -2,12 +2,13 @@ import '../module-resolver-helper';
 
 import { assert } from 'chai';
 import {
+  connectionCreateInviterNull,
   createConnectionInviterRequested,
   dataDisclosedProofCreateWithMsgId,
   dataDisclosedProofCreateWithRequest,
   disclosedProofCreateWithMsgId,
   disclosedProofCreateWithRequest,
-} from 'helpers/entities';
+} from 'helpers/entities'
 import { initVcxTestMode, shouldThrow } from 'helpers/utils';
 import { mapValues } from 'lodash';
 import { DisclosedProof, StateType, VCXCode } from 'src';
@@ -121,7 +122,8 @@ describe('DisclosedProof', () => {
   describe('updateState:', () => {
     it(`returns ${StateType.None}: not initialized`, async () => {
       const disclosedProof = new (DisclosedProof as any)();
-      const state1 = await disclosedProof.updateState();
+      const connection = await createConnectionInviterRequested();
+      const state1 = await disclosedProof.updateStateV2(connection);
       const state2 = await disclosedProof.getState();
       assert.equal(state1, state2);
       assert.equal(state2, StateType.None);
@@ -129,7 +131,8 @@ describe('DisclosedProof', () => {
 
     it(`returns ${StateType.RequestReceived}: created`, async () => {
       const disclosedProof = await disclosedProofCreateWithRequest();
-      await disclosedProof.updateState();
+      const connection = await createConnectionInviterRequested();
+      await disclosedProof.updateStateV2(connection);
       assert.equal(await disclosedProof.getState(), StateType.RequestReceived);
     });
   });
@@ -155,7 +158,7 @@ describe('DisclosedProof', () => {
         request: JSON.stringify(request),
         sourceId: 'disclosedProofTestSourceId',
       });
-      await disclosedProof.updateState();
+      await disclosedProof.updateStateV2(connection);
       assert.equal(await disclosedProof.getState(), StateType.RequestReceived);
     });
   });

--- a/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
@@ -116,14 +116,6 @@ describe('IssuerCredential:', () => {
   });
 
   describe('updateState:', () => {
-    it(`returns state none`, async () => {
-      const issuerCredential = new IssuerCredential(null as any, {} as any);
-      const state1 = await issuerCredential.updateState();
-      const state2 = await issuerCredential.getState();
-      assert.equal(state1, state2);
-      assert.equal(state2, StateType.None);
-    });
-
     it(`returns state offer sent`, async () => {
       const issuerCredential = await issuerCredentialCreate();
       const connection = await createConnectionInviterRequested();

--- a/wrappers/node/test/suite1/ariesvcx-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-proof.test.ts
@@ -111,15 +111,17 @@ describe('Proof:', () => {
   describe('updateState:', () => {
     it(`returns ${StateType.None}: not initialized`, async () => {
       const proof = new Proof(null as any, {} as any);
-      const state1 = await proof.updateState();
+      const connection = await createConnectionInviterRequested();
+      const state1 = await proof.updateStateV2(connection);
       const state2 = await proof.getState();
       assert.equal(state1, state2);
       assert.equal(state2, StateType.None);
     });
 
     it(`returns ${StateType.Initialized}: created`, async () => {
+      const connection = await createConnectionInviterRequested();
       const proof = await proofCreate();
-      await proof.updateState();
+      await proof.updateStateV2(connection);
       assert.equal(await proof.getState(), StateType.Initialized);
     });
   });


### PR DESCRIPTION
1. Remove support for 
- `vcx_credential_update_state`, `vcx_credential_update_state_with_message`, 
- `vcx_issuer_credential_update_state `, `vcx_issuer_credential_update_state`, 
- `vcx_disclosed_proof_update_state`, `vcx_disclosed_proof_update_state_with_message`, 
- `vcx_proof_update_state`, `vcx_proof_update_state_with_message`,  
Instead you should use `vcx_v2_*` versions of these functions which require connection handle as parameter

2. Refactor aries state machines such that it doesn't store connection handle, but rather getting handle passed down via funcion args.


Signed-off-by: Patrik Stas <patrik.stas@absa.africa>