### PR TITLE
Refactor/sending messages

### DIFF
--- a/libvcx/src/aries/handlers/connection/agent_info.rs
+++ b/libvcx/src/aries/handlers/connection/agent_info.rs
@@ -11,7 +11,6 @@ use crate::connection::create_agent_keys;
 use crate::error::prelude::*;
 use crate::libindy::utils::signus::create_and_store_my_did;
 use crate::settings;
-use crate::agency_client::httpclient;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentInfo {
@@ -147,16 +146,6 @@ impl AgentInfo {
 
     fn decrypt_decode_message_noauth(&self, message: &Message) -> VcxResult<A2AMessage> {
         EncryptionEnvelope::anon_unpack(message.payload()?)
-    }
-
-    /**
-    Sends authenticated message to connection counterparty
-     */
-    pub fn send_message(&self, message: &A2AMessage, did_dod: &DidDoc) -> VcxResult<()> {
-        trace!("Agent::send_message >>> message: {:?}, did_doc: {:?}", message, did_dod);
-        let envelope = EncryptionEnvelope::create(&message, Some(&self.pw_vk), &did_dod)?;
-        httpclient::post_message(&envelope.0, &did_dod.get_endpoint())?;
-        Ok(())
     }
 
     /**

--- a/libvcx/src/aries/handlers/connection/agent_info.rs
+++ b/libvcx/src/aries/handlers/connection/agent_info.rs
@@ -160,16 +160,6 @@ impl AgentInfo {
     }
 
     /**
-    Sends anonymous message to connection counterparty
-     */
-    pub fn send_message_anonymously(message: &A2AMessage, did_dod: &DidDoc) -> VcxResult<()> {
-        trace!("Agent::send_message_anonymously >>> message: {:?}, did_doc: {:?}", message, did_dod);
-        let envelope = EncryptionEnvelope::create(&message, None, &did_dod)?;
-        httpclient::post_message(&envelope.0, &did_dod.get_endpoint())?;
-        Ok(())
-    }
-
-    /**
     Sends message to one's agency signalling resources related to this connection agent can be deleted.
      */
     pub fn delete(&self) -> VcxResult<()> {

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -356,7 +356,7 @@ Get messages received from connection counterparty.
             .ok_or(VcxError::from_msg(VcxErrorKind::NotReady, "Cannot send message: Remote Connection information is not set"))?;
 
         warn!("Connection resolved did_doc = {:?}", did_doc);
-        self.agent_info().send_message(message, &did_doc)
+        did_doc.send_message(message, &self.agent_info().pw_vk)
     }
 
     fn parse_generic_message(message: &str) -> A2AMessage {

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -359,12 +359,6 @@ Get messages received from connection counterparty.
         self.agent_info().send_message(message, &did_doc)
     }
 
-    pub fn send_message_to_self_endpoint(message: &A2AMessage, did_doc: &DidDoc) -> VcxResult<()> {
-        trace!("Connection::send_message_to_self_endpoint >>> message: {:?}, did_doc: {:?}", message, did_doc);
-
-        AgentInfo::send_message_anonymously(message, did_doc)
-    }
-
     fn parse_generic_message(message: &str) -> A2AMessage {
         match ::serde_json::from_str::<A2AMessage>(message) {
             Ok(a2a_message) => a2a_message,

--- a/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
@@ -216,7 +216,8 @@ impl SmConnectionInvitee {
                             .set_keys(agent_info.recipient_keys(), agent_info.routing_keys()?);
 
                         trace!("invitation {:?}", state.invitation);
-                        agent_info.send_message(&request.to_a2a_message(), &DidDoc::from(state.invitation.clone()))?;
+                        let ddo = DidDoc::from(state.invitation.clone());
+                        ddo.send_message(&request.to_a2a_message(), &agent_info.pw_vk)?;
                         InviteeState::Requested((state, request).into())
                     }
                     DidExchangeMessages::ProblemReportReceived(problem_report) => {
@@ -239,7 +240,7 @@ impl SmConnectionInvitee {
                                     .set_problem_code(ProblemCode::ResponseProcessingError)
                                     .set_explain(err.to_string())
                                     .set_thread_id(&state.request.id.0);
-                                agent_info.send_message(&problem_report.to_a2a_message(), &state.did_doc).ok();
+                                state.did_doc.send_message(&problem_report.to_a2a_message(), &agent_info.pw_vk).ok();
                                 InviteeState::Null((state, problem_report).into())
                             }
                         }

--- a/libvcx/src/aries/handlers/connection/invitee/states/complete.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/states/complete.rs
@@ -59,7 +59,7 @@ impl CompleteState {
                 .request_response()
                 .set_comment(comment);
 
-        agent_info.send_message(&ping.to_a2a_message(), &self.did_doc).ok();
+        self.did_doc.send_message(&ping.to_a2a_message(), &agent_info.pw_vk).ok();
         Ok(())
     }
 
@@ -72,8 +72,7 @@ impl CompleteState {
             Query::create()
                 .set_query(query)
                 .set_comment(comment);
-
-        agent_info.send_message(&query_.to_a2a_message(), &self.did_doc)
+        self.did_doc.send_message(&query_.to_a2a_message(), &agent_info.pw_vk)
     }
 
     fn handle_discovery_query(&self, query: Query, agent_info: &AgentInfo) -> VcxResult<()> {
@@ -83,6 +82,6 @@ impl CompleteState {
             .set_protocols(protocols)
             .set_thread_id(query.id.0.clone());
 
-        agent_info.send_message(&disclose.to_a2a_message(), &self.did_doc)
+        self.did_doc.send_message(&disclose.to_a2a_message(), &agent_info.pw_vk)
     }
 }

--- a/libvcx/src/aries/handlers/connection/invitee/states/requested.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/states/requested.rs
@@ -53,7 +53,7 @@ impl RequestedState {
                 .to_a2a_message()
         };
 
-        agent_info.send_message(&message, &response.connection.did_doc)?;
+        response.connection.did_doc.send_message(&message, &agent_info.pw_vk)?;
 
         Ok(response)
     }

--- a/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
@@ -261,7 +261,7 @@ impl SmConnectionInviter {
                                     .set_explain(err.to_string())
                                     .set_thread_id(&request.id.0);
 
-                                agent_info.send_message(&problem_report.to_a2a_message(), &request.connection.did_doc).ok(); // IS is possible?
+                                request.connection.did_doc.send_message(&problem_report.to_a2a_message(), &agent_info.pw_vk).ok();
                                 InviterState::Null((state, problem_report).into())
                             }
                         }
@@ -292,7 +292,7 @@ impl SmConnectionInviter {
                                 .request_response()
                                 .set_comment(comment);
 
-                        agent_info.send_message(&ping.to_a2a_message(), &state.did_doc).ok();
+                        state.did_doc.send_message(&ping.to_a2a_message(), &agent_info.pw_vk).ok();
                         InviterState::Responded(state)
                     }
                     DidExchangeMessages::PingResponseReceived(ping_response) => {

--- a/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
@@ -59,7 +59,7 @@ impl CompleteState {
                 .request_response()
                 .set_comment(comment);
 
-        agent_info.send_message(&ping.to_a2a_message(), &self.did_doc).ok();
+        self.did_doc.send_message(&ping.to_a2a_message(), &agent_info.pw_vk).ok();
         Ok(())
     }
 
@@ -73,7 +73,7 @@ impl CompleteState {
                 .set_query(query)
                 .set_comment(comment);
 
-        agent_info.send_message(&query_.to_a2a_message(), &self.did_doc)
+        self.did_doc.send_message(&query_.to_a2a_message(), &agent_info.pw_vk)
     }
 
     fn handle_discovery_query(&self, query: Query, agent_info: &AgentInfo) -> VcxResult<()> {
@@ -83,6 +83,6 @@ impl CompleteState {
             .set_protocols(protocols)
             .set_thread_id(query.id.0.clone());
 
-        agent_info.send_message(&disclose.to_a2a_message(), &self.did_doc)
+        self.did_doc.send_message(&disclose.to_a2a_message(), &agent_info.pw_vk)
     }
 }

--- a/libvcx/src/aries/handlers/connection/inviter/states/invited.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/states/invited.rs
@@ -48,7 +48,8 @@ impl InvitedState {
             .set_thread_id(&request.id.0)
             .encode(&prev_agent_info.pw_vk)?;
 
-        new_agent_info.send_message(&signed_response.to_a2a_message(), &request.connection.did_doc)?;
+
+        request.connection.did_doc.send_message(&signed_response.to_a2a_message(), &new_agent_info.pw_vk)?;
 
         Ok((signed_response, new_agent_info))
     }

--- a/libvcx/src/aries/handlers/connection/util.rs
+++ b/libvcx/src/aries/handlers/connection/util.rs
@@ -8,7 +8,8 @@ pub fn handle_ping(ping: &Ping, agent_info: &AgentInfo, did_doc: &DidDoc) -> Vcx
     if ping.response_requested {
         let ping_response = PingResponse::create().set_thread_id(
             &ping.thread.as_ref().and_then(|thread| thread.thid.clone()).unwrap_or(ping.id.0.clone()));
-        agent_info.send_message(&ping_response.to_a2a_message(), did_doc)?;
+
+        did_doc.send_message(&ping_response.to_a2a_message(), &agent_info.pw_vk)?;
     }
     Ok(())
 }

--- a/libvcx/src/aries/handlers/issuance/holder/holder.rs
+++ b/libvcx/src/aries/handlers/issuance/holder/holder.rs
@@ -77,31 +77,4 @@ impl Holder {
         self.holder_sm = self.holder_sm.clone().handle_message(message, connection_handle)?;
         Ok(())
     }
-
-    pub fn get_credential_offer_message(connection_handle: u32, msg_id: &str) -> VcxResult<A2AMessage> {
-        match connection::get_message_by_id(connection_handle, msg_id.to_string()) {
-            Ok(message) => match message {
-                A2AMessage::CredentialOffer(_) => Ok(message),
-                msg => {
-                    return Err(VcxError::from_msg(VcxErrorKind::InvalidMessages,
-                                                  format!("Message of different type was received: {:?}", msg)));
-                }
-            }
-            Err(err) => Err(err)
-        }
-    }
-
-    pub fn get_credential_offer_messages(conn_handle: u32) -> VcxResult<Vec<A2AMessage>> {
-        let messages = connection::get_messages(conn_handle)?;
-        let msgs: Vec<A2AMessage> = messages
-            .into_iter()
-            .filter_map(|(_, a2a_message)| {
-                match a2a_message {
-                    A2AMessage::CredentialOffer(_) => Some(a2a_message),
-                    _ => None
-                }
-            })
-            .collect();
-        Ok(msgs)
-    }
 }

--- a/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
@@ -81,22 +81,6 @@ impl Prover {
         self.step(message, connection_handle)
     }
 
-    pub fn get_presentation_request(connection_handle: u32, msg_id: &str) -> VcxResult<PresentationRequest> {
-        trace!("Prover::get_presentation_request >>> connection_handle: {:?}, msg_id: {:?}", connection_handle, msg_id);
-
-        let message = connection::get_message_by_id(connection_handle, msg_id.to_string())?;
-
-        let presentation_request: PresentationRequest = match message {
-            A2AMessage::PresentationRequest(presentation_request) => presentation_request,
-            msg => {
-                return Err(VcxError::from_msg(VcxErrorKind::InvalidMessages,
-                                              format!("Message of different type was received: {:?}", msg)));
-            }
-        };
-
-        Ok(presentation_request)
-    }
-
     pub fn get_presentation_request_messages(connection_handle: u32) -> VcxResult<Vec<A2AMessage>> {
         trace!("Prover::get_presentation_request_messages >>> connection_handle: {:?}", connection_handle);
 

--- a/libvcx/src/aries/handlers/proof_presentation/prover/state_machine.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/state_machine.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
 
 use crate::api::VcxStateType;
-use crate::connection;
-use crate::error::prelude::*;
 use crate::aries::handlers::proof_presentation::prover::messages::ProverMessages;
+use crate::aries::handlers::proof_presentation::prover::states::finished::FinishedState;
+use crate::aries::handlers::proof_presentation::prover::states::initial::InitialState;
+use crate::aries::handlers::proof_presentation::prover::states::presentation_prepared::PresentationPreparedState;
+use crate::aries::handlers::proof_presentation::prover::states::presentation_prepared_failed::PresentationPreparationFailedState;
+use crate::aries::handlers::proof_presentation::prover::states::presentation_sent::PresentationSentState;
 use crate::aries::messages::a2a::A2AMessage;
 use crate::aries::messages::error::ProblemReport;
 use crate::aries::messages::proof_presentation::presentation::Presentation;
 use crate::aries::messages::proof_presentation::presentation_proposal::{PresentationPreview, PresentationProposal};
 use crate::aries::messages::proof_presentation::presentation_request::PresentationRequest;
 use crate::aries::messages::status::Status;
-use crate::aries::handlers::proof_presentation::prover::states::initial::InitialState;
-use crate::aries::handlers::proof_presentation::prover::states::presentation_prepared::PresentationPreparedState;
-use crate::aries::handlers::proof_presentation::prover::states::presentation_prepared_failed::PresentationPreparationFailedState;
-use crate::aries::handlers::proof_presentation::prover::states::presentation_sent::PresentationSentState;
-use crate::aries::handlers::proof_presentation::prover::states::finished::FinishedState;
+use crate::connection;
+use crate::error::prelude::*;
 
 /// A state machine that tracks the evolution of states for a Prover during
 /// the Present Proof protocol.
@@ -142,18 +142,10 @@ impl ProverSM {
             ProverState::PresentationPrepared(state) => {
                 match message {
                     ProverMessages::SendPresentation => {
-                        match state.presentation_request.service.clone() {
-                            None => {
-                                let connection_handle = connection_handle
-                                    .ok_or(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Presentation is already sent"))?;
-                                connection::send_message(connection_handle, state.presentation.to_a2a_message())?;
-                                ProverState::PresentationSent((state).into())
-                            }
-                            Some(service) => {
-                                connection::send_message_to_self_endpoint(state.presentation.to_a2a_message(), &service.into())?;
-                                ProverState::Finished(state.into())
-                            }
-                        }
+                        let connection_handle = connection_handle
+                            .ok_or(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Presentation is already sent"))?;
+                        connection::send_message(connection_handle, state.presentation.to_a2a_message())?;
+                        ProverState::PresentationSent((state).into())
                     }
                     ProverMessages::RejectPresentationRequest((reason)) => {
                         let connection_handle = connection_handle
@@ -175,17 +167,9 @@ impl ProverSM {
             ProverState::PresentationPreparationFailed(state) => {
                 match message {
                     ProverMessages::SendPresentation => {
-                        match state.presentation_request.service.clone() {
-                            None => {
-                                let connection_handle = connection_handle
-                                    .ok_or(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Presentation is already sent"))?;
-                                connection::send_message(connection_handle, state.problem_report.to_a2a_message())?;
-                            }
-                            Some(service) => {
-                                connection::send_message_to_self_endpoint(state.problem_report.to_a2a_message(), &service.into())?;
-                            }
-                        }
-
+                        let connection_handle = connection_handle
+                        .ok_or(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Presentation is already sent")) ?;
+                        connection::send_message(connection_handle, state.problem_report.to_a2a_message()) ?;
                         ProverState::Finished((state).into())
                     }
                     _ => {
@@ -220,11 +204,7 @@ impl ProverSM {
             .set_comment(reason.to_string())
             .set_thread_id(thread_id);
 
-        match presentation_request.service.clone() {
-            None => connection::send_message(connection_handle, problem_report.to_a2a_message())?,
-            Some(service) => connection::send_message_to_self_endpoint(problem_report.to_a2a_message(), &service.into())?
-        }
-
+        connection::send_message(connection_handle, problem_report.to_a2a_message())?;
         Ok(())
     }
 
@@ -233,10 +213,7 @@ impl ProverSM {
             .set_presentation_preview(preview)
             .set_thread_id(thread_id);
 
-        match presentation_request.service.clone() {
-            None => connection::send_message(connection_handle, proposal.to_a2a_message())?,
-            Some(service) => connection::send_message_to_self_endpoint(proposal.to_a2a_message(), &service.into())?
-        }
+        connection::send_message(connection_handle, proposal.to_a2a_message())?;
 
         Ok(())
     }
@@ -299,13 +276,13 @@ impl ProverSM {
 
 #[cfg(test)]
 pub mod test {
-    use crate::utils::devsetup::SetupMocks;
     use crate::aries::handlers::connection::tests::mock_connection;
     use crate::aries::messages::proof_presentation::presentation::tests::_presentation;
     use crate::aries::messages::proof_presentation::presentation_proposal::tests::{_presentation_preview, _presentation_proposal};
-    use crate::aries::messages::proof_presentation::presentation_request::tests::{_presentation_request, _presentation_request_with_service};
+    use crate::aries::messages::proof_presentation::presentation_request::tests::{_presentation_request};
     use crate::aries::messages::proof_presentation::test::{_ack, _problem_report};
     use crate::aries::test::source_id;
+    use crate::utils::devsetup::SetupMocks;
 
     use super::*;
 
@@ -372,9 +349,10 @@ pub mod test {
     }
 
     mod step {
-        use super::*;
         use crate::utils::constants::CREDS_FROM_PROOF_REQ;
         use crate::utils::mockdata::mock_settings::MockBuilder;
+
+        use super::*;
 
         #[test]
         #[cfg(feature = "general_test")]
@@ -462,20 +440,6 @@ pub mod test {
             prover_sm = prover_sm.step(ProverMessages::SendPresentation, connection_handle).unwrap();
 
             assert_match!(ProverState::PresentationSent(_), prover_sm.state);
-        }
-
-        #[test]
-        #[cfg(feature = "general_test")]
-        fn test_prover_handle_send_presentation_message_from_presentation_prepared_state_for_presentation_request_contains_service_decorator() {
-            let _setup = SetupMocks::init();
-
-            let connection_handle = Some(mock_connection());
-            let mut prover_sm = ProverSM::new(_presentation_request_with_service(), source_id());
-
-            prover_sm = prover_sm.step(ProverMessages::PreparePresentation((_credentials(), _self_attested())), connection_handle).unwrap();
-            prover_sm = prover_sm.step(ProverMessages::SendPresentation, connection_handle).unwrap();
-
-            assert_match!(ProverState::Finished(_), prover_sm.state);
         }
 
         #[test]

--- a/libvcx/src/aries/handlers/proof_presentation/prover/state_machine.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/state_machine.rs
@@ -168,8 +168,8 @@ impl ProverSM {
                 match message {
                     ProverMessages::SendPresentation => {
                         let connection_handle = connection_handle
-                        .ok_or(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Presentation is already sent")) ?;
-                        connection::send_message(connection_handle, state.problem_report.to_a2a_message()) ?;
+                            .ok_or(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Presentation is already sent"))?;
+                        connection::send_message(connection_handle, state.problem_report.to_a2a_message())?;
                         ProverState::Finished((state).into())
                     }
                     _ => {
@@ -279,7 +279,7 @@ pub mod test {
     use crate::aries::handlers::connection::tests::mock_connection;
     use crate::aries::messages::proof_presentation::presentation::tests::_presentation;
     use crate::aries::messages::proof_presentation::presentation_proposal::tests::{_presentation_preview, _presentation_proposal};
-    use crate::aries::messages::proof_presentation::presentation_request::tests::{_presentation_request};
+    use crate::aries::messages::proof_presentation::presentation_request::tests::_presentation_request;
     use crate::aries::messages::proof_presentation::test::{_ack, _problem_report};
     use crate::aries::test::source_id;
     use crate::utils::devsetup::SetupMocks;

--- a/libvcx/src/aries/messages/proof_presentation/presentation_request.rs
+++ b/libvcx/src/aries/messages/proof_presentation/presentation_request.rs
@@ -12,9 +12,6 @@ pub struct PresentationRequest {
     pub comment: Option<String>,
     #[serde(rename = "request_presentations~attach")]
     pub request_presentations_attach: Attachments,
-    #[serde(rename = "~service")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub service: Option<Service>
 }
 
 impl PresentationRequest {
@@ -37,10 +34,6 @@ impl PresentationRequest {
         Ok(self)
     }
 
-    pub fn set_service(mut self, service: Option<Service>) -> Self {
-        self.service = service;
-        self
-    }
     pub fn to_json(&self) -> VcxResult<String> {
         serde_json::to_string(self)
             .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot serialize PresentationRequest: {}", err)))
@@ -87,16 +80,6 @@ pub mod tests {
             id: MessageId::id(),
             comment: Some(_comment()),
             request_presentations_attach: _attachment(),
-            service: None,
-        }
-    }
-
-    pub fn _presentation_request_with_service() -> PresentationRequest {
-        PresentationRequest {
-            id: MessageId::id(),
-            comment: Some(_comment()),
-            request_presentations_attach: _attachment(),
-            service: Some(_service()),
         }
     }
 
@@ -108,16 +91,5 @@ pub mod tests {
             .set_request_presentations_attach(&_presentation_request_data()).unwrap();
 
         assert_eq!(_presentation_request(), presentation_request);
-    }
-
-    #[test]
-    #[cfg(feature = "general_test")]
-    fn test_presentation_request_build_works_for_service() {
-        let presentation_request: PresentationRequest = PresentationRequest::default()
-            .set_comment(_comment())
-            .set_service(Some(_service()))
-            .set_request_presentations_attach(&_presentation_request_data()).unwrap();
-
-        assert_eq!(_presentation_request_with_service(), presentation_request);
     }
 }

--- a/libvcx/src/connection.rs
+++ b/libvcx/src/connection.rs
@@ -264,10 +264,6 @@ pub fn send_message(handle: u32, message: A2AMessage) -> VcxResult<()> {
     })
 }
 
-pub fn send_message_to_self_endpoint(message: A2AMessage, did_doc: &DidDoc) -> VcxResult<()> {
-    Connection::send_message_to_self_endpoint(&message, did_doc)
-}
-
 pub fn is_v3_connection(connection_handle: u32) -> VcxResult<bool> {
     CONNECTION_MAP.get(connection_handle, |_| {
         Ok(true)

--- a/libvcx/src/credential.rs
+++ b/libvcx/src/credential.rs
@@ -199,7 +199,16 @@ fn get_credential_offer_msg(connection_handle: u32, msg_id: &str) -> VcxResult<S
         AgencyMockDecrypted::set_next_decrypted_response(GET_MESSAGES_DECRYPTED_RESPONSE);
         AgencyMockDecrypted::set_next_decrypted_message(ARIES_CREDENTIAL_OFFER);
     }
-    let credential_offer = Holder::get_credential_offer_message(connection_handle, msg_id)?;
+    let credential_offer = match connection::get_message_by_id(connection_handle, msg_id.to_string()) {
+        Ok(message) => match message {
+            A2AMessage::CredentialOffer(_) => Ok(message),
+            msg => {
+                return Err(VcxError::from_msg(VcxErrorKind::InvalidMessages,
+                                              format!("Message of different type was received: {:?}", msg)));
+            }
+        }
+        Err(err) => Err(err)
+    }?;
 
     return serde_json::to_string(&credential_offer).
         map_err(|err| {
@@ -213,7 +222,15 @@ pub fn get_credential_offer_messages(connection_handle: u32) -> VcxResult<String
     AgencyMockDecrypted::set_next_decrypted_response(GET_MESSAGES_DECRYPTED_RESPONSE);
     AgencyMockDecrypted::set_next_decrypted_message(ARIES_CREDENTIAL_OFFER);
 
-    let credential_offers = Holder::get_credential_offer_messages(connection_handle)?;
+    let credential_offers: Vec<A2AMessage> = connection::get_messages(connection_handle)?
+        .into_iter()
+        .filter_map(|(_, a2a_message)| {
+            match a2a_message {
+                A2AMessage::CredentialOffer(_) => Some(a2a_message),
+                _ => None
+            }
+        })
+        .collect();
 
     Ok(json!(credential_offers).to_string())
 }

--- a/libvcx/src/disclosed_proof.rs
+++ b/libvcx/src/disclosed_proof.rs
@@ -13,6 +13,7 @@ use crate::utils::constants::GET_MESSAGES_DECRYPTED_RESPONSE;
 use crate::utils::error;
 use crate::utils::mockdata::mockdata_proof::ARIES_PROOF_REQUEST_PRESENTATION;
 use crate::utils::object_cache::ObjectCache;
+use crate::aries::messages::a2a::A2AMessage;
 
 lazy_static! {
     static ref HANDLE_MAP: ObjectCache<Prover> = ObjectCache::<Prover>::new("disclosed-proofs-cache");
@@ -198,7 +199,19 @@ fn get_proof_request(connection_handle: u32, msg_id: &str) -> VcxResult<String> 
         AgencyMockDecrypted::set_next_decrypted_message(ARIES_PROOF_REQUEST_PRESENTATION);
     }
 
-    let presentation_request = Prover::get_presentation_request(connection_handle, msg_id)?;
+    let presentation_request =  {
+        trace!("Prover::get_presentation_request >>> connection_handle: {:?}, msg_id: {:?}", connection_handle, msg_id);
+
+        let message = connection::get_message_by_id(connection_handle, msg_id.to_string())?;
+
+        match message {
+            A2AMessage::PresentationRequest(presentation_request) => presentation_request,
+            msg => {
+                return Err(VcxError::from_msg(VcxErrorKind::InvalidMessages,
+                                              format!("Message of different type was received: {:?}", msg)));
+            }
+        }
+    };
     serde_json::to_string_pretty(&presentation_request)
         .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot serialize message: {}", err)))
 }


### PR DESCRIPTION
Recreated PR https://github.com/hyperledger/aries-vcx/pull/250 so we can rather merge it into master for sake of release changelog clarity.

- Remove logic around sending Aries message from `AgentInfo`. Instead move this logic as part of  `DidDoc` implementation. 
- Don't use `httpclient` of agency to send Aries messages. This causes some duplication, but otherwise causes dependency of DDO on Agency which is odd. We could later perhaps have some shared "commons" crate. 

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>