### PR TITLE
Use enums instead of u32 to distinguish connection FSM states on Rust layer

### DIFF
--- a/libvcx/src/abi_utils/mod.rs
+++ b/libvcx/src/abi_utils/mod.rs
@@ -1,0 +1,28 @@
+use crate::aries::handlers::connection::connection::ConnectionState;
+use crate::aries::handlers::connection::inviter::state_machine::InviterState;
+use crate::aries::handlers::connection::invitee::state_machine::InviteeState;
+
+impl From<ConnectionState> for u32 {
+    fn from(state: ConnectionState) -> u32 {
+        match state {
+            ConnectionState::Inviter(inviter_state) => {
+                match inviter_state {
+                    InviterState::Null => 0,
+                    InviterState::Invited => 1,
+                    InviterState::Requested => 2,
+                    InviterState::Responded => 3,
+                    InviterState::Completed => 4,
+                }
+            }
+            ConnectionState::Invitee(invitee_state) => {
+                match invitee_state {
+                    InviteeState::Null => 0,
+                    InviteeState::Invited => 1,
+                    InviteeState::Requested => 2,
+                    InviteeState::Responded => 3,
+                    InviteeState::Completed => 4,
+                }
+            }
+        }
+    }
+}

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -124,13 +124,13 @@ impl Connection {
         }.into()
     }
 
-    pub fn state(&self) -> ConnectionState {
+    pub fn get_state(&self) -> ConnectionState {
         match &self.connection_sm {
             SmConnection::Inviter(sm_inviter) => {
-                ConnectionState::Inviter(sm_inviter.state())
+                ConnectionState::Inviter(sm_inviter.get_state())
             }
             SmConnection::Invitee(sm_invitee) => {
-                ConnectionState::Invitee(sm_invitee.state())
+                ConnectionState::Invitee(sm_invitee.get_state())
             }
         }
     }
@@ -735,7 +735,7 @@ pub mod tests {
         assert_eq!(connection.pairwise_info().pw_vk, "rCw3x5h1jS6gPo7rRrt3EYbXXe5nNjnGbdf1jAwUxuj");
         assert_eq!(connection.cloud_agent_info().agent_did, "EZrZyu4bfydm4ByNm56kPP");
         assert_eq!(connection.cloud_agent_info().agent_vk, "8Ps2WosJ9AV1eXPoJKsEJdM3NchPhSyS8qFt6LQUTKv2");
-        assert_eq!(connection.state(), ConnectionState::Inviter(InviterState::Completed));
+        assert_eq!(connection.get_state(), ConnectionState::Inviter(InviterState::Completed));
     }
 
     fn test_deserialize_and_serialize(sm_serialized: &str) {
@@ -791,18 +791,18 @@ pub mod tests {
         institution.activate().unwrap();
         thread::sleep(Duration::from_millis(500));
         institution_to_consumer.update_state().unwrap();
-        assert_eq!(ConnectionState::Inviter(InviterState::Responded), institution_to_consumer.state());
+        assert_eq!(ConnectionState::Inviter(InviterState::Responded), institution_to_consumer.get_state());
 
         debug!("Consumer is going to complete the connection protocol.");
         consumer.activate().unwrap();
         consumer_to_institution.update_state().unwrap();
-        assert_eq!(ConnectionState::Invitee(InviteeState::Completed), consumer_to_institution.state());
+        assert_eq!(ConnectionState::Invitee(InviteeState::Completed), consumer_to_institution.get_state());
 
         debug!("Institution is going to complete the connection protocol.");
         institution.activate().unwrap();
         thread::sleep(Duration::from_millis(500));
         institution_to_consumer.update_state().unwrap();
-        assert_eq!(ConnectionState::Inviter(InviterState::Completed), institution_to_consumer.state());
+        assert_eq!(ConnectionState::Inviter(InviterState::Completed), institution_to_consumer.get_state());
 
         (consumer_to_institution, institution_to_consumer)
     }

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -796,7 +796,7 @@ pub mod tests {
         debug!("Consumer is going to complete the connection protocol.");
         consumer.activate().unwrap();
         consumer_to_institution.update_state().unwrap();
-        assert_eq!(ConnectionState::Invitee(InviteeState::Responded), consumer_to_institution.state());
+        assert_eq!(ConnectionState::Invitee(InviteeState::Completed), consumer_to_institution.state());
 
         debug!("Institution is going to complete the connection protocol.");
         institution.activate().unwrap();

--- a/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
@@ -87,7 +87,7 @@ impl SmConnectionInvitee {
         &self.source_id
     }
 
-    pub fn state(&self) -> InviteeState {
+    pub fn get_state(&self) -> InviteeState {
         InviteeState::from(self.state.clone())
     }
 
@@ -793,9 +793,9 @@ pub mod test {
             fn test_get_state() {
                 let _setup = SetupMocks::init();
 
-                assert_eq!(InviteeState::Null, invitee_sm().state());
-                assert_eq!(InviteeState::Invited, invitee_sm().to_invitee_invited_state().state());
-                assert_eq!(InviteeState::Requested, invitee_sm().to_invitee_requested_state().state());
+                assert_eq!(InviteeState::Null, invitee_sm().get_state());
+                assert_eq!(InviteeState::Invited, invitee_sm().to_invitee_invited_state().get_state());
+                assert_eq!(InviteeState::Requested, invitee_sm().to_invitee_requested_state().get_state());
             }
         }
     }

--- a/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
@@ -87,7 +87,7 @@ impl SmConnectionInviter {
         &self.source_id
     }
 
-    pub fn state(&self) -> InviterState {
+    pub fn get_state(&self) -> InviterState {
         InviterState::from(self.state.clone())
     }
 
@@ -933,10 +933,10 @@ pub mod test {
             fn test_get_state() {
                 let _setup = SetupMocks::init();
 
-                assert_eq!(InviterState::Null, inviter_sm().state());
-                assert_eq!(InviterState::Invited, inviter_sm().to_inviter_invited_state().state());
-                assert_eq!(InviterState::Responded, inviter_sm().to_inviter_responded_state().state());
-                assert_eq!(InviterState::Completed, inviter_sm().to_inviter_completed_state().state());
+                assert_eq!(InviterState::Null, inviter_sm().get_state());
+                assert_eq!(InviterState::Invited, inviter_sm().to_inviter_invited_state().get_state());
+                assert_eq!(InviterState::Responded, inviter_sm().to_inviter_responded_state().get_state());
+                assert_eq!(InviterState::Completed, inviter_sm().to_inviter_completed_state().get_state());
             }
         }
     }

--- a/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
@@ -25,11 +25,11 @@ use crate::error::prelude::*;
 pub struct SmConnectionInviter {
     pub source_id: String,
     pub pairwise_info: PairwiseInfo,
-    pub state: InviterState,
+    pub state: InviterFullState,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum InviterState {
+pub enum InviterFullState {
     Null(NullState),
     Invited(InvitedState),
     Requested(RequestedState),
@@ -37,14 +37,23 @@ pub enum InviterState {
     Completed(CompleteState),
 }
 
-impl InviterState {
-    pub fn code(&self) -> u32 {
-        match self {
-            InviterState::Null(_) => VcxStateType::VcxStateNone as u32,
-            InviterState::Invited(_) => VcxStateType::VcxStateInitialized as u32,
-            InviterState::Requested(_) => VcxStateType::VcxStateOfferSent as u32,
-            InviterState::Responded(_) => VcxStateType::VcxStateRequestReceived as u32,
-            InviterState::Completed(_) => VcxStateType::VcxStateAccepted as u32,
+#[derive(Debug, Clone, PartialEq)]
+pub enum InviterState {
+    Null,
+    Invited,
+    Requested,
+    Responded,
+    Completed,
+}
+
+impl From<InviterFullState> for InviterState {
+    fn from(state: InviterFullState) -> InviterState {
+        match state {
+            InviterFullState::Null(_) => InviterState::Null,
+            InviterFullState::Invited(_) => InviterState::Invited,
+            InviterFullState::Requested(_) => InviterState::Requested,
+            InviterFullState::Responded(_) => InviterState::Responded,
+            InviterFullState::Completed(_) => InviterState::Completed
         }
     }
 }
@@ -53,19 +62,16 @@ impl SmConnectionInviter {
     pub fn new(source_id: &str, pairwise_info: PairwiseInfo) -> Self {
         Self {
             source_id: source_id.to_string(),
-            state: InviterState::Null(NullState {}),
+            state: InviterFullState::Null(NullState {}),
             pairwise_info,
         }
     }
 
     pub fn is_in_null_state(&self) -> bool {
-        match self.state {
-            InviterState::Null(_) => true,
-            _ => false
-        }
+        return InviterState::from(self.state.clone()) == InviterState::Null
     }
 
-    pub fn from(source_id: String, pairwise_info: PairwiseInfo, state: InviterState) -> Self {
+    pub fn from(source_id: String, pairwise_info: PairwiseInfo, state: InviterFullState) -> Self {
         Self {
             source_id,
             pairwise_info,
@@ -81,27 +87,27 @@ impl SmConnectionInviter {
         &self.source_id
     }
 
-    pub fn state(&self) -> u32 {
-        self.state.code()
+    pub fn state(&self) -> InviterState {
+        InviterState::from(self.state.clone())
     }
 
-    pub fn state_object(&self) -> &InviterState {
+    pub fn state_object(&self) -> &InviterFullState {
         &self.state
     }
 
     pub fn their_did_doc(&self) -> Option<DidDoc> {
         match self.state {
-            InviterState::Null(_) => None,
-            InviterState::Invited(ref _state) => None,
-            InviterState::Requested(ref state) => Some(state.did_doc.clone()),
-            InviterState::Responded(ref state) => Some(state.did_doc.clone()),
-            InviterState::Completed(ref state) => Some(state.did_doc.clone()),
+            InviterFullState::Null(_) => None,
+            InviterFullState::Invited(ref _state) => None,
+            InviterFullState::Requested(ref state) => Some(state.did_doc.clone()),
+            InviterFullState::Responded(ref state) => Some(state.did_doc.clone()),
+            InviterFullState::Completed(ref state) => Some(state.did_doc.clone()),
         }
     }
 
     pub fn get_invitation(&self) -> Option<&Invitation> {
         match self.state {
-            InviterState::Invited(ref state) => Some(&state.invitation),
+            InviterFullState::Invited(ref state) => Some(&state.invitation),
             _ => None
         }
     }
@@ -121,14 +127,14 @@ impl SmConnectionInviter {
 
     pub fn get_remote_protocols(&self) -> Option<Vec<ProtocolDescriptor>> {
         match self.state {
-            InviterState::Completed(ref state) => state.protocols.clone(),
+            InviterFullState::Completed(ref state) => state.protocols.clone(),
             _ => None
         }
     }
 
     pub fn needs_message(&self) -> bool {
         match self.state {
-            InviterState::Requested(_) => false,
+            InviterFullState::Requested(_) => false,
             _ => true
         }
     }
@@ -147,7 +153,7 @@ impl SmConnectionInviter {
 
     pub fn can_handle_message(&self, message: &A2AMessage) -> bool {
         match self.state {
-            InviterState::Invited(_) => {
+            InviterFullState::Invited(_) => {
                 match message {
                     A2AMessage::ConnectionRequest(_) => {
                         debug!("Inviter received ConnectionRequest message");
@@ -163,7 +169,7 @@ impl SmConnectionInviter {
                     }
                 }
             }
-            InviterState::Responded(_) => {
+            InviterFullState::Responded(_) => {
                 match message {
                     A2AMessage::Ack(_) => {
                         debug!("Ack message received");
@@ -187,7 +193,7 @@ impl SmConnectionInviter {
                     }
                 }
             }
-            InviterState::Completed(_) => {
+            InviterFullState::Completed(_) => {
                 match message {
                     A2AMessage::Ping(_) => {
                         debug!("Ping message received");
@@ -247,14 +253,14 @@ impl SmConnectionInviter {
     pub fn handle_connect(self, routing_keys: Vec<String>, service_endpoint: String) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Null(state) => {
+            InviterFullState::Null(state) => {
                 let invite: Invitation = Invitation::create()
                     .set_label(source_id.to_string())
                     .set_recipient_keys(vec!(pairwise_info.pw_vk.clone()))
                     .set_routing_keys(routing_keys)
                     .set_service_endpoint(service_endpoint);
 
-                let new_state = InviterState::Invited((state, invite).into());
+                let new_state = InviterFullState::Invited((state, invite).into());
                 new_state
             }
             _ => {
@@ -272,7 +278,7 @@ impl SmConnectionInviter {
                                      new_service_endpoint: String) -> VcxResult<Self> {
         let Self { source_id, pairwise_info: bootstrap_pairwise_info, state } = self;
         let state = match state {
-            InviterState::Invited(state) => {
+            InviterFullState::Invited(state) => {
                 match Self::_build_response(
                     &request,
                     &bootstrap_pairwise_info,
@@ -280,7 +286,7 @@ impl SmConnectionInviter {
                     new_routing_keys,
                     new_service_endpoint) {
                     Ok(signed_response) => {
-                        InviterState::Requested((state, request, signed_response).into())
+                        InviterFullState::Requested((state, request, signed_response).into())
                     }
                     Err(err) => {
                         let problem_report = ProblemReport::create()
@@ -292,7 +298,7 @@ impl SmConnectionInviter {
                             &problem_report.to_a2a_message(),
                             &bootstrap_pairwise_info.pw_vk,
                         ).ok();
-                        InviterState::Null((state, problem_report).into())
+                        InviterFullState::Null((state, problem_report).into())
                     }
                 }
             }
@@ -306,13 +312,13 @@ impl SmConnectionInviter {
     pub fn handle_ping(self, ping: Ping) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Responded(state) => {
+            InviterFullState::Responded(state) => {
                 state.handle_ping(&ping, &pairwise_info.pw_vk)?;
-                InviterState::Completed((state, ping).into())
+                InviterFullState::Completed((state, ping).into())
             }
-            InviterState::Completed(state) => {
+            InviterFullState::Completed(state) => {
                 state.handle_ping(&ping, &pairwise_info.pw_vk)?;
-                InviterState::Completed(state)
+                InviterFullState::Completed(state)
             }
             _ => {
                 state.clone()
@@ -324,18 +330,18 @@ impl SmConnectionInviter {
     pub fn handle_send_ping(self, comment: Option<String>) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Responded(state) => {
+            InviterFullState::Responded(state) => {
                 let ping =
                     Ping::create()
                         .request_response()
                         .set_comment(comment);
 
                 state.did_doc.send_message(&ping.to_a2a_message(), &pairwise_info.pw_vk).ok();
-                InviterState::Responded(state)
+                InviterFullState::Responded(state)
             }
-            InviterState::Completed(state) => {
+            InviterFullState::Completed(state) => {
                 state.handle_send_ping(comment, &pairwise_info.pw_vk)?;
-                InviterState::Completed(state)
+                InviterFullState::Completed(state)
             }
             _ => {
                 state.clone()
@@ -347,8 +353,8 @@ impl SmConnectionInviter {
     pub fn handle_ping_response(self, ping_response: PingResponse) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Responded(state) => {
-                InviterState::Completed((state, ping_response).into())
+            InviterFullState::Responded(state) => {
+                InviterFullState::Completed((state, ping_response).into())
             }
             _ => {
                 state.clone()
@@ -360,9 +366,9 @@ impl SmConnectionInviter {
     pub fn handle_discover_features(self, query_: Option<String>, comment: Option<String>) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Completed(state) => {
+            InviterFullState::Completed(state) => {
                 state.handle_discover_features(query_, comment, &pairwise_info.pw_vk)?;
-                InviterState::Completed(state)
+                InviterFullState::Completed(state)
             }
             _ => {
                 state.clone()
@@ -374,9 +380,9 @@ impl SmConnectionInviter {
     pub fn handle_discovery_query(self, query: Query) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Completed(state) => {
+            InviterFullState::Completed(state) => {
                 state.handle_discovery_query(query, &pairwise_info.pw_vk)?;
-                InviterState::Completed(state)
+                InviterFullState::Completed(state)
             }
             _ => {
                 state.clone()
@@ -388,8 +394,8 @@ impl SmConnectionInviter {
     pub fn handle_disclose(self, disclose: Disclose) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Completed(state) => {
-                InviterState::Completed((state.clone(), disclose.protocols).into())
+            InviterFullState::Completed(state) => {
+                InviterFullState::Completed((state.clone(), disclose.protocols).into())
             }
             _ => {
                 state.clone()
@@ -401,11 +407,11 @@ impl SmConnectionInviter {
     pub fn handle_problem_report(self, problem_report: ProblemReport) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Responded(state) => {
-                InviterState::Null((state, problem_report).into())
+            InviterFullState::Responded(state) => {
+                InviterFullState::Null((state, problem_report).into())
             }
-            InviterState::Invited(state) => {
-                InviterState::Null((state, problem_report).into())
+            InviterFullState::Invited(state) => {
+                InviterFullState::Null((state, problem_report).into())
             }
             _ => {
                 state.clone()
@@ -417,10 +423,10 @@ impl SmConnectionInviter {
     pub fn handle_send_response(self) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Requested(state) => {
+            InviterFullState::Requested(state) => {
                 match Self::_send_response(&state, &pairwise_info.pw_vk.clone()) {
                     Ok(_) => {
-                        InviterState::Responded(state.into())
+                        InviterFullState::Responded(state.into())
                     }
                     Err(err) => {
                         // todo: we should distinguish errors - probably should not send problem report
@@ -431,7 +437,7 @@ impl SmConnectionInviter {
                             .set_thread_id(&state.thread_id);
 
                         state.did_doc.send_message(&problem_report.to_a2a_message(), &pairwise_info.pw_vk).ok();
-                        InviterState::Null((state, problem_report).into())
+                        InviterFullState::Null((state, problem_report).into())
                     }
                 }
             }
@@ -443,8 +449,8 @@ impl SmConnectionInviter {
     pub fn handle_ack(self, ack: Ack) -> VcxResult<Self> {
         let Self { source_id, pairwise_info, state } = self;
         let state = match state {
-            InviterState::Responded(state) => {
-                InviterState::Completed((state, ack).into())
+            InviterFullState::Responded(state) => {
+                InviterFullState::Completed((state, ack).into())
             }
             _ => {
                 state.clone()
@@ -523,7 +529,7 @@ pub mod test {
 
                 let inviter_sm = inviter_sm();
 
-                assert_match!(InviterState::Null(_), inviter_sm.state);
+                assert_match!(InviterFullState::Null(_), inviter_sm.state);
                 assert_eq!(source_id(), inviter_sm.source_id());
             }
         }
@@ -539,7 +545,7 @@ pub mod test {
                 let _setup = SetupIndyMocks::init();
 
                 let did_exchange_sm = inviter_sm();
-                assert_match!(InviterState::Null(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Null(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -553,7 +559,7 @@ pub mod test {
                 let service_endpoint = String::from("https://example.org/agent");
                 did_exchange_sm = did_exchange_sm.handle_connect(routing_keys, service_endpoint).unwrap();
 
-                assert_match!(InviterState::Invited(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Invited(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -564,10 +570,10 @@ pub mod test {
                 let mut did_exchange_sm = inviter_sm();
 
                 did_exchange_sm = did_exchange_sm.handle_ack(_ack()).unwrap();
-                assert_match!(InviterState::Null(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Null(_), did_exchange_sm.state);
 
                 did_exchange_sm = did_exchange_sm.handle_problem_report(_problem_report()).unwrap();
-                assert_match!(InviterState::Null(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Null(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -583,7 +589,7 @@ pub mod test {
                 let new_service_endpoint = String::from("https://example.org/agent");
                 did_exchange_sm = did_exchange_sm.handle_connection_request(_request(), &new_pairwise_info, new_routing_keys, new_service_endpoint).unwrap();
                 did_exchange_sm = did_exchange_sm.handle_send_response().unwrap();
-                assert_match!(InviterState::Responded(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Responded(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -601,7 +607,7 @@ pub mod test {
                 let new_service_endpoint = String::from("https://example.org/agent");
                 did_exchange_sm = did_exchange_sm.handle_connection_request(request, &new_pairwise_info, new_routing_keys, new_service_endpoint).unwrap();
 
-                assert_match!(InviterState::Null(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Null(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -613,7 +619,7 @@ pub mod test {
 
                 did_exchange_sm = did_exchange_sm.handle_problem_report(_problem_report()).unwrap();
 
-                assert_match!(InviterState::Null(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Null(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -626,10 +632,10 @@ pub mod test {
                 let routing_keys: Vec<String> = vec!("verkey123".into());
                 let service_endpoint = String::from("https://example.org/agent");
                 did_exchange_sm = did_exchange_sm.handle_connect(routing_keys, service_endpoint).unwrap();
-                assert_match!(InviterState::Invited(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Invited(_), did_exchange_sm.state);
 
                 did_exchange_sm = did_exchange_sm.handle_ack(_ack()).unwrap();
-                assert_match!(InviterState::Invited(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Invited(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -641,7 +647,7 @@ pub mod test {
 
                 did_exchange_sm = did_exchange_sm.handle_ack(_ack()).unwrap();
 
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -653,7 +659,7 @@ pub mod test {
 
                 did_exchange_sm = did_exchange_sm.handle_ping(_ping()).unwrap();
 
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -665,7 +671,7 @@ pub mod test {
 
                 did_exchange_sm = did_exchange_sm.handle_problem_report(_problem_report()).unwrap();
 
-                assert_match!(InviterState::Null(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Null(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -679,7 +685,7 @@ pub mod test {
                 let service_endpoint = String::from("https://example.org/agent");
                 did_exchange_sm = did_exchange_sm.handle_connect(routing_keys, service_endpoint).unwrap();
 
-                assert_match!(InviterState::Responded(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Responded(_), did_exchange_sm.state);
             }
 
             #[test]
@@ -691,40 +697,40 @@ pub mod test {
 
                 // Send Ping
                 did_exchange_sm = did_exchange_sm.handle_send_ping(None).unwrap();
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
 
                 // Ping
                 did_exchange_sm = did_exchange_sm.handle_ping(_ping()).unwrap();
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
 
                 // Ping Response
                 did_exchange_sm = did_exchange_sm.handle_ping_response(_ping_response()).unwrap();
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
 
                 // Discovery Features
                 did_exchange_sm = did_exchange_sm.handle_discover_features(None, None).unwrap();
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
 
                 // Query
                 did_exchange_sm = did_exchange_sm.handle_discovery_query(_query()).unwrap();
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
 
                 // Disclose
                 assert!(did_exchange_sm.get_remote_protocols().is_none());
 
                 did_exchange_sm = did_exchange_sm.handle_disclose(_disclose()).unwrap();
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
 
                 assert!(did_exchange_sm.get_remote_protocols().is_some());
 
                 // ignore
                 // Ack
                 did_exchange_sm = did_exchange_sm.handle_ack(_ack()).unwrap();
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
 
                 // Problem Report
                 did_exchange_sm = did_exchange_sm.handle_problem_report(_problem_report()).unwrap();
-                assert_match!(InviterState::Completed(_), did_exchange_sm.state);
+                assert_match!(InviterFullState::Completed(_), did_exchange_sm.state);
             }
         }
 
@@ -927,10 +933,10 @@ pub mod test {
             fn test_get_state() {
                 let _setup = SetupMocks::init();
 
-                assert_eq!(VcxStateType::VcxStateNone as u32, inviter_sm().state());
-                assert_eq!(VcxStateType::VcxStateInitialized as u32, inviter_sm().to_inviter_invited_state().state());
-                assert_eq!(VcxStateType::VcxStateRequestReceived as u32, inviter_sm().to_inviter_responded_state().state());
-                assert_eq!(VcxStateType::VcxStateAccepted as u32, inviter_sm().to_inviter_completed_state().state());
+                assert_eq!(InviterState::Null, inviter_sm().state());
+                assert_eq!(InviterState::Invited, inviter_sm().to_inviter_invited_state().state());
+                assert_eq!(InviterState::Responded, inviter_sm().to_inviter_responded_state().state());
+                assert_eq!(InviterState::Completed, inviter_sm().to_inviter_completed_state().state());
             }
         }
     }

--- a/libvcx/src/aries/handlers/connection/mod.rs
+++ b/libvcx/src/aries/handlers/connection/mod.rs
@@ -2,7 +2,7 @@ pub mod pairwise_info;
 pub mod cloud_agent;
 pub mod legacy_agent_info;
 pub mod connection;
-mod invitee;
-mod inviter;
+pub mod invitee;
+pub mod inviter;
 mod util;
 

--- a/libvcx/src/connection.rs
+++ b/libvcx/src/connection.rs
@@ -62,7 +62,7 @@ pub fn get_their_pw_verkey(handle: u32) -> VcxResult<String> {
 pub fn get_state(handle: u32) -> u32 {
     trace!("get_state >>> handle = {:?}", handle);
     CONNECTION_MAP.get(handle, |connection| {
-        Ok(connection.state().into())
+        Ok(connection.get_state().into())
     }).unwrap_or(0)
 }
 

--- a/libvcx/src/connection.rs
+++ b/libvcx/src/connection.rs
@@ -4,7 +4,7 @@ use serde_json;
 
 use agency_client;
 use agency_client::{MessageStatusCode};
-use agency_client::get_message::{Message, MessageByConnection};
+use agency_client::get_message::MessageByConnection;
 
 use crate::aries::handlers::connection::pairwise_info::PairwiseInfo;
 use crate::aries::handlers::connection::connection::{Connection, SmConnectionState};
@@ -14,8 +14,6 @@ use crate::error::prelude::*;
 use crate::utils::error;
 use crate::utils::object_cache::ObjectCache;
 use crate::aries::handlers::connection::cloud_agent::CloudAgentInfo;
-use crate::aries::handlers::connection::legacy_agent_info::LegacyAgentInfo;
-use crate::utils::serialization::SerializableObjectWithState;
 
 lazy_static! {
     static ref CONNECTION_MAP: ObjectCache<Connection> = ObjectCache::<Connection>::new("connections-cache");
@@ -64,7 +62,7 @@ pub fn get_their_pw_verkey(handle: u32) -> VcxResult<String> {
 pub fn get_state(handle: u32) -> u32 {
     trace!("get_state >>> handle = {:?}", handle);
     CONNECTION_MAP.get(handle, |connection| {
-        Ok(connection.state())
+        Ok(connection.state().into())
     }).unwrap_or(0)
 }
 

--- a/libvcx/src/lib.rs
+++ b/libvcx/src/lib.rs
@@ -49,6 +49,7 @@ pub mod disclosed_proof;
 pub mod aries;
 mod filters;
 pub mod libindy;
+pub mod abi_utils;
 
 #[allow(unused_imports)]
 #[allow(dead_code)]

--- a/libvcx/src/utils/devsetup_agent.rs
+++ b/libvcx/src/utils/devsetup_agent.rs
@@ -192,7 +192,7 @@ pub mod test {
             self.activate().unwrap();
             self.connection.connect().unwrap();
             self.connection.update_state().unwrap();
-            assert_eq!(ConnectionState::Inviter(InviterState::Invited), self.connection.state());
+            assert_eq!(ConnectionState::Inviter(InviterState::Invited), self.connection.get_state());
 
             json!(self.connection.get_invite_details().unwrap()).to_string()
         }
@@ -200,7 +200,7 @@ pub mod test {
         pub fn update_state(&mut self, expected_state: u32) {
             self.activate().unwrap();
             self.connection.update_state().unwrap();
-            assert_eq!(expected_state, u32::from(self.connection.state()));
+            assert_eq!(expected_state, u32::from(self.connection.get_state()));
         }
 
         pub fn ping(&mut self) {
@@ -338,13 +338,13 @@ pub mod test {
             self.connection = Connection::create_with_invite("faber", serde_json::from_str(invite).unwrap(), true).unwrap();
             self.connection.connect().unwrap();
             self.connection.update_state().unwrap();
-            assert_eq!(ConnectionState::Invitee(InviteeState::Requested), self.connection.state());
+            assert_eq!(ConnectionState::Invitee(InviteeState::Requested), self.connection.get_state());
         }
 
         pub fn update_state(&mut self, expected_state: u32) {
             self.activate().unwrap();
             self.connection.update_state().unwrap();
-            assert_eq!(expected_state, u32::from(self.connection.state()));
+            assert_eq!(expected_state, u32::from(self.connection.get_state()));
         }
 
         pub fn download_message(&mut self, message_type: PayloadKinds) -> VcxResult<VcxAgencyMessage> {

--- a/libvcx/src/utils/devsetup_agent.rs
+++ b/libvcx/src/utils/devsetup_agent.rs
@@ -13,7 +13,9 @@ pub mod test {
     use crate::utils::provision::{provision_cloud_agent, AgentProvisionConfig, AgencyClientConfig};
     use crate::init::{open_as_main_wallet, init_issuer_config, create_agency_client_for_main_wallet};
     use crate::utils::constants;
-    use crate::aries::handlers::connection::connection::Connection;
+    use crate::aries::handlers::connection::connection::{Connection, ConnectionState};
+    use crate::aries::handlers::connection::invitee::state_machine::InviteeState;
+    use crate::aries::handlers::connection::inviter::state_machine::InviterState;
 
     #[derive(Debug)]
     pub struct VcxAgencyMessage {
@@ -190,7 +192,7 @@ pub mod test {
             self.activate().unwrap();
             self.connection.connect().unwrap();
             self.connection.update_state().unwrap();
-            assert_eq!(1, self.connection.state());
+            assert_eq!(ConnectionState::Inviter(InviterState::Invited), self.connection.state());
 
             json!(self.connection.get_invite_details().unwrap()).to_string()
         }
@@ -198,7 +200,7 @@ pub mod test {
         pub fn update_state(&mut self, expected_state: u32) {
             self.activate().unwrap();
             self.connection.update_state().unwrap();
-            assert_eq!(expected_state, self.connection.state());
+            assert_eq!(expected_state, u32::from(self.connection.state()));
         }
 
         pub fn ping(&mut self) {
@@ -336,13 +338,13 @@ pub mod test {
             self.connection = Connection::create_with_invite("faber", serde_json::from_str(invite).unwrap(), true).unwrap();
             self.connection.connect().unwrap();
             self.connection.update_state().unwrap();
-            assert_eq!(2, self.connection.state());
+            assert_eq!(ConnectionState::Invitee(InviteeState::Invited), self.connection.state());
         }
 
         pub fn update_state(&mut self, expected_state: u32) {
             self.activate().unwrap();
             self.connection.update_state().unwrap();
-            assert_eq!(expected_state, self.connection.state());
+            assert_eq!(expected_state, u32::from(self.connection.state()));
         }
 
         pub fn download_message(&mut self, message_type: PayloadKinds) -> VcxResult<VcxAgencyMessage> {

--- a/libvcx/src/utils/devsetup_agent.rs
+++ b/libvcx/src/utils/devsetup_agent.rs
@@ -338,7 +338,7 @@ pub mod test {
             self.connection = Connection::create_with_invite("faber", serde_json::from_str(invite).unwrap(), true).unwrap();
             self.connection.connect().unwrap();
             self.connection.update_state().unwrap();
-            assert_eq!(ConnectionState::Invitee(InviteeState::Invited), self.connection.state());
+            assert_eq!(ConnectionState::Invitee(InviteeState::Requested), self.connection.state());
         }
 
         pub fn update_state(&mut self, expected_state: u32) {


### PR DESCRIPTION
Replaces `u32` representation of AriesFMS states by enums (which do not contain complete copy of state details).  u32 representation of FSM state exists only so it could be used on C ABI layer and therefore it should also be expressed in that layer.

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>