### PR TITLE
Make send_message implementation pluggable for Connection FSM

### DIFF
--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -731,7 +731,8 @@ impl<'de> Visitor<'de> for ConnectionVisitor {
             map_value.insert(k, v);
         }
         let obj = Value::from(map_value);
-        let ver: SerializableObjectWithState<LegacyAgentInfo, SmConnectionState> = serde_json::from_value(obj).unwrap();
+        let ver: SerializableObjectWithState<LegacyAgentInfo, SmConnectionState> = serde_json::from_value(obj)
+            .map_err(|err| A::Error::custom(err.to_string()))?;
         match ver {
             SerializableObjectWithState::V1 { data, state, source_id } => {
                 let pairwise_info = PairwiseInfo { pw_did: data.pw_did, pw_vk: data.pw_vk };

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -793,7 +793,7 @@ pub mod tests {
     fn test_deserialize_and_serialize(sm_serialized: &str) {
         let original_object: Value = serde_json::from_str(sm_serialized).unwrap();
         let connection = Connection::from_string(sm_serialized).unwrap();
-        let reserialized = connection.to_string();
+        let reserialized = connection.to_string().unwrap();
         let reserialized_object: Value = serde_json::from_str(&reserialized).unwrap();
 
         assert_eq!(original_object, reserialized_object);
@@ -816,10 +816,10 @@ pub mod tests {
         let _setup = SetupMocks::init();
 
         let connection = Connection::create("test_serialize_deserialize", true).unwrap();
-        let first_string = connection.to_string();
+        let first_string = connection.to_string().unwrap();
 
         let connection2 = Connection::from_string(&first_string).unwrap();
-        let second_string = connection2.to_string();
+        let second_string = connection2.to_string().unwrap();
 
         assert_eq!(first_string, second_string);
     }

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -15,15 +15,16 @@ use crate::aries::messages::connection::invite::Invitation;
 use crate::aries::messages::discovery::disclose::ProtocolDescriptor;
 use crate::error::prelude::*;
 use crate::utils::serialization::SerializableObjectWithState;
+use crate::aries::utils::send_message;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone)]
 pub struct Connection {
     connection_sm: SmConnection,
     cloud_agent_info: CloudAgentInfo,
     autohop_enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone)]
 pub enum SmConnection {
     Inviter(SmConnectionInviter),
     Invitee(SmConnectionInvitee),
@@ -107,7 +108,7 @@ impl Connection {
             SmConnectionState::Inviter(state) => {
                 Connection {
                     cloud_agent_info,
-                    connection_sm: SmConnection::Inviter(SmConnectionInviter::from(source_id, pairwise_info, state)),
+                    connection_sm: SmConnection::Inviter(SmConnectionInviter::from(source_id, pairwise_info, state, send_message)),
                     autohop_enabled,
                 }
             }

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -80,12 +80,9 @@ impl Connection {
         trace!("Connection::create >>> source_id: {}", source_id);
         let pairwise_info = PairwiseInfo::create()?;
         let cloud_agent_info = CloudAgentInfo::create(&pairwise_info)?;
-        let routing_keys = cloud_agent_info.routing_keys()?;
-        let agency_endpoint = cloud_agent_info.service_endpoint()?;
-
         Ok(Connection {
             cloud_agent_info,
-            connection_sm: SmConnection::Inviter(SmConnectionInviter::new(source_id, pairwise_info)),
+            connection_sm: SmConnection::Inviter(SmConnectionInviter::new(source_id, pairwise_info, send_message)),
             autohop_enabled: autohop,
         })
     }
@@ -97,12 +94,9 @@ impl Connection {
         trace!("Connection::create_with_invite >>> source_id: {}", source_id);
         let pairwise_info = PairwiseInfo::create()?;
         let cloud_agent_info = CloudAgentInfo::create(&pairwise_info)?;
-        let routing_keys = cloud_agent_info.routing_keys()?;
-        let agency_endpoint = cloud_agent_info.service_endpoint()?;
-
         let mut connection = Connection {
             cloud_agent_info,
-            connection_sm: SmConnection::Invitee(SmConnectionInvitee::new(source_id, pairwise_info)),
+            connection_sm: SmConnection::Invitee(SmConnectionInvitee::new(source_id, pairwise_info, send_message)),
             autohop_enabled,
         };
         connection.process_invite(invitation)?;

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -115,7 +115,7 @@ impl Connection {
             SmConnectionState::Invitee(state) => {
                 Connection {
                     cloud_agent_info,
-                    connection_sm: SmConnection::Invitee(SmConnectionInvitee::from(source_id, pairwise_info, state)),
+                    connection_sm: SmConnection::Invitee(SmConnectionInvitee::from(source_id, pairwise_info, state, send_message)),
                     autohop_enabled,
                 }
             }
@@ -578,7 +578,7 @@ Get messages received from connection counterparty.
             .ok_or(VcxError::from_msg(VcxErrorKind::NotReady, "Cannot send message: Remote Connection information is not set"))?;
         let sender_vk = self.pairwise_info().pw_vk.clone();
         return Ok(move |a2a_message: &A2AMessage| {
-            did_doc.send_message(a2a_message, &sender_vk)
+            send_message(&sender_vk, &did_doc, a2a_message)
         });
     }
 

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -1,11 +1,17 @@
+use core::fmt;
 use std::collections::HashMap;
+use std::fmt::{Formatter, Write};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::{EnumAccess, Error, MapAccess, SeqAccess, Unexpected, Visitor};
+use serde_json::Value;
 
 use agency_client::get_message::{Message, MessageByConnection};
 use agency_client::MessageStatusCode;
 
 use crate::aries::handlers::connection::cloud_agent::CloudAgentInfo;
-use crate::aries::handlers::connection::invitee::state_machine::{InviteeFullState, SmConnectionInvitee, InviteeState};
-use crate::aries::handlers::connection::inviter::state_machine::{InviterFullState, SmConnectionInviter, InviterState};
+use crate::aries::handlers::connection::invitee::state_machine::{InviteeFullState, InviteeState, SmConnectionInvitee};
+use crate::aries::handlers::connection::inviter::state_machine::{InviterFullState, InviterState, SmConnectionInviter};
 use crate::aries::handlers::connection::legacy_agent_info::LegacyAgentInfo;
 use crate::aries::handlers::connection::pairwise_info::PairwiseInfo;
 use crate::aries::messages::a2a::A2AMessage;
@@ -13,14 +19,9 @@ use crate::aries::messages::basic_message::message::BasicMessage;
 use crate::aries::messages::connection::did_doc::DidDoc;
 use crate::aries::messages::connection::invite::Invitation;
 use crate::aries::messages::discovery::disclose::ProtocolDescriptor;
+use crate::aries::utils::send_message;
 use crate::error::prelude::*;
 use crate::utils::serialization::SerializableObjectWithState;
-use crate::aries::utils::send_message;
-use serde::{Serialize, Serializer, Deserializer, Deserialize};
-use serde::de::{Visitor, Unexpected, Error, MapAccess, SeqAccess, EnumAccess};
-use std::fmt::{Formatter, Write};
-use core::fmt;
-use serde_json::Value;
 
 #[derive(Clone)]
 pub struct Connection {
@@ -50,7 +51,7 @@ struct ConnectionInfo {
 #[derive(Debug, PartialEq)]
 pub enum ConnectionState {
     Inviter(InviterState),
-    Invitee(InviteeState)
+    Invitee(InviteeState),
 }
 
 

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -690,9 +690,8 @@ Get messages received from connection counterparty.
     }
 
     pub fn from_string(connection_data: &str) -> VcxResult<Connection> {
-        let conn = serde_json::from_str(connection_data)
-            .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot deserialize Connection: {:?}", err)))?;
-        Ok(conn)
+        serde_json::from_str(connection_data)
+            .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot deserialize Connection: {:?}", err)))
     }
 }
 

--- a/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
@@ -21,7 +21,7 @@ use crate::aries::messages::trust_ping::ping_response::PingResponse;
 use crate::error::prelude::*;
 use crate::aries::handlers::connection::inviter::state_machine::InviterState;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone)]
 pub struct SmConnectionInvitee {
     source_id: String,
     pairwise_info: PairwiseInfo,

--- a/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
@@ -5,6 +5,7 @@ use crate::aries::handlers::connection::invitee::states::invited::InvitedState;
 use crate::aries::handlers::connection::invitee::states::null::NullState;
 use crate::aries::handlers::connection::invitee::states::requested::RequestedState;
 use crate::aries::handlers::connection::invitee::states::responded::RespondedState;
+use crate::aries::handlers::connection::inviter::state_machine::InviterState;
 use crate::aries::handlers::connection::pairwise_info::PairwiseInfo;
 use crate::aries::messages::a2a::A2AMessage;
 use crate::aries::messages::a2a::protocol_registry::ProtocolRegistry;
@@ -19,7 +20,6 @@ use crate::aries::messages::discovery::query::Query;
 use crate::aries::messages::trust_ping::ping::Ping;
 use crate::aries::messages::trust_ping::ping_response::PingResponse;
 use crate::error::prelude::*;
-use crate::aries::handlers::connection::inviter::state_machine::InviterState;
 
 #[derive(Clone)]
 pub struct SmConnectionInvitee {
@@ -70,7 +70,7 @@ impl SmConnectionInvitee {
     }
 
     pub fn is_in_null_state(&self) -> bool {
-        return InviteeState::from(self.state.clone()) == InviteeState::Null
+        return InviteeState::from(self.state.clone()) == InviteeState::Null;
     }
 
     pub fn from(source_id: String, pairwise_info: PairwiseInfo, state: InviteeFullState, send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>) -> Self {

--- a/libvcx/src/aries/handlers/connection/invitee/states/complete.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/states/complete.rs
@@ -1,6 +1,7 @@
 use crate::aries::handlers::connection::invitee::states::requested::RequestedState;
 use crate::aries::handlers::connection::invitee::states::responded::RespondedState;
 use crate::aries::handlers::connection::util::handle_ping;
+use crate::aries::messages::a2a::A2AMessage;
 use crate::aries::messages::a2a::protocol_registry::ProtocolRegistry;
 use crate::aries::messages::connection::did_doc::DidDoc;
 use crate::aries::messages::connection::response::Response;
@@ -8,7 +9,6 @@ use crate::aries::messages::discovery::disclose::{Disclose, ProtocolDescriptor};
 use crate::aries::messages::discovery::query::Query;
 use crate::aries::messages::trust_ping::ping::Ping;
 use crate::error::VcxResult;
-use crate::aries::messages::a2a::A2AMessage;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompleteState {
@@ -41,7 +41,7 @@ impl CompleteState {
     pub fn handle_send_ping(&self,
                             comment: Option<String>,
                             pw_vk: &str,
-                            send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+                            send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
         let ping =
             Ping::create()
@@ -55,7 +55,7 @@ impl CompleteState {
     pub fn handle_ping(&self,
                        ping: &Ping,
                        pw_vk: &str,
-                       send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+                       send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
         handle_ping(ping, pw_vk, &self.did_doc, send_message)
     }
@@ -64,7 +64,7 @@ impl CompleteState {
                                     query: Option<String>,
                                     comment: Option<String>,
                                     pw_vk: &str,
-                                    send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+                                    send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
         let query_ =
             Query::create()
@@ -76,7 +76,7 @@ impl CompleteState {
     pub fn handle_discovery_query(&self,
                                   query: Query,
                                   pw_vk: &str,
-                                  send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+                                  send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
         let protocols = ProtocolRegistry::init().get_protocols_for_query(query.query.as_ref().map(String::as_str));
 

--- a/libvcx/src/aries/handlers/connection/invitee/states/complete.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/states/complete.rs
@@ -8,6 +8,7 @@ use crate::aries::messages::discovery::disclose::{Disclose, ProtocolDescriptor};
 use crate::aries::messages::discovery::query::Query;
 use crate::aries::messages::trust_ping::ping::Ping;
 use crate::error::VcxResult;
+use crate::aries::messages::a2a::A2AMessage;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompleteState {
@@ -37,35 +38,52 @@ impl From<(RespondedState, Response)> for CompleteState {
 }
 
 impl CompleteState {
-    pub fn handle_send_ping(&self, comment: Option<String>, pw_vk: &str) -> VcxResult<()> {
+    pub fn handle_send_ping(&self,
+                            comment: Option<String>,
+                            pw_vk: &str,
+                            send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+    ) -> VcxResult<()> {
         let ping =
             Ping::create()
                 .request_response()
                 .set_comment(comment);
 
-        self.did_doc.send_message(&ping.to_a2a_message(), pw_vk).ok();
+        send_message(pw_vk, &self.did_doc, &ping.to_a2a_message()).ok();
         Ok(())
     }
 
-    pub fn handle_ping(&self, ping: &Ping, pw_vk: &str) -> VcxResult<()> {
-        handle_ping(ping, pw_vk, &self.did_doc)
+    pub fn handle_ping(&self,
+                       ping: &Ping,
+                       pw_vk: &str,
+                       send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+    ) -> VcxResult<()> {
+        handle_ping(ping, pw_vk, &self.did_doc, send_message)
     }
 
-    pub fn handle_discover_features(&self, query: Option<String>, comment: Option<String>, pw_vk: &str) -> VcxResult<()> {
+    pub fn handle_discover_features(&self,
+                                    query: Option<String>,
+                                    comment: Option<String>,
+                                    pw_vk: &str,
+                                    send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+    ) -> VcxResult<()> {
         let query_ =
             Query::create()
                 .set_query(query)
                 .set_comment(comment);
-        self.did_doc.send_message(&query_.to_a2a_message(), pw_vk)
+        send_message(pw_vk, &self.did_doc, &query_.to_a2a_message())
     }
 
-    pub fn handle_discovery_query(&self, query: Query, pw_vk: &str) -> VcxResult<()> {
+    pub fn handle_discovery_query(&self,
+                                  query: Query,
+                                  pw_vk: &str,
+                                  send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+    ) -> VcxResult<()> {
         let protocols = ProtocolRegistry::init().get_protocols_for_query(query.query.as_ref().map(String::as_str));
 
         let disclose = Disclose::create()
             .set_protocols(protocols)
             .set_thread_id(query.id.0.clone());
 
-        self.did_doc.send_message(&disclose.to_a2a_message(), pw_vk)
+        send_message(pw_vk, &self.did_doc, &disclose.to_a2a_message())
     }
 }

--- a/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use crate::api::VcxStateType;
 use crate::aries::handlers::connection::inviter::states::complete::CompleteState;
 use crate::aries::handlers::connection::inviter::states::invited::InvitedState;
 use crate::aries::handlers::connection::inviter::states::null::NullState;
@@ -21,11 +20,12 @@ use crate::aries::messages::trust_ping::ping::Ping;
 use crate::aries::messages::trust_ping::ping_response::PingResponse;
 use crate::error::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone)]
 pub struct SmConnectionInviter {
     pub source_id: String,
     pub pairwise_info: PairwiseInfo,
     pub state: InviterFullState,
+    send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,23 +59,25 @@ impl From<InviterFullState> for InviterState {
 }
 
 impl SmConnectionInviter {
-    pub fn new(source_id: &str, pairwise_info: PairwiseInfo) -> Self {
+    pub fn new(source_id: &str, pairwise_info: PairwiseInfo, send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>) -> Self {
         Self {
             source_id: source_id.to_string(),
             state: InviterFullState::Null(NullState {}),
             pairwise_info,
+            send_message,
         }
     }
 
     pub fn is_in_null_state(&self) -> bool {
-        return InviterState::from(self.state.clone()) == InviterState::Null
+        return InviterState::from(self.state.clone()) == InviterState::Null;
     }
 
-    pub fn from(source_id: String, pairwise_info: PairwiseInfo, state: InviterFullState) -> Self {
+    pub fn from(source_id: String, pairwise_info: PairwiseInfo, state: InviterFullState, send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>) -> Self {
         Self {
             source_id,
             pairwise_info,
             state,
+            send_message,
         }
     }
 
@@ -245,13 +247,14 @@ impl SmConnectionInviter {
     fn _send_response(
         state: &RequestedState,
         new_pw_vk: &str,
+        send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
-        state.did_doc.send_message(&state.signed_response.to_a2a_message(), &new_pw_vk)?;
+        send_message(&new_pw_vk, &state.did_doc, &state.signed_response.to_a2a_message())?;
         Ok(())
     }
 
     pub fn handle_connect(self, routing_keys: Vec<String>, service_endpoint: String) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Null(state) => {
                 let invite: Invitation = Invitation::create()
@@ -267,7 +270,7 @@ impl SmConnectionInviter {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 
 
@@ -276,7 +279,7 @@ impl SmConnectionInviter {
                                      new_pairwise_info: &PairwiseInfo,
                                      new_routing_keys: Vec<String>,
                                      new_service_endpoint: String) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info: bootstrap_pairwise_info, state } = self;
+        let Self { source_id, pairwise_info: bootstrap_pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Invited(state) => {
                 match Self::_build_response(
@@ -294,10 +297,10 @@ impl SmConnectionInviter {
                             .set_explain(err.to_string())
                             .set_thread_id(&request.id.0);
 
-                        request.connection.did_doc.send_message(
-                            &problem_report.to_a2a_message(),
+                        send_message(
                             &bootstrap_pairwise_info.pw_vk,
-                        ).ok();
+                            &request.connection.did_doc,
+                            &problem_report.to_a2a_message()).ok();
                         InviterFullState::Null((state, problem_report).into())
                     }
                 }
@@ -306,11 +309,11 @@ impl SmConnectionInviter {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info: new_pairwise_info.clone(), state })
+        Ok(Self { source_id, pairwise_info: new_pairwise_info.clone(), state, send_message })
     }
 
     pub fn handle_ping(self, ping: Ping) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Responded(state) => {
                 state.handle_ping(&ping, &pairwise_info.pw_vk)?;
@@ -324,11 +327,11 @@ impl SmConnectionInviter {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 
     pub fn handle_send_ping(self, comment: Option<String>) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Responded(state) => {
                 let ping =
@@ -336,22 +339,22 @@ impl SmConnectionInviter {
                         .request_response()
                         .set_comment(comment);
 
-                state.did_doc.send_message(&ping.to_a2a_message(), &pairwise_info.pw_vk).ok();
+                send_message(&pairwise_info.pw_vk, &state.did_doc, &ping.to_a2a_message()).ok();
                 InviterFullState::Responded(state)
             }
             InviterFullState::Completed(state) => {
-                state.handle_send_ping(comment, &pairwise_info.pw_vk)?;
+                state.handle_send_ping(comment, &pairwise_info.pw_vk, send_message)?;
                 InviterFullState::Completed(state)
             }
             _ => {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 
     pub fn handle_ping_response(self, ping_response: PingResponse) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Responded(state) => {
                 InviterFullState::Completed((state, ping_response).into())
@@ -360,39 +363,39 @@ impl SmConnectionInviter {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 
     pub fn handle_discover_features(self, query_: Option<String>, comment: Option<String>) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Completed(state) => {
-                state.handle_discover_features(query_, comment, &pairwise_info.pw_vk)?;
+                state.handle_discover_features(query_, comment, &pairwise_info.pw_vk, send_message)?;
                 InviterFullState::Completed(state)
             }
             _ => {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 
     pub fn handle_discovery_query(self, query: Query) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Completed(state) => {
-                state.handle_discovery_query(query, &pairwise_info.pw_vk)?;
+                state.handle_discovery_query(query, &pairwise_info.pw_vk, send_message)?;
                 InviterFullState::Completed(state)
             }
             _ => {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 
     pub fn handle_disclose(self, disclose: Disclose) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Completed(state) => {
                 InviterFullState::Completed((state.clone(), disclose.protocols).into())
@@ -401,11 +404,11 @@ impl SmConnectionInviter {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 
     pub fn handle_problem_report(self, problem_report: ProblemReport) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Responded(state) => {
                 InviterFullState::Null((state, problem_report).into())
@@ -417,14 +420,14 @@ impl SmConnectionInviter {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 
     pub fn handle_send_response(self) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Requested(state) => {
-                match Self::_send_response(&state, &pairwise_info.pw_vk.clone()) {
+                match Self::_send_response(&state, &pairwise_info.pw_vk.clone(), send_message) {
                     Ok(_) => {
                         InviterFullState::Responded(state.into())
                     }
@@ -436,18 +439,18 @@ impl SmConnectionInviter {
                             .set_explain(err.to_string())
                             .set_thread_id(&state.thread_id);
 
-                        state.did_doc.send_message(&problem_report.to_a2a_message(), &pairwise_info.pw_vk).ok();
+                        send_message(&pairwise_info.pw_vk, &state.did_doc, &problem_report.to_a2a_message()).ok();
                         InviterFullState::Null((state, problem_report).into())
                     }
                 }
             }
             _ => state.clone()
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 
     pub fn handle_ack(self, ack: Ack) -> VcxResult<Self> {
-        let Self { source_id, pairwise_info, state } = self;
+        let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Responded(state) => {
                 InviterFullState::Completed((state, ack).into())
@@ -456,7 +459,7 @@ impl SmConnectionInviter {
                 state.clone()
             }
         };
-        Ok(Self { source_id, pairwise_info, state })
+        Ok(Self { source_id, pairwise_info, state, send_message })
     }
 }
 
@@ -478,9 +481,14 @@ pub mod test {
     pub mod inviter {
         use super::*;
 
+        fn _send_message(pv_wk: &str, did_doc: &DidDoc, a2a_message: &A2AMessage) -> VcxResult<()> {
+            VcxResult::Ok(())
+        }
+
+
         pub fn inviter_sm() -> SmConnectionInviter {
             let pairwise_info = PairwiseInfo::create().unwrap();
-            SmConnectionInviter::new(&source_id(), pairwise_info)
+            SmConnectionInviter::new(&source_id(), pairwise_info, _send_message)
         }
 
         impl SmConnectionInviter {

--- a/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
@@ -316,11 +316,11 @@ impl SmConnectionInviter {
         let Self { source_id, pairwise_info, state, send_message } = self;
         let state = match state {
             InviterFullState::Responded(state) => {
-                state.handle_ping(&ping, &pairwise_info.pw_vk)?;
+                state.handle_ping(&ping, &pairwise_info.pw_vk, send_message)?;
                 InviterFullState::Completed((state, ping).into())
             }
             InviterFullState::Completed(state) => {
-                state.handle_ping(&ping, &pairwise_info.pw_vk)?;
+                state.handle_ping(&ping, &pairwise_info.pw_vk, send_message)?;
                 InviterFullState::Completed(state)
             }
             _ => {
@@ -484,7 +484,6 @@ pub mod test {
         fn _send_message(pv_wk: &str, did_doc: &DidDoc, a2a_message: &A2AMessage) -> VcxResult<()> {
             VcxResult::Ok(())
         }
-
 
         pub fn inviter_sm() -> SmConnectionInviter {
             let pairwise_info = PairwiseInfo::create().unwrap();

--- a/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
@@ -1,11 +1,11 @@
 use crate::aries::handlers::connection::util::handle_ping;
+use crate::aries::messages::a2a::A2AMessage;
 use crate::aries::messages::a2a::protocol_registry::ProtocolRegistry;
 use crate::aries::messages::connection::did_doc::DidDoc;
 use crate::aries::messages::discovery::disclose::{Disclose, ProtocolDescriptor};
 use crate::aries::messages::discovery::query::Query;
 use crate::aries::messages::trust_ping::ping::Ping;
 use crate::error::VcxResult;
-use crate::aries::messages::a2a::A2AMessage;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompleteState {
@@ -24,7 +24,7 @@ impl CompleteState {
     pub fn handle_send_ping(&self,
                             comment: Option<String>,
                             pw_vk: &str,
-                            send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+                            send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
         let ping =
             Ping::create()
@@ -38,7 +38,7 @@ impl CompleteState {
     pub fn handle_ping(&self,
                        ping: &Ping,
                        pw_vk: &str,
-                       send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+                       send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
         handle_ping(ping, pw_vk, &self.did_doc, send_message)
     }
@@ -47,7 +47,7 @@ impl CompleteState {
                                     query: Option<String>,
                                     comment: Option<String>,
                                     pw_vk: &str,
-                                    send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+                                    send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
         let query_ =
             Query::create()
@@ -60,7 +60,7 @@ impl CompleteState {
     pub fn handle_discovery_query(&self,
                                   query: Query,
                                   pw_vk: &str,
-                                  send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+                                  send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
         let protocols = ProtocolRegistry::init().get_protocols_for_query(query.query.as_ref().map(String::as_str));
 

--- a/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
@@ -5,6 +5,7 @@ use crate::aries::messages::discovery::disclose::{Disclose, ProtocolDescriptor};
 use crate::aries::messages::discovery::query::Query;
 use crate::aries::messages::trust_ping::ping::Ping;
 use crate::error::VcxResult;
+use crate::aries::messages::a2a::A2AMessage;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompleteState {
@@ -20,13 +21,17 @@ impl From<(CompleteState, Vec<ProtocolDescriptor>)> for CompleteState {
 }
 
 impl CompleteState {
-    pub fn handle_send_ping(&self, comment: Option<String>, pw_vk: &str) -> VcxResult<()> {
+    pub fn handle_send_ping(&self,
+                            comment: Option<String>,
+                            pw_vk: &str,
+                            send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+    ) -> VcxResult<()> {
         let ping =
             Ping::create()
                 .request_response()
                 .set_comment(comment);
 
-        self.did_doc.send_message(&ping.to_a2a_message(), pw_vk).ok();
+        send_message(pw_vk, &self.did_doc, &ping.to_a2a_message()).ok();
         Ok(())
     }
 
@@ -34,22 +39,31 @@ impl CompleteState {
         handle_ping(ping, pw_vk, &self.did_doc)
     }
 
-    pub fn handle_discover_features(&self, query: Option<String>, comment: Option<String>, pw_vk: &str) -> VcxResult<()> {
+    pub fn handle_discover_features(&self,
+                                    query: Option<String>,
+                                    comment: Option<String>,
+                                    pw_vk: &str,
+                                    send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+    ) -> VcxResult<()> {
         let query_ =
             Query::create()
                 .set_query(query)
                 .set_comment(comment);
 
-        self.did_doc.send_message(&query_.to_a2a_message(), pw_vk)
+        send_message(pw_vk, &self.did_doc, &query_.to_a2a_message())
     }
 
-    pub fn handle_discovery_query(&self, query: Query, pw_vk: &str) -> VcxResult<()> {
+    pub fn handle_discovery_query(&self,
+                                  query: Query,
+                                  pw_vk: &str,
+                                  send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+    ) -> VcxResult<()> {
         let protocols = ProtocolRegistry::init().get_protocols_for_query(query.query.as_ref().map(String::as_str));
 
         let disclose = Disclose::create()
             .set_protocols(protocols)
             .set_thread_id(query.id.0.clone());
 
-        self.did_doc.send_message(&disclose.to_a2a_message(), pw_vk)
+        send_message(pw_vk, &self.did_doc, &disclose.to_a2a_message())
     }
 }

--- a/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/states/complete.rs
@@ -35,8 +35,12 @@ impl CompleteState {
         Ok(())
     }
 
-    pub fn handle_ping(&self, ping: &Ping, pw_vk: &str) -> VcxResult<()> {
-        handle_ping(ping, pw_vk, &self.did_doc)
+    pub fn handle_ping(&self,
+                       ping: &Ping,
+                       pw_vk: &str,
+                       send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+    ) -> VcxResult<()> {
+        handle_ping(ping, pw_vk, &self.did_doc, send_message)
     }
 
     pub fn handle_discover_features(&self,

--- a/libvcx/src/aries/handlers/connection/inviter/states/responded.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/states/responded.rs
@@ -1,6 +1,7 @@
 use crate::aries::handlers::connection::inviter::states::complete::CompleteState;
 use crate::aries::handlers::connection::inviter::states::null::NullState;
 use crate::aries::handlers::connection::util::handle_ping;
+use crate::aries::messages::a2a::A2AMessage;
 use crate::aries::messages::ack::Ack;
 use crate::aries::messages::connection::did_doc::DidDoc;
 use crate::aries::messages::connection::problem_report::ProblemReport;
@@ -8,7 +9,6 @@ use crate::aries::messages::connection::response::SignedResponse;
 use crate::aries::messages::trust_ping::ping::Ping;
 use crate::aries::messages::trust_ping::ping_response::PingResponse;
 use crate::error::prelude::*;
-use crate::aries::messages::a2a::A2AMessage;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RespondedState {
@@ -49,9 +49,8 @@ impl RespondedState {
     pub fn handle_ping(&self,
                        ping: &Ping,
                        pw_vk: &str,
-                       send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+                       send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>,
     ) -> VcxResult<()> {
         handle_ping(ping, pw_vk, &self.did_doc, send_message)
     }
-
 }

--- a/libvcx/src/aries/handlers/connection/inviter/states/responded.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/states/responded.rs
@@ -8,6 +8,7 @@ use crate::aries::messages::connection::response::SignedResponse;
 use crate::aries::messages::trust_ping::ping::Ping;
 use crate::aries::messages::trust_ping::ping_response::PingResponse;
 use crate::error::prelude::*;
+use crate::aries::messages::a2a::A2AMessage;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RespondedState {
@@ -45,7 +46,12 @@ impl From<(RespondedState, PingResponse)> for CompleteState {
 }
 
 impl RespondedState {
-    pub fn handle_ping(&self, ping: &Ping, pw_vk: &str) -> VcxResult<()> {
-        handle_ping(ping, pw_vk, &self.did_doc)
+    pub fn handle_ping(&self,
+                       ping: &Ping,
+                       pw_vk: &str,
+                       send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+    ) -> VcxResult<()> {
+        handle_ping(ping, pw_vk, &self.did_doc, send_message)
     }
+
 }

--- a/libvcx/src/aries/handlers/connection/util.rs
+++ b/libvcx/src/aries/handlers/connection/util.rs
@@ -2,13 +2,18 @@ use crate::aries::messages::connection::did_doc::DidDoc;
 use crate::aries::messages::trust_ping::ping::Ping;
 use crate::aries::messages::trust_ping::ping_response::PingResponse;
 use crate::error::VcxResult;
+use crate::aries::messages::a2a::A2AMessage;
 
-pub fn handle_ping(ping: &Ping, pw_vk: &str, did_doc: &DidDoc) -> VcxResult<()> {
+pub fn handle_ping(ping: &Ping,
+                   pw_vk: &str,
+                   did_doc: &DidDoc,
+                   send_message: fn(&str, &DidDoc, &A2AMessage) -> VcxResult<()>
+) -> VcxResult<()> {
     if ping.response_requested {
         let ping_response = PingResponse::create().set_thread_id(
             &ping.thread.as_ref().and_then(|thread| thread.thid.clone()).unwrap_or(ping.id.0.clone()));
 
-        did_doc.send_message(&ping_response.to_a2a_message(), pw_vk)?;
+        send_message(pw_vk, &did_doc, &ping_response.to_a2a_message())?;
     }
     Ok(())
 }

--- a/libvcx/src/aries/messages/connection/did_doc.rs
+++ b/libvcx/src/aries/messages/connection/did_doc.rs
@@ -1,8 +1,6 @@
 use url::Url;
 
-use crate::aries::messages::a2a::A2AMessage;
 use crate::aries::messages::connection::invite::Invitation;
-use crate::aries::utils::encryption_envelope::EncryptionEnvelope;
 use crate::error::prelude::*;
 use crate::utils::validation::validate_verkey;
 
@@ -20,8 +18,7 @@ pub struct DidDoc {
     pub id: String,
     #[serde(default)]
     #[serde(rename = "publicKey")]
-    pub public_key: Vec<Ed25519PublicKey>,
-    // TODO: A DID document MAY include a publicKey property??? (https://w3c.github.io/did-core/#public-keys)
+    pub public_key: Vec<Ed25519PublicKey>, // TODO: A DID document MAY include a publicKey property??? (https://w3c.github.io/did-core/#public-keys)
     #[serde(default)]
     pub authentication: Vec<Authentication>,
     pub service: Vec<Service>,
@@ -31,8 +28,7 @@ pub struct DidDoc {
 pub struct Ed25519PublicKey {
     pub id: String,
     #[serde(rename = "type")]
-    pub type_: String,
-    // all list of types: https://w3c-ccg.github.io/ld-cryptosuite-registry/
+    pub type_: String, // all list of types: https://w3c-ccg.github.io/ld-cryptosuite-registry/
     pub controller: String,
     #[serde(rename = "publicKeyBase58")]
     pub public_key_base_58: String,

--- a/libvcx/src/aries/messages/connection/did_doc.rs
+++ b/libvcx/src/aries/messages/connection/did_doc.rs
@@ -1,10 +1,10 @@
-use crate::aries::messages::connection::invite::Invitation;
-
-use crate::error::prelude::*;
 use url::Url;
-use crate::utils::validation::validate_verkey;
+
 use crate::aries::messages::a2a::A2AMessage;
+use crate::aries::messages::connection::invite::Invitation;
 use crate::aries::utils::encryption_envelope::EncryptionEnvelope;
+use crate::error::prelude::*;
+use crate::utils::validation::validate_verkey;
 
 pub const CONTEXT: &str = "https://w3id.org/did/v1";
 pub const KEY_TYPE: &str = "Ed25519VerificationKey2018";
@@ -20,7 +20,8 @@ pub struct DidDoc {
     pub id: String,
     #[serde(default)]
     #[serde(rename = "publicKey")]
-    pub public_key: Vec<Ed25519PublicKey>, // TODO: A DID document MAY include a publicKey property??? (https://w3c.github.io/did-core/#public-keys)
+    pub public_key: Vec<Ed25519PublicKey>,
+    // TODO: A DID document MAY include a publicKey property??? (https://w3c.github.io/did-core/#public-keys)
     #[serde(default)]
     pub authentication: Vec<Authentication>,
     pub service: Vec<Service>,
@@ -30,7 +31,8 @@ pub struct DidDoc {
 pub struct Ed25519PublicKey {
     pub id: String,
     #[serde(rename = "type")]
-    pub type_: String, // all list of types: https://w3c-ccg.github.io/ld-cryptosuite-registry/
+    pub type_: String,
+    // all list of types: https://w3c-ccg.github.io/ld-cryptosuite-registry/
     pub controller: String,
     #[serde(rename = "publicKeyBase58")]
     pub public_key_base_58: String,
@@ -275,26 +277,6 @@ impl DidDoc {
         let pars: Vec<&str> = DidDoc::_key_parts(key_reference);
         pars.get(1).or(pars.get(0)).map(|s| s.to_string()).unwrap_or_default()
     }
-
-    /**
-  Sends authenticated message to connection counterparty
-   */
-    pub fn send_message(&self, message: &A2AMessage, sender_verkey: &str) -> VcxResult<()> {
-        trace!("DidDoc::send_message >>> message: {:?}, did_doc: {:?}", message, &self);
-        let envelope = EncryptionEnvelope::create(&message, Some(sender_verkey), &self)?;
-        agency_client::httpclient::post_message(&envelope.0, &self.get_endpoint())?;
-        Ok(())
-    }
-
-    /**
-    Sends anonymous message to connection counterparty
-     */
-    pub fn send_message_anonymously(&self, message: &A2AMessage) -> VcxResult<()> {
-        trace!("DidDoc::send_message_anonymously >>> message: {:?}, did_doc: {:?}", message, &self);
-        let envelope = EncryptionEnvelope::create(&message, None, &self)?;
-        agency_client::httpclient::post_message(&envelope.0, &self.get_endpoint())?;
-        Ok(())
-    }
 }
 
 impl Default for Service {
@@ -335,9 +317,10 @@ impl From<DidDoc> for Invitation {
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
     use crate::aries::messages::a2a::MessageId;
     use crate::aries::messages::connection::invite::tests::_invitation;
+
+    use super::*;
 
     pub fn _key_1() -> String {
         String::from("GJ1SzoWzavQYfNL9XkaJdrQejfztN4XqdsiV4ct3LXKL")

--- a/libvcx/src/aries/utils/mod.rs
+++ b/libvcx/src/aries/utils/mod.rs
@@ -1,1 +1,27 @@
+use crate::aries::messages::connection::did_doc::DidDoc;
+use crate::aries::messages::a2a::A2AMessage;
+use crate::aries::utils::encryption_envelope::EncryptionEnvelope;
+use crate::error::VcxResult;
+
 pub mod encryption_envelope;
+
+
+/**
+Sends authenticated message to connection counterparty
+*/
+pub fn send_message(sender_verkey: &str, did_doc: &DidDoc, message: &A2AMessage) -> VcxResult<()> {
+    trace!("DidDoc::send_message >>> message: {:?}, did_doc: {:?}", message, &did_doc);
+    let envelope = EncryptionEnvelope::create(&message, Some(sender_verkey), &did_doc)?;
+    agency_client::httpclient::post_message(&envelope.0, &did_doc.get_endpoint())?;
+    Ok(())
+}
+
+/**
+Sends anonymous message to connection counterparty
+ */
+pub fn send_message_anonymously(did_doc: &DidDoc, message: &A2AMessage) -> VcxResult<()> {
+    trace!("DidDoc::send_message_anonymously >>> message: {:?}, did_doc: {:?}", message, &did_doc);
+    let envelope = EncryptionEnvelope::create(&message, None, &did_doc)?;
+    agency_client::httpclient::post_message(&envelope.0, &did_doc.get_endpoint())?;
+    Ok(())
+}

--- a/libvcx/src/aries/utils/mod.rs
+++ b/libvcx/src/aries/utils/mod.rs
@@ -6,14 +6,14 @@ use crate::error::VcxResult;
 pub mod encryption_envelope;
 
 pub fn send_message(sender_verkey: &str, did_doc: &DidDoc, message: &A2AMessage) -> VcxResult<()> {
-    trace!("DidDoc::send_message >>> message: {:?}, did_doc: {:?}", message, &did_doc);
+    trace!("send_message >>> message: {:?}, did_doc: {:?}", message, &did_doc);
     let envelope = EncryptionEnvelope::create(&message, Some(sender_verkey), &did_doc)?;
     agency_client::httpclient::post_message(&envelope.0, &did_doc.get_endpoint())?;
     Ok(())
 }
 
 pub fn send_message_anonymously(did_doc: &DidDoc, message: &A2AMessage) -> VcxResult<()> {
-    trace!("DidDoc::send_message_anonymously >>> message: {:?}, did_doc: {:?}", message, &did_doc);
+    trace!("send_message_anonymously >>> message: {:?}, did_doc: {:?}", message, &did_doc);
     let envelope = EncryptionEnvelope::create(&message, None, &did_doc)?;
     agency_client::httpclient::post_message(&envelope.0, &did_doc.get_endpoint())?;
     Ok(())

--- a/libvcx/src/aries/utils/mod.rs
+++ b/libvcx/src/aries/utils/mod.rs
@@ -5,10 +5,6 @@ use crate::error::VcxResult;
 
 pub mod encryption_envelope;
 
-
-/**
-Sends authenticated message to connection counterparty
-*/
 pub fn send_message(sender_verkey: &str, did_doc: &DidDoc, message: &A2AMessage) -> VcxResult<()> {
     trace!("DidDoc::send_message >>> message: {:?}, did_doc: {:?}", message, &did_doc);
     let envelope = EncryptionEnvelope::create(&message, Some(sender_verkey), &did_doc)?;
@@ -16,9 +12,6 @@ pub fn send_message(sender_verkey: &str, did_doc: &DidDoc, message: &A2AMessage)
     Ok(())
 }
 
-/**
-Sends anonymous message to connection counterparty
- */
 pub fn send_message_anonymously(did_doc: &DidDoc, message: &A2AMessage) -> VcxResult<()> {
     trace!("DidDoc::send_message_anonymously >>> message: {:?}, did_doc: {:?}", message, &did_doc);
     let envelope = EncryptionEnvelope::create(&message, None, &did_doc)?;

--- a/libvcx/src/connection.rs
+++ b/libvcx/src/connection.rs
@@ -149,7 +149,7 @@ pub fn connect(handle: u32) -> VcxResult<Option<String>> {
 
 pub fn to_string(handle: u32) -> VcxResult<String> {
     CONNECTION_MAP.get(handle, |connection| {
-        Ok(connection.to_string())
+        connection.to_string()
     })
 }
 


### PR DESCRIPTION
- Previously `impl DidDoc` contained method `send_message_*`  which was using agency_client http client for sending requests.
- Aries FSM Connection layer was directly calling `ddo.send_message` - making it dependent on particular network IO implementation, in this case even transitively dependent on Agency client
- This PR introduces new field `send_message` which has to be injected upon construction of Aries FSM state machines. As consequence, default serde-derived traits `Serialize`, `Deserialize`  had to be removed (there's no way to serialize `fn`). This is not a big deal, `aries-vcx` was relying on this default de/serialization traits anyway.


- This PR keeps logic of custom connection de/serialization code, but moves it under serde de/serializer - so there would only be 1 way to perform de/serialization. ( In Aries Test Harness we are actually relying on serde derived de/serialization traits, hence changes so far are breaking harness code. This fact pointed out design issue - we previously had 2 ways to serialize Connection - either using serde derived de/serialization traits, or by calling our own implementation `Connection::to_string`, `Connection::from_string`.   ) 