### PR TITLE
Refactor sending Aries messages

### DIFF
--- a/libvcx/src/aries/handlers/connection/agent_info.rs
+++ b/libvcx/src/aries/handlers/connection/agent_info.rs
@@ -11,7 +11,6 @@ use crate::connection::create_agent_keys;
 use crate::error::prelude::*;
 use crate::libindy::utils::signus::create_and_store_my_did;
 use crate::settings;
-use crate::agency_client::httpclient;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentInfo {
@@ -147,16 +146,6 @@ impl AgentInfo {
 
     fn decrypt_decode_message_noauth(&self, message: &Message) -> VcxResult<A2AMessage> {
         EncryptionEnvelope::anon_unpack(message.payload()?)
-    }
-
-    /**
-    Sends authenticated message to connection counterparty
-     */
-    pub fn send_message(&self, message: &A2AMessage, did_dod: &DidDoc) -> VcxResult<()> {
-        trace!("Agent::send_message >>> message: {:?}, did_doc: {:?}", message, did_dod);
-        let envelope = EncryptionEnvelope::create(&message, Some(&self.pw_vk), &did_dod)?;
-        httpclient::post_message(&envelope.0, &did_dod.get_endpoint())?;
-        Ok(())
     }
 
     /**

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -356,7 +356,7 @@ Get messages received from connection counterparty.
             .ok_or(VcxError::from_msg(VcxErrorKind::NotReady, "Cannot send message: Remote Connection information is not set"))?;
 
         warn!("Connection resolved did_doc = {:?}", did_doc);
-        self.agent_info().send_message(message, &did_doc)
+        did_doc.send_message(message, &self.agent_info().pw_vk)
     }
 
     fn parse_generic_message(message: &str) -> A2AMessage {

--- a/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
@@ -216,7 +216,8 @@ impl SmConnectionInvitee {
                             .set_keys(agent_info.recipient_keys(), agent_info.routing_keys()?);
 
                         trace!("invitation {:?}", state.invitation);
-                        agent_info.send_message(&request.to_a2a_message(), &DidDoc::from(state.invitation.clone()))?;
+                        let ddo = DidDoc::from(state.invitation.clone());
+                        ddo.send_message(&request.to_a2a_message(), &agent_info.pw_vk)?;
                         InviteeState::Requested((state, request).into())
                     }
                     DidExchangeMessages::ProblemReportReceived(problem_report) => {
@@ -239,7 +240,7 @@ impl SmConnectionInvitee {
                                     .set_problem_code(ProblemCode::ResponseProcessingError)
                                     .set_explain(err.to_string())
                                     .set_thread_id(&state.request.id.0);
-                                agent_info.send_message(&problem_report.to_a2a_message(), &state.did_doc).ok();
+                                state.did_doc.send_message(&problem_report.to_a2a_message(), &agent_info.pw_vk).ok();
                                 InviteeState::Null((state, problem_report).into())
                             }
                         }

--- a/libvcx/src/aries/handlers/connection/invitee/states/complete.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/states/complete.rs
@@ -59,7 +59,7 @@ impl CompleteState {
                 .request_response()
                 .set_comment(comment);
 
-        agent_info.send_message(&ping.to_a2a_message(), &self.did_doc).ok();
+        self.did_doc.send_message(&ping.to_a2a_message(), &agent_info.pw_vk).ok();
         Ok(())
     }
 
@@ -72,8 +72,7 @@ impl CompleteState {
             Query::create()
                 .set_query(query)
                 .set_comment(comment);
-
-        agent_info.send_message(&query_.to_a2a_message(), &self.did_doc)
+        self.did_doc.send_message(&query_.to_a2a_message(), &agent_info.pw_vk)
     }
 
     fn handle_discovery_query(&self, query: Query, agent_info: &AgentInfo) -> VcxResult<()> {
@@ -83,6 +82,6 @@ impl CompleteState {
             .set_protocols(protocols)
             .set_thread_id(query.id.0.clone());
 
-        agent_info.send_message(&disclose.to_a2a_message(), &self.did_doc)
+        self.did_doc.send_message(&disclose.to_a2a_message(), &agent_info.pw_vk)
     }
 }

--- a/libvcx/src/aries/handlers/connection/invitee/states/requested.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/states/requested.rs
@@ -53,7 +53,7 @@ impl RequestedState {
                 .to_a2a_message()
         };
 
-        agent_info.send_message(&message, &response.connection.did_doc)?;
+        response.connection.did_doc.send_message(&message, &agent_info.pw_vk)?;
 
         Ok(response)
     }

--- a/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
@@ -261,7 +261,7 @@ impl SmConnectionInviter {
                                     .set_explain(err.to_string())
                                     .set_thread_id(&request.id.0);
 
-                                agent_info.send_message(&problem_report.to_a2a_message(), &request.connection.did_doc).ok(); // IS is possible?
+                                request.connection.did_doc.send_message(&problem_report.to_a2a_message(), &agent_info.pw_vk).ok();
                                 InviterState::Null((state, problem_report).into())
                             }
                         }
@@ -292,7 +292,7 @@ impl SmConnectionInviter {
                                 .request_response()
                                 .set_comment(comment);
 
-                        agent_info.send_message(&ping.to_a2a_message(), &state.did_doc).ok();
+                        state.did_doc.send_message(&ping.to_a2a_message(), &agent_info.pw_vk).ok();
                         InviterState::Responded(state)
                     }
                     DidExchangeMessages::PingResponseReceived(ping_response) => {

--- a/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
@@ -59,7 +59,7 @@ impl CompleteState {
                 .request_response()
                 .set_comment(comment);
 
-        agent_info.send_message(&ping.to_a2a_message(), &self.did_doc).ok();
+        self.did_doc.send_message(&ping.to_a2a_message(), &agent_info.pw_vk).ok();
         Ok(())
     }
 
@@ -73,7 +73,7 @@ impl CompleteState {
                 .set_query(query)
                 .set_comment(comment);
 
-        agent_info.send_message(&query_.to_a2a_message(), &self.did_doc)
+        self.did_doc.send_message(&query_.to_a2a_message(), &agent_info.pw_vk)
     }
 
     fn handle_discovery_query(&self, query: Query, agent_info: &AgentInfo) -> VcxResult<()> {
@@ -83,6 +83,6 @@ impl CompleteState {
             .set_protocols(protocols)
             .set_thread_id(query.id.0.clone());
 
-        agent_info.send_message(&disclose.to_a2a_message(), &self.did_doc)
+        self.did_doc.send_message(&disclose.to_a2a_message(), &agent_info.pw_vk)
     }
 }

--- a/libvcx/src/aries/handlers/connection/inviter/states/invited.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/states/invited.rs
@@ -48,7 +48,8 @@ impl InvitedState {
             .set_thread_id(&request.id.0)
             .encode(&prev_agent_info.pw_vk)?;
 
-        new_agent_info.send_message(&signed_response.to_a2a_message(), &request.connection.did_doc)?;
+
+        request.connection.did_doc.send_message(&signed_response.to_a2a_message(), &new_agent_info.pw_vk)?;
 
         Ok((signed_response, new_agent_info))
     }

--- a/libvcx/src/aries/handlers/connection/util.rs
+++ b/libvcx/src/aries/handlers/connection/util.rs
@@ -8,7 +8,8 @@ pub fn handle_ping(ping: &Ping, agent_info: &AgentInfo, did_doc: &DidDoc) -> Vcx
     if ping.response_requested {
         let ping_response = PingResponse::create().set_thread_id(
             &ping.thread.as_ref().and_then(|thread| thread.thid.clone()).unwrap_or(ping.id.0.clone()));
-        agent_info.send_message(&ping_response.to_a2a_message(), did_doc)?;
+
+        did_doc.send_message(&ping_response.to_a2a_message(), &agent_info.pw_vk)?;
     }
     Ok(())
 }


### PR DESCRIPTION
- Remove logic around sending Aries message from `AgentInfo`. Instead move this logic as part of  `DidDoc` implementation. 
- Don't use `httpclient` of agency to send Aries messages. This causes some duplication, but otherwise causes dependency of DDO on Agency which is odd. We could later perhaps have some shared "commons" crate. 

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>