### PR TITLE
Support additional credential data input format in Credential and CredentialOffer

### DIFF
--- a/libvcx/src/aries/handlers/issuance/holder/state_machine.rs
+++ b/libvcx/src/aries/handlers/issuance/holder/state_machine.rs
@@ -56,7 +56,7 @@ impl HolderSM {
     }
 
     pub fn find_message_to_handle(&self, messages: HashMap<String, A2AMessage>) -> Option<(String, A2AMessage)> {
-        trace!("Holder::find_message_to_handle >>> messages: {:?}", messages);
+        trace!("Holder::find_message_to_handle >>> messages: {:?}, state: {:?}", messages, self.state);
 
         for (uid, message) in messages {
             match self.state {
@@ -92,7 +92,7 @@ impl HolderSM {
     }
 
     pub fn handle_message(self, cim: CredentialIssuanceMessage, send_message: Option<&impl Fn(&A2AMessage) -> VcxResult<()>>) -> VcxResult<HolderSM> {
-        trace!("Holder::handle_message >>> cim: {:?}", cim);
+        trace!("Holder::handle_message >>> cim: {:?}, state: {:?}", cim, self.state);
 
         let HolderSM { state, source_id, thread_id } = self;
         let state = match state {

--- a/libvcx/src/aries/handlers/issuance/issuer/state_machine.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/state_machine.rs
@@ -311,19 +311,19 @@ fn _append_credential_preview(cred_offer_msg: CredentialOffer, credential_json: 
     trace!("Issuer::_append_credential_preview >>> cred_offer_msg: {:?}, credential_json: {:?}", cred_offer_msg, credential_json);
 
     let cred_values: serde_json::Value = serde_json::from_str(credential_json)
-        .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Can't deserialize credential preview json. credential_json={} error={:?}", credential_json, err)))?;
+        .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Can't deserialize credential preview json. credential_json: {}, error: {:?}", credential_json, err)))?;
 
     let mut new_offer = cred_offer_msg;
     match cred_values {
         serde_json::Value::Array(cred_values) => {
             for cred_value in cred_values.iter() {
-                let key = cred_value.get("name").unwrap();
-                let value = cred_value.get("value").unwrap();
+                let key = cred_value.get("name").ok_or(VcxError::from(VcxErrorKind::InvalidAttributesStructure, format!("No 'name' field in cred_value: {:?}", cred_value)))?;
+                let value = cred_value.get("value").ok_or(VcxError::from(VcxErrorKind::InvalidAttributesStructure, format!("No 'value' field in cred_value: {:?}", cred_value)))?;
                 new_offer = new_offer.add_credential_preview_data(
                     &key.to_string(),
                     &value.to_string(),
                     MimeType::Plain,
-                ).unwrap();
+                )?;
             };
         }
         serde_json::Value::Object(values_map) => {

--- a/libvcx/src/aries/handlers/issuance/issuer/utils.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/utils.rs
@@ -5,53 +5,72 @@ use crate::utils::error;
 use crate::utils::openssl::encode;
 
 pub fn encode_attributes(attributes: &str) -> VcxResult<String> {
-    let mut attributes: HashMap<String, serde_json::Value> = serde_json::from_str(attributes)
-        .map_err(|err| {
-            warn!("Invalid Json for Attribute data");
-            VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot deserialize credential attributes: {}", err))
-        })?;
-
     let mut dictionary = HashMap::new();
+    match serde_json::from_str::<HashMap<String, serde_json::Value>>(attributes) {
+        Ok(mut attributes) => {
+            for (attr, attr_data) in attributes.iter_mut() {
+                let first_attr: &str = match attr_data {
+                    // new style input such as {"address2":"101 Wilson Lane"}
+                    serde_json::Value::String(str_type) => str_type,
 
-    for (attr, attr_data) in attributes.iter_mut() {
-        let first_attr: &str = match attr_data {
-            // old style input such as {"address2":["101 Wilson Lane"]}
-            serde_json::Value::Array(array_type) => {
-                let attrib_value: &str = match array_type.get(0).and_then(serde_json::Value::as_str) {
-                    Some(x) => x,
-                    None => {
-                        warn!("Cannot encode attribute: {}", error::INVALID_ATTRIBUTES_STRUCTURE.message);
-                        return Err(VcxError::from_msg(VcxErrorKind::InvalidAttributesStructure, "Attribute value not found"));
+                    // old style input such as {"address2":["101 Wilson Lane"]}
+                    serde_json::Value::Array(array_type) => {
+                        let attrib_value: &str = match array_type.get(0).and_then(serde_json::Value::as_str) {
+                            Some(x) => x,
+                            None => {
+                                warn!("Cannot encode attribute: {}", error::INVALID_ATTRIBUTES_STRUCTURE.message);
+                                return Err(VcxError::from_msg(VcxErrorKind::InvalidAttributesStructure, "Attribute value not found"));
+                            }
+                        };
+
+                        warn!("Old attribute format detected. See vcx_issuer_create_credential api for additional information.");
+                        attrib_value
+                    }
+
+                    // anything else is an error
+                    _ => {
+                        warn!("Invalid Json for Attribute data");
+                        return Err(VcxError::from_msg(VcxErrorKind::InvalidJson, "Invalid Json for Attribute data"));
                     }
                 };
 
-                warn!("Old attribute format detected. See vcx_issuer_create_credential api for additional information.");
-                attrib_value
+                let encoded = encode(&first_attr)?;
+                let attrib_values = json!({
+                    "raw": first_attr,
+                    "encoded": encoded
+                });
+
+                dictionary.insert(attr.to_string(), attrib_values);
+            };
+            serde_json::to_string_pretty(&dictionary)
+                .map_err(|err| {
+                    warn!("Invalid Json for Attribute data");
+                    VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Invalid Json for Attribute data: {}", err))
+                })
+        }
+        Err(err) => { // TODO: Check error type
+            match serde_json::from_str::<Vec<serde_json::Value>>(attributes) {
+                Ok(mut attributes) => {
+                    for cred_value in attributes.iter_mut() {
+                        let name = cred_value.get("name").unwrap();
+                        let value = cred_value.get("value").unwrap();
+                        let encoded = encode(&value.to_string())?;
+                        let attrib_values = json!({
+                            "raw": value,
+                            "encoded": encoded
+                        });
+                        dictionary.insert(name.as_str().unwrap().to_string(), attrib_values);
+                    };
+                    serde_json::to_string_pretty(&dictionary)
+                        .map_err(|err| {
+                            warn!("Invalid Json for Attribute data");
+                            VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Invalid Json for Attribute data: {}", err))
+                        })
+                }
+                Err(err) => return Err(VcxError::from_msg(VcxErrorKind::InvalidAttributesStructure, format!("Attribute value not found: {:?}", err)))
             }
-
-            // new style input such as {"address2":"101 Wilson Lane"}
-            serde_json::Value::String(str_type) => str_type,
-            // anything else is an error
-            _ => {
-                warn!("Invalid Json for Attribute data");
-                return Err(VcxError::from_msg(VcxErrorKind::InvalidJson, "Invalid Json for Attribute data"));
-            }
-        };
-
-        let encoded = encode(&first_attr)?;
-        let attrib_values = json!({
-            "raw": first_attr,
-            "encoded": encoded
-        });
-
-        dictionary.insert(attr, attrib_values);
+        }
     }
-
-    serde_json::to_string_pretty(&dictionary)
-        .map_err(|err| {
-            warn!("Invalid Json for Attribute data");
-            VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Invalid Json for Attribute data: {}", err))
-        })
 }
 
 

--- a/libvcx/src/connection.rs
+++ b/libvcx/src/connection.rs
@@ -132,12 +132,6 @@ fn get_bootstrap_agent_messages(remote_vk: VcxResult<String>, bootstrap_agent_in
     Ok(None)
 }
 
-/**
-Tries to update state of connection state machine in 3 steps:
-  1. find relevant message in agency,
-  2. use it to update connection state and possibly send response over network,
-  3. update state of used message in agency to "Reviewed".
- */
 pub fn update_state(handle: u32) -> VcxResult<u32> {
     CONNECTION_MAP.get_mut(handle, |connection| {
         match connection.update_state() {

--- a/libvcx/src/credential.rs
+++ b/libvcx/src/credential.rs
@@ -86,7 +86,7 @@ pub fn credential_create_with_msgid(source_id: &str, connection_handle: u32, msg
 pub fn update_state(handle: u32, message: Option<&str>, connection_handle: u32) -> VcxResult<u32> {
     HANDLE_MAP.get_mut(handle, |credential| {
         trace!("credential::update_state >>> ");
-        if credential.is_terminal_state() { return Ok(credential.get_status()); }
+        if credential.is_terminal_state() { return Ok(credential.get_state()); }
         let send_message = connection::send_message_closure(connection_handle)?;
 
         if let Some(message) = message {
@@ -100,7 +100,7 @@ pub fn update_state(handle: u32, message: Option<&str>, connection_handle: u32) 
             connection::update_message_status(connection_handle, uid)?;
             }
         }
-        Ok(credential.get_status())
+        Ok(credential.get_state())
     })
 }
 
@@ -170,7 +170,7 @@ pub fn get_credential_offer(handle: u32) -> VcxResult<String> {
 
 pub fn get_state(handle: u32) -> VcxResult<u32> {
     HANDLE_MAP.get(handle, |credential| {
-        Ok(credential.get_status())
+        Ok(credential.get_state())
     }).map_err(handle_err)
 }
 

--- a/libvcx/src/issuer_credential.rs
+++ b/libvcx/src/issuer_credential.rs
@@ -49,8 +49,8 @@ pub fn update_state(handle: u32, message: Option<&str>, connection_handle: u32) 
         } else {
             let messages = connection::get_messages(connection_handle)?;
             if let Some((uid, msg)) = credential.find_message_to_handle(messages) {
-            credential.step(msg.into(), Some(&send_message))?;
-            connection::update_message_status(connection_handle, uid)?;
+                credential.step(msg.into(), Some(&send_message))?;
+                connection::update_message_status(connection_handle, uid)?;
             }
         }
         credential.get_state()


### PR DESCRIPTION
Currently, we support two formats of credential attributes:
```
{attr_name_1: attr_value_1, attr_name_2: attr_value_2, ...} // Preferred
```
and 
```
{attr_name_1: [attr_value_1], attr_name_2: [attr_value_2], ...} // Legacy
```
This change introduces support for the following format:
```
[{"name": attr_name_1, "value": "attr_value1"}, {"name": attr_name_2, "value": "attr_value2"}, ...]
```