### PR TITLE
Remove deprecated vcx_get_proof, vcx_get_proof_msg doesn't do proof update

### DIFF
--- a/agents/node/vcxagent-core/demo/faber.js
+++ b/agents/node/vcxagent-core/demo/faber.js
@@ -10,6 +10,7 @@ const bodyParser = require('body-parser')
 const { getFaberProofDataWithNonRevocation } = require('../test/utils/data')
 const { createVcxAgent, initRustapi, getSampleSchemaData, buildRevocationDetails } = require('../src/index')
 const { getAliceSchemaAttrs, getFaberCredDefName } = require('../test/utils/data')
+require('@hyperledger/node-vcx-wrapper')
 
 const tailsFile = '/tmp/tails'
 
@@ -99,12 +100,12 @@ async function runFaber (options) {
     }
 
     logger.info('#27 Process the proof provided by alice.')
-    const { proofState, proof } = await vcxProof.getProof(connectionToAlice)
+    const { proofState, proof } = await vcxProof.getProof()
     assert(proofState)
     assert(proof)
     logger.info(`Proof protocol state = ${JSON.stringify(proofProtocolState)}`)
     logger.info(`Proof verification state =${proofState}`)
-    logger.info(`Proof = ${JSON.stringify(vcxProof)}`)
+    logger.debug(`Proof presentation = ${JSON.stringify(proof, null, 2)}`)
     logger.debug(`Serialized Proof state machine ${JSON.stringify(await vcxProof.serialize())}`)
 
     if (proofState === ProofState.Verified) {

--- a/agents/node/vcxagent-core/package.json
+++ b/agents/node/vcxagent-core/package.json
@@ -66,6 +66,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@hyperledger/node-vcx-wrapper": "^0.11.0"
+    "@hyperledger/node-vcx-wrapper": "^0.15.0"
   }
 }

--- a/agents/node/vcxagent-core/src/services/service-connections.js
+++ b/agents/node/vcxagent-core/src/services/service-connections.js
@@ -181,6 +181,7 @@ module.exports.createServiceConnections = function createServiceConnections ({ l
     verifySignature,
     sendMessage,
     getMessages,
+
     getMessagesV2,
     updateMessagesStatus,
     updateAllReceivedMessages,

--- a/libvcx/src/api/proof.rs
+++ b/libvcx/src/api/proof.rs
@@ -644,35 +644,6 @@ pub extern fn vcx_proof_get_request_msg(command_handle: CommandHandle,
 }
 
 
-/// #Params
-/// command_handle: command handle to map callback to user context.
-///
-/// proof_handle: Proof handle that was provided during creation. Used to identify proof object
-///
-/// connection_handle: Connection handle that identifies pairwise connection
-///
-/// cb: Callback that provides Proof attributes and error status of sending the credential
-///
-/// #Returns
-/// Error code as a u32
-#[deprecated(
-since = "1.15.0",
-note = "Use vcx_get_proof_msg() instead. This api is similar, but requires an extra parameter (connection_handle) which is unnecessary and unused in the internals."
-)]
-#[no_mangle]
-pub extern fn vcx_get_proof(command_handle: CommandHandle,
-                            proof_handle: u32,
-                            _unused_connection_handle: u32,
-                            cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, proof_state: u32, response_data: *const c_char)>) -> u32 {
-    info!("vcx_get_proof >>>");
-
-    check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
-
-    if let Some(err) = proof_to_cb(command_handle, proof_handle, cb).err() { return err.into(); }
-
-    error::SUCCESS.code_num
-}
-
 /// Get Proof Msg
 ///
 /// *Note* This replaces vcx_get_proof. You no longer need a connection handle.
@@ -693,49 +664,34 @@ pub extern fn vcx_get_proof_msg(command_handle: CommandHandle,
 
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
-    if let Some(err) = proof_to_cb(command_handle, proof_handle, cb).err() { return err.into(); }
+    let source_id = proof::get_source_id(proof_handle).unwrap_or_default();
+    trace!("vcx_get_proof_msg(command_handle: {}, proof_handle: {}) source_id: {}",
+           command_handle, proof_handle, source_id);
+
+    if !proof::is_valid_handle(proof_handle) {
+        return VcxError::from(VcxErrorKind::InvalidProofHandle).into();
+    }
+
+    spawn(move || {
+        let source_id = proof::get_source_id(proof_handle).unwrap_or_default();
+
+        match proof::get_proof(proof_handle) {
+            Ok(proof_msg) => {
+                trace!("vcx_get_proof_cb(command_handle: {}, proof_handle: {}, rc: {}, proof: {}) source_id: {}", command_handle, proof_handle, 0, proof_msg, source_id);
+                let msg = CStringUtils::string_to_cstring(proof_msg);
+                cb(command_handle, error::SUCCESS.code_num, proof::get_proof_state(proof_handle).unwrap_or(0), msg.as_ptr());
+            }
+            Err(err) => {
+                warn!("vcx_get_proof_cb(command_handle: {}, proof_handle: {}, rc: {}, proof: {}) source_id: {}", command_handle, proof_handle, err, "null", source_id);
+                cb(command_handle, err.into(), proof::get_proof_state(proof_handle).unwrap_or(0), ptr::null_mut());
+            }
+        };
+        Ok(())
+    });
 
     error::SUCCESS.code_num
 }
 
-fn proof_to_cb(command_handle: CommandHandle,
-               proof_handle: u32,
-               cb: extern fn(xcommand_handle: CommandHandle, err: u32, proof_state: u32, response_data: *const c_char))
-               -> VcxResult<()> {
-    proof_api_input_validation(command_handle, proof_handle)?;
-
-    spawn(move || {
-        let source_id = proof::get_source_id(proof_handle).unwrap_or_default();
-        //update the state to see if proof has come, ignore any errors
-        let _ = proof::update_state(proof_handle, None, None);
-
-        match proof::get_proof(proof_handle) {
-            Ok(x) => {
-                trace!("vcx_get_proof_cb(command_handle: {}, proof_handle: {}, rc: {}, proof: {}) source_id: {}", command_handle, proof_handle, 0, x, source_id);
-                let msg = CStringUtils::string_to_cstring(x);
-                cb(command_handle, error::SUCCESS.code_num, proof::get_proof_state(proof_handle).unwrap_or(0), msg.as_ptr());
-            }
-            Err(x) => {
-                warn!("vcx_get_proof_cb(command_handle: {}, proof_handle: {}, rc: {}, proof: {}) source_id: {}", command_handle, proof_handle, x, "null", source_id);
-                cb(command_handle, x.into(), proof::get_proof_state(proof_handle).unwrap_or(0), ptr::null_mut());
-            }
-        };
-
-        Ok(())
-    });
-
-    Ok(())
-}
-
-fn proof_api_input_validation(command_handle: CommandHandle, proof_handle: u32) -> VcxResult<()> {
-    let source_id = proof::get_source_id(proof_handle).unwrap_or_default();
-    trace!("vcx_get_proof(command_handle: {}, proof_handle: {}) source_id: {}",
-           command_handle, proof_handle, source_id);
-
-    if !proof::is_valid_handle(proof_handle) { Err(VcxError::from(VcxErrorKind::InvalidProofHandle))?; }
-
-    Ok(())
-}
 
 #[allow(unused_variables)]
 pub extern fn vcx_proof_accepted(proof_handle: u32, response_data: *const c_char) -> u32 {
@@ -904,9 +860,8 @@ mod tests {
         let proof_handle = create_proof_util().unwrap();
 
         let cb = return_types_u32::Return_U32_U32_STR::new().unwrap();
-        assert_eq!(vcx_get_proof(cb.command_handle,
+        assert_eq!(vcx_get_proof_msg(cb.command_handle,
                                  proof_handle,
-                                 0,
                                  Some(cb.get_callback())),
                    error::SUCCESS.code_num);
         let _ = cb.receive(TimeoutUtils::some_medium()).is_err();
@@ -920,9 +875,8 @@ mod tests {
         let proof_handle = proof::from_string(mockdata_proof::SERIALIZIED_PROOF_REVOKED).unwrap();
 
         let cb = return_types_u32::Return_U32_U32_STR::new().unwrap();
-        assert_eq!(vcx_get_proof(cb.command_handle,
+        assert_eq!(vcx_get_proof_msg(cb.command_handle,
                                  proof_handle,
-                                 0,
                                  Some(cb.get_callback())),
                    error::SUCCESS.code_num);
         let (state, _) = cb.receive(TimeoutUtils::some_medium()).unwrap();

--- a/wrappers/node/src/api/proof.ts
+++ b/wrappers/node/src/api/proof.ts
@@ -491,14 +491,14 @@ export class Proof extends VCXBaseWithState<IProofData> {
    * assert.equal(proofData.proofState, ProofState.Verified)
    * ```
    */
-  public async getProof(connection: Connection): Promise<IProofResponses> {
+  public async getProof(): Promise<IProofResponses> {
     try {
       const proofRes = await createFFICallbackPromise<{
         proofState: ProofState;
         proofData: string;
       }>(
         (resolve, reject, cb) => {
-          const rc = rustAPI().vcx_get_proof(0, this.handle, connection.handle, cb);
+          const rc = rustAPI().vcx_get_proof_msg(0, this.handle, cb);
           if (rc) {
             reject(rc);
           }

--- a/wrappers/node/src/rustlib.ts
+++ b/wrappers/node/src/rustlib.ts
@@ -340,10 +340,9 @@ export interface IFFIEntryPoint {
     cb: ICbRef,
   ) => number;
   vcx_proof_deserialize: (commandId: number, data: string, cb: ICbRef) => number;
-  vcx_get_proof: (
+  vcx_get_proof_msg: (
     commandId: number,
     proofHandle: number,
-    connectionHandle: number,
     cb: ICbRef,
   ) => number;
   vcx_proof_release: (handle: number) => number;
@@ -872,9 +871,9 @@ export const FFIConfiguration: { [Key in keyof IFFIEntryPoint]: any } = {
     ],
   ],
   vcx_proof_deserialize: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_STRING_DATA, FFI_CALLBACK_PTR]],
-  vcx_get_proof: [
+  vcx_get_proof_msg: [
     FFI_ERROR_CODE,
-    [FFI_COMMAND_HANDLE, FFI_PROOF_HANDLE, FFI_CONNECTION_HANDLE, FFI_CALLBACK_PTR],
+    [FFI_COMMAND_HANDLE, FFI_PROOF_HANDLE, FFI_CALLBACK_PTR],
   ],
   vcx_proof_release: [FFI_ERROR_CODE, [FFI_PROOF_HANDLE]],
   vcx_proof_send_request: [

--- a/wrappers/node/test/suite1/ariesvcx-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-proof.test.ts
@@ -138,39 +138,6 @@ describe('Proof:', () => {
       assert(msg);
     });
 
-    // todo: adjust for aries, need to use aries data mocks
-    it.skip('success -> received', async () => {
-      const connection = await createConnectionInviterRequested();
-      const proof = await proofCreate();
-      await proof.requestProof(connection);
-      assert.equal(await proof.getState(), StateType.OfferSent);
-      VCXMock.setVcxMock(VCXMockMessage.Proof);
-      VCXMock.setVcxMock(VCXMockMessage.UpdateProof);
-      await proof.updateState();
-      assert.equal(await proof.getState(), StateType.Accepted);
-      const proofData = await proof.getProof(connection);
-      assert.ok(proofData);
-      assert.ok(proofData.proof);
-      assert.equal(proofData.proofState, ProofState.Verified);
-      assert.equal(proof.proofState, ProofState.Verified);
-    });
-
-    // todo: adjust for aries, need to use aries data mocks
-    it.skip('success via message-> received', async () => {
-      const connection = await createConnectionInviterRequested();
-      const proof = await proofCreate();
-      const request = await proof.getProofRequestMessage();
-      const disProof = await DisclosedProof.create({ connection, sourceId: 'name', request });
-      const proofMsg = await disProof.getProofMessage();
-      await proof.updateStateWithMessage(proofMsg);
-      assert.equal(await proof.getState(), StateType.Accepted);
-      const proofData = await proof.getProof(connection);
-      assert.ok(proofData);
-      assert.ok(proofData.proof);
-      assert.equal(proofData.proofState, ProofState.Verified);
-      assert.equal(proof.proofState, ProofState.Verified);
-    });
-
     it('throws: not initialized', async () => {
       const connection = await createConnectionInviterRequested();
       const proof = new Proof(null as any, {} as any);


### PR DESCRIPTION
- Remove deprecated `vcx_get_proof`  (use  `vcx_get_proof_msg` )
- Change `vcx_get_proof_msg` behaviour - it should not attempt to perform update on proof state machine
- Removed skipped nodejs unit tests

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>