### PR TITLE
Fix bug in encoding new attributes format

### DIFF
--- a/libvcx/src/aries/handlers/issuance/holder/state_machine.rs
+++ b/libvcx/src/aries/handlers/issuance/holder/state_machine.rs
@@ -273,7 +273,7 @@ fn _parse_rev_reg_id_from_credential(credential: &str) -> VcxResult<Option<Strin
 
 fn _store_credential(credential: &Credential,
                      req_meta: &str, cred_def_json: &str) -> VcxResult<(String, Option<String>)> {
-    trace!("Holder::_store_credential >>>");
+    trace!("Holder::_store_credential >>> credential: {:?}, req_meta: {}, cred_def_json: {}", credential, req_meta, cred_def_json);
 
     let credential_json = credential.credentials_attach.content()?;
     let rev_reg_id = _parse_rev_reg_id_from_credential(&credential_json)?;

--- a/libvcx/src/libindy/utils/anoncreds.rs
+++ b/libvcx/src/libindy/utils/anoncreds.rs
@@ -247,6 +247,7 @@ pub fn libindy_prover_store_credential(cred_id: Option<&str>,
                                        cred_json: &str,
                                        cred_def_json: &str,
                                        rev_reg_def_json: Option<&str>) -> VcxResult<String> {
+    trace!("libindy_prover_store_credential >>> cred_id: {:?}, cred_req_meta: {}, cred_json: {}, cred_def_json: {}, rev_reg_def_json: {:?}", cred_id, cred_req_meta, cred_json, cred_def_json, rev_reg_def_json);
     if settings::indy_mocks_enabled() { return Ok("cred_id".to_string()); }
 
     anoncreds::prover_store_credential(get_wallet_handle(),


### PR DESCRIPTION
Adding new credential data format in #291 introduced a bug - an `"attr_name"` was encoded instead of `attr_name`. This change fixes the issue and covers the case with a unit test.

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>