### PR TITLE
Prover SM sends Aries messages through a closure

### DIFF
--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -359,7 +359,6 @@ Get messages received from connection counterparty.
             .ok_or(VcxError::from_msg(VcxErrorKind::NotReady, "Cannot send message: Remote Connection information is not set"))?;
         let sender_vk = self.agent_info().pw_vk.clone();
         return Ok(move |a2a_message: &A2AMessage| {
-            warn!("Connection resolved did_doc = {:?}", did_doc);
             did_doc.send_message(a2a_message, &sender_vk)
         })
     }

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -346,14 +346,6 @@ Get messages received from connection counterparty.
         self.agent_info().get_message_by_id(msg_id, &expected_sender_vk)
     }
 
-    /**
-    Sends authenticated message to connection counterparty
-     */
-    pub fn send_message(&self, message: &A2AMessage) -> VcxResult<()> {
-        let send_message = self.send_message_closure()?;
-        send_message(message)
-    }
-
     pub fn send_message_closure(&self) -> VcxResult<impl Fn(&A2AMessage) -> VcxResult<()>> {
         let did_doc = self.their_did_doc()
             .ok_or(VcxError::from_msg(VcxErrorKind::NotReady, "Cannot send message: Remote Connection information is not set"))?;
@@ -379,7 +371,8 @@ Get messages received from connection counterparty.
         trace!("Connection::send_generic_message >>> message: {:?}", message);
 
         let message = Connection::parse_generic_message(message);
-        self.send_message(&message).map(|_| String::new())
+        let send_message = self.send_message_closure()?;
+        send_message(&message).map(|_| String::new())
     }
 
     pub fn send_ping(&mut self, comment: Option<String>) -> VcxResult<()> {

--- a/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
@@ -67,17 +67,6 @@ impl Prover {
         self.prover_sm.find_message_to_handle(messages)
     }
 
-    pub fn update_state_with_message(&mut self, message: &str, connection_handle: u32) -> VcxResult<u32> {
-        trace!("Prover::update_state_with_message >>> message: {:?}", message);
-
-        let a2a_message: A2AMessage = serde_json::from_str(&message)
-            .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidOption, format!("Cannot updated state with message: Message deserialization failed: {:?}", err)))?;
-
-        let send_message = connection::send_message_closure(connection_handle)?;
-        self.handle_message(a2a_message.into(), Some(&send_message))?;
-
-        Ok(self.state())
-    }
 
     pub fn handle_message(&mut self, message: ProverMessages, send_message: Option<&impl Fn(&A2AMessage) -> VcxResult<()>>) -> VcxResult<()> {
         trace!("Prover::handle_message >>> message: {:?}", message);

--- a/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
@@ -37,8 +37,9 @@ impl Prover {
     }
 
     pub fn generate_presentation(&mut self, credentials: String, self_attested_attrs: String) -> VcxResult<()> {
+        let closure = move |a2a_message: &A2AMessage| { panic!("This should not be called") };
         trace!("Prover::generate_presentation >>> credentials: {}, self_attested_attrs: {:?}", credentials, self_attested_attrs);
-        self.step(ProverMessages::PreparePresentation((credentials, self_attested_attrs)), None)
+        self.step(ProverMessages::PreparePresentation((credentials, self_attested_attrs)), Some(&closure))
     }
 
     pub fn generate_presentation_msg(&self) -> VcxResult<String> {
@@ -49,12 +50,13 @@ impl Prover {
 
     pub fn set_presentation(&mut self, presentation: Presentation) -> VcxResult<()> {
         trace!("Prover::set_presentation >>>");
-        self.step(ProverMessages::SetPresentation(presentation), None)
+        let closure = move |a2a_message: &A2AMessage| { panic!("This should not be called") };
+        self.step(ProverMessages::SetPresentation(presentation), Some(&closure))
     }
 
-    pub fn send_presentation(&mut self, connection_handle: u32) -> VcxResult<()> {
+    pub fn send_presentation(&mut self, send_message: &impl Fn(&A2AMessage) -> VcxResult<()>) -> VcxResult<()> {
         trace!("Prover::send_presentation >>>");
-        self.step(ProverMessages::SendPresentation, Some(connection_handle))
+        self.step(ProverMessages::SendPresentation, Some(&send_message))
     }
 
     pub fn has_transitions(&self) -> bool {
@@ -71,31 +73,15 @@ impl Prover {
         let a2a_message: A2AMessage = serde_json::from_str(&message)
             .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidOption, format!("Cannot updated state with message: Message deserialization failed: {:?}", err)))?;
 
-        self.handle_message(a2a_message.into(), Some(connection_handle))?;
+        let send_message = connection::send_message_closure(connection_handle)?;
+        self.handle_message(a2a_message.into(), Some(&send_message))?;
 
         Ok(self.state())
     }
 
-    pub fn handle_message(&mut self, message: ProverMessages, connection_handle: Option<u32>) -> VcxResult<()> {
+    pub fn handle_message(&mut self, message: ProverMessages, send_message: Option<&impl Fn(&A2AMessage) -> VcxResult<()>>) -> VcxResult<()> {
         trace!("Prover::handle_message >>> message: {:?}", message);
-        self.step(message, connection_handle)
-    }
-
-    pub fn get_presentation_request_messages(connection_handle: u32) -> VcxResult<Vec<A2AMessage>> {
-        trace!("Prover::get_presentation_request_messages >>> connection_handle: {:?}", connection_handle);
-
-        let presentation_requests: Vec<A2AMessage> =
-            connection::get_messages(connection_handle)?
-                .into_iter()
-                .filter_map(|(_, message)| {
-                    match message {
-                        A2AMessage::PresentationRequest(_) => Some(message),
-                        _ => None
-                    }
-                })
-                .collect();
-
-        Ok(presentation_requests)
+        self.step(message, send_message)
     }
 
     pub fn presentation_request_data(&self) -> VcxResult<String> {
@@ -111,22 +97,24 @@ impl Prover {
 
     pub fn get_source_id(&self) -> String { self.prover_sm.source_id() }
 
-    pub fn step(&mut self, message: ProverMessages, connection_handle: Option<u32>) -> VcxResult<()> {
-        self.prover_sm = self.prover_sm.clone().step(message, connection_handle)?;
+    pub fn step<T>(&mut self, message: ProverMessages, send_message: Option<&T>)
+        -> VcxResult<()> where T: Fn(&A2AMessage) -> VcxResult<()>
+    {
+        self.prover_sm = self.prover_sm.clone().step(message, send_message)?;
         Ok(())
     }
 
-    pub fn decline_presentation_request(&mut self, connection_handle: u32, reason: Option<String>, proposal: Option<String>) -> VcxResult<()> {
-        trace!("Prover::decline_presentation_request >>> connection_handle: {}, reason: {:?}, proposal: {:?}", connection_handle, reason, proposal);
+    pub fn decline_presentation_request(&mut self, send_message: &impl Fn(&A2AMessage) -> VcxResult<()>, reason: Option<String>, proposal: Option<String>) -> VcxResult<()> {
+        trace!("Prover::decline_presentation_request >>> reason: {:?}, proposal: {:?}", reason, proposal);
         match (reason, proposal) {
             (Some(reason), None) => {
-                self.step(ProverMessages::RejectPresentationRequest((reason)), Some(connection_handle))
+                self.step(ProverMessages::RejectPresentationRequest((reason)), Some(send_message))
             }
             (None, Some(proposal)) => {
                 let presentation_preview: PresentationPreview = serde_json::from_str(&proposal)
                     .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot serialize Presentation Preview: {:?}", err)))?;
 
-                self.step(ProverMessages::ProposePresentation((presentation_preview)), Some(connection_handle))
+                self.step(ProverMessages::ProposePresentation((presentation_preview)), Some(send_message))
             }
             (None, None) => {
                 return Err(VcxError::from_msg(VcxErrorKind::InvalidOption, "Either `reason` or `proposal` parameter must be specified."));

--- a/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
@@ -12,7 +12,7 @@ use crate::libindy::utils::anoncreds;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Prover {
-    prover_sm: ProverSM
+    prover_sm: ProverSM,
 }
 
 impl Prover {
@@ -37,9 +37,8 @@ impl Prover {
     }
 
     pub fn generate_presentation(&mut self, credentials: String, self_attested_attrs: String) -> VcxResult<()> {
-        let closure = move |a2a_message: &A2AMessage| { panic!("This should not be called") };
         trace!("Prover::generate_presentation >>> credentials: {}, self_attested_attrs: {:?}", credentials, self_attested_attrs);
-        self.step(ProverMessages::PreparePresentation((credentials, self_attested_attrs)), Some(&closure))
+        self.step(ProverMessages::PreparePresentation((credentials, self_attested_attrs)), None::<&fn(&A2AMessage) -> _>)
     }
 
     pub fn generate_presentation_msg(&self) -> VcxResult<String> {
@@ -86,8 +85,10 @@ impl Prover {
 
     pub fn get_source_id(&self) -> String { self.prover_sm.source_id() }
 
-    pub fn step<T>(&mut self, message: ProverMessages, send_message: Option<&T>)
-        -> VcxResult<()> where T: Fn(&A2AMessage) -> VcxResult<()>
+    pub fn step(&mut self,
+                message: ProverMessages,
+                send_message: Option<&impl Fn(&A2AMessage) -> VcxResult<()>>)
+                -> VcxResult<()>
     {
         self.prover_sm = self.prover_sm.clone().step(message, send_message)?;
         Ok(())

--- a/libvcx/src/aries/handlers/proof_presentation/prover/state_machine.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/state_machine.rs
@@ -314,7 +314,7 @@ pub mod test {
 
     impl ProverSM {
         fn to_presentation_prepared_state(mut self) -> ProverSM {
-            self = self.step(ProverMessages::PreparePresentation((_credentials(), _self_attested())), None::<&Box<dyn Fn(&A2AMessage) -> VcxResult<()>>>).unwrap();
+            self = self.step(ProverMessages::PreparePresentation((_credentials(), _self_attested())), None::<&fn(&A2AMessage) -> _>).unwrap();
             self
         }
 
@@ -327,7 +327,7 @@ pub mod test {
 
         fn to_finished_state(mut self) -> ProverSM {
             let send_message = Some(&|a2a_message: &A2AMessage| VcxResult::Ok(()));
-            self = self.step(ProverMessages::PreparePresentation((_credentials(), _self_attested())), None::<&Box<dyn Fn(&A2AMessage) -> VcxResult<()>>>).unwrap();
+            self = self.step(ProverMessages::PreparePresentation((_credentials(), _self_attested())), None::<&fn(&A2AMessage) -> _>).unwrap();
             self = self.step(ProverMessages::SendPresentation, send_message).unwrap();
             self = self.step(ProverMessages::PresentationAckReceived(_ack()), send_message).unwrap();
             self

--- a/libvcx/src/aries/handlers/proof_presentation/prover/state_machine.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/state_machine.rs
@@ -125,13 +125,21 @@ impl ProverSM {
                             }
                         }
                     }
-                    ProverMessages::RejectPresentationRequest((reason)) => {
-                        Self::_handle_reject_presentation_request(send_message.unwrap(), &reason, &state.presentation_request, &thread_id)?;
-                        ProverState::Finished(state.into())
+                    ProverMessages::RejectPresentationRequest(reason) => {
+                        if let Some(send_message) = send_message {
+                            Self::_handle_reject_presentation_request(send_message, &reason, &state.presentation_request, &thread_id)?;
+                            ProverState::Finished(state.into())
+                        } else {
+                            return Err(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Send message closure is required."));
+                        }
                     }
-                    ProverMessages::ProposePresentation((preview)) => {
-                        Self::_handle_presentation_proposal(send_message.unwrap(), preview, &state.presentation_request, &thread_id)?;
-                        ProverState::Finished(state.into())
+                    ProverMessages::ProposePresentation(preview) => {
+                        if let Some(send_message) = send_message {
+                            Self::_handle_presentation_proposal(send_message, preview, &state.presentation_request, &thread_id)?;
+                            ProverState::Finished(state.into())
+                        } else {
+                            return Err(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Send message closure is required."));
+                        }
                     }
                     _ => {
                         ProverState::Initiated(state)
@@ -141,17 +149,28 @@ impl ProverSM {
             ProverState::PresentationPrepared(state) => {
                 match message {
                     ProverMessages::SendPresentation => {
-                        let send_message = send_message.unwrap();
-                        send_message(&state.presentation.to_a2a_message())?;
-                        ProverState::PresentationSent((state).into())
+                        if let Some(send_message) = send_message {
+                            send_message(&state.presentation.to_a2a_message())?;
+                            ProverState::PresentationSent((state).into())
+                        } else {
+                            return Err(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Send message closure is required."));
+                        }
                     }
-                    ProverMessages::RejectPresentationRequest((reason)) => {
-                        Self::_handle_reject_presentation_request(send_message.unwrap(), &reason, &state.presentation_request, &thread_id)?;
-                        ProverState::Finished(state.into())
+                    ProverMessages::RejectPresentationRequest(reason) => {
+                        if let Some(send_message) = send_message {
+                            Self::_handle_reject_presentation_request(send_message, &reason, &state.presentation_request, &thread_id)?;
+                            ProverState::Finished(state.into())
+                        } else {
+                            return Err(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Send message closure is required."));
+                        }
                     }
-                    ProverMessages::ProposePresentation((preview)) => {
-                        Self::_handle_presentation_proposal(send_message.unwrap(), preview, &state.presentation_request, &thread_id)?;
-                        ProverState::Finished(state.into())
+                    ProverMessages::ProposePresentation(preview) => {
+                        if let Some(send_message) = send_message {
+                            Self::_handle_presentation_proposal(send_message, preview, &state.presentation_request, &thread_id)?;
+                            ProverState::Finished(state.into())
+                        } else {
+                            return Err(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Send message closure is required."));
+                        }
                     }
                     _ => {
                         ProverState::PresentationPrepared(state)
@@ -161,9 +180,12 @@ impl ProverSM {
             ProverState::PresentationPreparationFailed(state) => {
                 match message {
                     ProverMessages::SendPresentation => {
-                        let send_message = send_message.unwrap();
-                        send_message(&state.problem_report.to_a2a_message())?;
-                        ProverState::Finished((state).into())
+                        if let Some(send_message) = send_message {
+                            send_message(&state.problem_report.to_a2a_message())?;
+                            ProverState::Finished((state).into())
+                        } else {
+                            return Err(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Send message closure is required."));
+                        }
                     }
                     _ => {
                         ProverState::PresentationPreparationFailed(state)

--- a/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_prepared.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_prepared.rs
@@ -10,8 +10,8 @@ pub struct PresentationPreparedState {
     pub presentation: Presentation,
 }
 
-impl From<(PresentationPreparedState)> for PresentationSentState {
-    fn from((state): (PresentationPreparedState)) -> Self {
+impl From<PresentationPreparedState> for PresentationSentState {
+    fn from(state: PresentationPreparedState) -> Self {
         trace!("transit state from PresentationPreparedState to PresentationSentState");
         PresentationSentState {
             presentation_request: state.presentation_request,

--- a/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_prepared_failed.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/states/presentation_prepared_failed.rs
@@ -10,8 +10,8 @@ pub struct PresentationPreparationFailedState {
     pub problem_report: ProblemReport,
 }
 
-impl From<(PresentationPreparationFailedState)> for FinishedState {
-    fn from((state): (PresentationPreparationFailedState)) -> Self {
+impl From<PresentationPreparationFailedState> for FinishedState {
+    fn from(state: PresentationPreparationFailedState) -> Self {
         trace!("transit state from PresentationPreparationFailedState to FinishedState");
         FinishedState {
             presentation_request: state.presentation_request,

--- a/libvcx/src/connection.rs
+++ b/libvcx/src/connection.rs
@@ -259,9 +259,8 @@ pub fn get_message_by_id(handle: u32, msg_id: String) -> VcxResult<A2AMessage> {
 
 pub fn send_message(handle: u32, message: A2AMessage) -> VcxResult<()> {
     trace!("connection::send_message >>>");
-    CONNECTION_MAP.get_mut(handle, |connection| {
-        connection.send_message(&message)
-    })
+    let send_message = send_message_closure(handle)?;
+    send_message(&message)
 }
 
 pub fn send_message_closure(handle: u32) -> VcxResult<impl Fn(&A2AMessage) -> VcxResult<()>> {

--- a/libvcx/src/connection.rs
+++ b/libvcx/src/connection.rs
@@ -264,6 +264,12 @@ pub fn send_message(handle: u32, message: A2AMessage) -> VcxResult<()> {
     })
 }
 
+pub fn send_message_closure(handle: u32) -> VcxResult<impl Fn(&A2AMessage) -> VcxResult<()>> {
+    CONNECTION_MAP.get(handle, |connection| {
+        return connection.send_message_closure()
+    })
+}
+
 pub fn is_v3_connection(connection_handle: u32) -> VcxResult<bool> {
     CONNECTION_MAP.get(connection_handle, |_| {
         Ok(true)

--- a/libvcx/src/disclosed_proof.rs
+++ b/libvcx/src/disclosed_proof.rs
@@ -80,11 +80,11 @@ pub fn update_state(handle: u32, message: Option<&str>, connection_handle: u32) 
         }
         let send_message = connection::send_message_closure(connection_handle)?;
 
-        if let Some(message_) = message {
-            let a2a_message: A2AMessage = serde_json::from_str(message_)
-                .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidOption, format!("Cannot updated state with message: Message deserialization failed: {:?}", err)))?;
-            trace!("disclosed_proof::update_state >>> updating using message {:?}", a2a_message);
-            proof.handle_message(a2a_message.into(), Some(&send_message))?;
+        if let Some(message) = message {
+            let message: A2AMessage = serde_json::from_str(message)
+                .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidOption, format!("Can not updated state with message: Message deserialization failed: {:?}", err)))?;
+            trace!("disclosed_proof::update_state >>> updating using message {:?}", message);
+            proof.handle_message(message.into(), Some(&send_message))?;
         } else {
             let messages = connection::get_messages(connection_handle)?;
             trace!("disclosed_proof::update_state >>> found messages: {:?}", messages);

--- a/libvcx/src/disclosed_proof.rs
+++ b/libvcx/src/disclosed_proof.rs
@@ -2,18 +2,18 @@ use serde_json;
 
 use agency_client::mocking::AgencyMockDecrypted;
 
-use crate::connection;
 use crate::aries::{
     handlers::proof_presentation::prover::prover::Prover,
     messages::proof_presentation::presentation_request::PresentationRequest,
 };
+use crate::aries::messages::a2a::A2AMessage;
+use crate::connection;
 use crate::error::prelude::*;
 use crate::settings::indy_mocks_enabled;
 use crate::utils::constants::GET_MESSAGES_DECRYPTED_RESPONSE;
 use crate::utils::error;
 use crate::utils::mockdata::mockdata_proof::ARIES_PROOF_REQUEST_PRESENTATION;
 use crate::utils::object_cache::ObjectCache;
-use crate::aries::messages::a2a::A2AMessage;
 
 lazy_static! {
     static ref HANDLE_MAP: ObjectCache<Prover> = ObjectCache::<Prover>::new("disclosed-proofs-cache");
@@ -88,7 +88,8 @@ pub fn update_state(handle: u32, message: Option<&str>, connection_handle: u32) 
         trace!("disclosed_proof::update_state >>> found messages: {:?}", messages);
 
         if let Some((uid, message)) = proof.find_message_to_handle(messages) {
-            proof.handle_message(message.into(), Some(connection_handle))?;
+            let send_message = connection::send_message_closure(connection_handle)?;
+            proof.handle_message(message.into(), Some(&send_message))?;
             connection::update_message_status(connection_handle, uid)?;
         };
 
@@ -128,7 +129,8 @@ pub fn generate_proof_msg(handle: u32) -> VcxResult<String> {
 
 pub fn send_proof(handle: u32, connection_handle: u32) -> VcxResult<u32> {
     HANDLE_MAP.get_mut(handle, |proof| {
-        proof.send_presentation(connection_handle)?;
+        let send_message = connection::send_message_closure(connection_handle)?;
+        proof.send_presentation(&send_message)?;
         let new_proof = proof.clone();
         *proof = new_proof;
         Ok(error::SUCCESS.code_num)
@@ -144,7 +146,8 @@ pub fn generate_reject_proof_msg(handle: u32) -> VcxResult<String> {
 
 pub fn reject_proof(handle: u32, connection_handle: u32) -> VcxResult<u32> {
     HANDLE_MAP.get_mut(handle, |proof| {
-        proof.decline_presentation_request(connection_handle, Some(String::from("Presentation Request was rejected")), None)?;
+        let send_message = connection::send_message_closure(connection_handle)?;
+        proof.decline_presentation_request(&send_message, Some(String::from("Presentation Request was rejected")), None)?;
         let new_proof = proof.clone();
         *proof = new_proof;
         Ok(error::SUCCESS.code_num)
@@ -160,7 +163,8 @@ pub fn generate_proof(handle: u32, credentials: String, self_attested_attrs: Str
 
 pub fn decline_presentation_request(handle: u32, connection_handle: u32, reason: Option<String>, proposal: Option<String>) -> VcxResult<u32> {
     HANDLE_MAP.get_mut(handle, |proof| {
-        proof.decline_presentation_request(connection_handle, reason.clone(), proposal.clone())?;
+        let send_message = connection::send_message_closure(connection_handle)?;
+        proof.decline_presentation_request(&send_message, reason.clone(), proposal.clone())?;
         let new_proof = proof.clone();
         *proof = new_proof;
         Ok(error::SUCCESS.code_num)
@@ -199,7 +203,7 @@ fn get_proof_request(connection_handle: u32, msg_id: &str) -> VcxResult<String> 
         AgencyMockDecrypted::set_next_decrypted_message(ARIES_PROOF_REQUEST_PRESENTATION);
     }
 
-    let presentation_request =  {
+    let presentation_request = {
         trace!("Prover::get_presentation_request >>> connection_handle: {:?}, msg_id: {:?}", connection_handle, msg_id);
 
         let message = connection::get_message_by_id(connection_handle, msg_id.to_string())?;
@@ -223,7 +227,17 @@ pub fn get_proof_request_messages(connection_handle: u32) -> VcxResult<String> {
         return Err(VcxError::from_msg(VcxErrorKind::InvalidConnectionHandle, format!("Connection can not be used for Proprietary Issuance protocol")));
     }
 
-    let presentation_requests = Prover::get_presentation_request_messages(connection_handle)?;
+    let presentation_requests: Vec<A2AMessage> =
+        connection::get_messages(connection_handle)?
+            .into_iter()
+            .filter_map(|(_, message)| {
+                match message {
+                    A2AMessage::PresentationRequest(_) => Some(message),
+                    _ => None
+                }
+            })
+            .collect();
+
     Ok(json!(presentation_requests).to_string())
 }
 
@@ -244,10 +258,11 @@ mod tests {
     extern crate serde_json;
 
     use serde_json::Value;
+
     use crate::api::VcxStateType;
     use crate::aries::messages::proof_presentation::presentation_request::PresentationRequestData;
-    use crate::utils::constants::{ARIES_PROVER_CREDENTIALS, ARIES_PROVER_SELF_ATTESTED_ATTRS, GET_MESSAGES_DECRYPTED_RESPONSE};
     use crate::utils;
+    use crate::utils::constants::{ARIES_PROVER_CREDENTIALS, ARIES_PROVER_SELF_ATTESTED_ATTRS, GET_MESSAGES_DECRYPTED_RESPONSE};
     use crate::utils::devsetup::*;
     use crate::utils::mockdata::mock_settings::MockBuilder;
     use crate::utils::mockdata::mockdata_proof;

--- a/libvcx/src/libindy/proofs/prover/prover_internal.rs
+++ b/libvcx/src/libindy/proofs/prover/prover_internal.rs
@@ -202,7 +202,6 @@ pub fn build_requested_credentials_json(credentials_identifiers: &Vec<CredInfoPr
 
 #[cfg(test)]
 pub mod tests {
-    use crate::libindy;
     use crate::libindy::proofs::proof_request_internal::NonRevokedInterval;
     use crate::libindy::proofs::prover::prover_internal::CredInfoProver;
     use crate::utils::{


### PR DESCRIPTION
- This PR modifies prover state machine interface such that it removes dependency on `connection_handle`. The numeric handle is only FFI-enabling concept and has no reason to be present at bottom levels of the library, preventing the state machine abstraction to be used without having to manage numeric connection handles.

   Typically the only reason why `connection_handle` is being passed to protocol state machines is in order for the state machine to submit reply message to counterparty connection. So in this PR, instead of passing `connection_handle`, we pass down `send_message` closure, which is responsible of dispatching the message to counterparty.
   
   This is also better for state machine testing, as tests could use custom implementation of  `send_message` which does not passes information over network at all.

- This is important steps towards making `aries-vcx` a consumable crate ( https://github.com/hyperledger/aries-vcx/issues/196 )

- In this PR, the changes are only applied on `prover` state machine, but if it's agreed this is good way marching forward, applying analogous changes on other protocol state machines is easy.

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>