### PR TITLE
Release 0.18.2 (previous release 0.18.1 publish process got broken)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "libvcx"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "agency_client",
  "android_logger",

--- a/agents/node/vcxagent-core/package.json
+++ b/agents/node/vcxagent-core/package.json
@@ -67,6 +67,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@hyperledger/node-vcx-wrapper": "^0.18.1"
+    "@hyperledger/node-vcx-wrapper": "^0.18.2"
   }
 }

--- a/libvcx/Cargo.toml
+++ b/libvcx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libvcx"
-version = "0.18.1"
+version = "0.18.2"
 authors = ["Absa Group Limited", "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>"]
 publish = false
 description = "Absa's fork of HL LibVCX"


### PR DESCRIPTION
Previous release 0.18.1 is incomplete because publishing libvcx docker image silently failed
```
Releasing libvcx docker image version 0.18.1, tagged docker.pkg.github.com/hyperledger/aries-vcx/libvcx:0.18.1
The push refers to repository [docker.pkg.github.com/hyperledger/aries-vcx/libvcx]
5f70bf18a086: Preparing
677317b7bb65: Preparing
958dcc0bb643: Preparing
ed93e08f5e4a: Preparing
10ce3b93143e: Preparing
250adad2e09e: Preparing
9c750d09432d: Preparing
f18998204895: Preparing
5f70bf18a086: Preparing
0a28081e49af: Preparing
3b06dff7e1f0: Preparing
32f366d666a5: Preparing
9c750d09432d: Waiting
f18998204895: Waiting
0a28081e49af: Waiting
3b06dff7e1f0: Waiting
32f366d666a5: Waiting
250adad2e09e: Waiting
10ce3b93143e: Pushed
ed93e08f5e4a: Pushed
958dcc0bb643: Pushed
5f70bf18a086: Pushed
250adad2e09e: Pushed
9c750d09432d: Pushed
f18998204895: Pushed
32f366d666a5: Layer already exists
3b06dff7e1f0: Pushed
0a28081e49af: Pushed
677317b7bb65: Pushed
received unexpected HTTP status: 500 Internal Server Error
```

So this release contains no changes, just to re-release artifacts.

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>