### PR TITLE
Try to fix occasionally failing integration test.

### DIFF
--- a/libvcx/src/credential_def.rs
+++ b/libvcx/src/credential_def.rs
@@ -695,6 +695,7 @@ pub mod tests {
                                          "tag_1".to_string(),
                                          revocation_details.to_string()).unwrap();
 
+        sleep(Duration::from_secs(1));
         let err = create_and_publish_credentialdef("1".to_string(),
                                                    "name".to_string(),
                                                    did.clone(),


### PR DESCRIPTION
The test `test_create_credential_works_twice` occasionally fails in CI - never run into this issue locally. The CI failure of this test is such that the second of creating the same credential definition passes, while it's expected to fail. I think the reason is  that probably on the second attempt, the created credential definition is not yet fully propagated through the pool, and so it appears like the credential definition doesn't exist yet. 
This PR add timeout into the test between first and second attempt to create the same cred. definition.

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>