### PR TITLE
Revert rust version to 1.45.2, release aries-vcx 0.18.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.52.1
+          toolchain: 1.45.2
       - name: Set outputs
         id: mainstep
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "libvcx"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "agency_client",
  "android_logger",

--- a/agents/node/vcxagent-core/package.json
+++ b/agents/node/vcxagent-core/package.json
@@ -67,6 +67,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@hyperledger/node-vcx-wrapper": "^0.18.2"
+    "@hyperledger/node-vcx-wrapper": "^0.18.3"
   }
 }

--- a/ci/alpine_core.dockerfile
+++ b/ci/alpine_core.dockerfile
@@ -22,7 +22,7 @@ RUN apk update && apk upgrade && \
         openssl-dev \
         zeromq-dev
 
-ARG RUST_VER="1.52.1"
+ARG RUST_VER="1.45.2"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
 
 USER indy

--- a/ci/libvcx.dockerfile
+++ b/ci/libvcx.dockerfile
@@ -44,7 +44,7 @@ RUN apk add --no-cache \
         python2 \
         zeromq-dev
 
-ARG RUST_VER="1.52.1"
+ARG RUST_VER="1.45.2"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
 
 USER node

--- a/ci/ubuntu.dockerfile
+++ b/ci/ubuntu.dockerfile
@@ -60,7 +60,7 @@ ARG uid=1000
 RUN useradd -ms /bin/bash -u $uid vcx
 USER vcx
 
-ARG RUST_VER="1.52.1"
+ARG RUST_VER="1.45.2"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
 ENV PATH /home/vcx/.cargo/bin:$PATH
 

--- a/libvcx/Cargo.toml
+++ b/libvcx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libvcx"
-version = "0.18.2"
+version = "0.18.3"
 authors = ["Absa Group Limited", "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>"]
 publish = false
 description = "Absa's fork of HL LibVCX"

--- a/wrappers/ios/ci/build.sh
+++ b/wrappers/ios/ci/build.sh
@@ -23,7 +23,7 @@ INDY_SDK_DIR=$OUTPUT_DIR/indy-sdk
 
 setup() {
     echo "Setup rustup"
-    rustup default 1.52.1
+    rustup default 1.45.2
     rustup component add rls-preview rust-analysis rust-src
 
     echo "Setup rustup target platforms"

--- a/wrappers/java/ci/android.dockerfile
+++ b/wrappers/java/ci/android.dockerfile
@@ -51,7 +51,7 @@ RUN apt-get install -y nodejs
 USER indy
 
 # Install Rust toolchain
-ARG RUST_VER=1.52.1
+ARG RUST_VER=1.45.2
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VER}
 ENV PATH /home/indy/.cargo/bin:$PATH
 


### PR DESCRIPTION
###
- It appears like after upgrading to Rust 1.52.1, we run into a strange issue on iOS where `create_wallet` operating just kind of hangs forever, as if it never executed the callback.
- Downgrade to previously 1.45.2 seems to fix this issue
- Will try to upgrade Rust in next releases to see if (or which) version of rustc introduces this issue

### 
- Release 0.18.3

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>