### PR TITLE
Remove dependence of aries module on VcxStateType

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ members = [
 debug = true
 panic = 'unwind'
 incremental = false
- 
-[profile.dev]
-split-debuginfo = "unpacked" 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ members = [
 debug = true
 panic = 'unwind'
 incremental = false
-
+ 
 [profile.dev]
 split-debuginfo = "unpacked" 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
 debug = true
 panic = 'unwind'
 incremental = false
+
+[profile.dev]
+split-debuginfo = "unpacked" 

--- a/agents/node/vcxagent-core/demo/alice.js
+++ b/agents/node/vcxagent-core/demo/alice.js
@@ -93,7 +93,7 @@ async function runAlice (options) {
 
 function _validateMsgs (msgs) {
   logger.debug(`Validating messages:\n${JSON.stringify(msgs, null, 2)}`)
-  assert(msgs.length === 5)
+  assert(msgs.length === 4)
   assert(msgs[0].uid)
   assert(msgs[0].statusCode)
   assert(msgs[0].decryptedMsg)

--- a/agents/node/vcxagent-core/demo/faber.js
+++ b/agents/node/vcxagent-core/demo/faber.js
@@ -88,12 +88,12 @@ async function runFaber (options) {
     let proofProtocolState = await vcxProof.updateStateV2(connectionToAlice)
     logger.debug(`vcxProof = ${JSON.stringify(vcxProof)}`)
     logger.debug(`proofState = ${proofProtocolState}`)
-    while (proofProtocolState !== StateType.Accepted) { // even if revoked credential was used, state should in final state be StateType.Accepted
+    while (![2, 3].includes(proofProtocolState)) { // even if revoked credential was used, state should in final state be StateType.Accepted
       await sleepPromise(2000)
       proofProtocolState = await vcxProof.updateStateV2(connectionToAlice)
       logger.info(`proofState=${proofProtocolState}`)
-      if (proofProtocolState === StateType.None) {
-        logger.error(`Faber proof protocol state is ${StateType.None} which an error has ocurred.`)
+      if (proofProtocolState === 3) {
+        logger.error(`Faber proof protocol state is ${3} which an error has ocurred.`)
         logger.error(`Serialized proof state = ${JSON.stringify(await vcxProof.serialize())}`)
         process.exit(-1)
       }

--- a/agents/node/vcxagent-core/demo/faber.js
+++ b/agents/node/vcxagent-core/demo/faber.js
@@ -1,4 +1,4 @@
-const { StateType, ProofState, Proof } = require('@hyperledger/node-vcx-wrapper')
+const { VerifierStateType, ProofState, Proof } = require('@hyperledger/node-vcx-wrapper')
 const sleepPromise = require('sleep-promise')
 const { runScript } = require('./script-common')
 const { testTailsUrl } = require('../src/common')
@@ -88,11 +88,11 @@ async function runFaber (options) {
     let proofProtocolState = await vcxProof.updateStateV2(connectionToAlice)
     logger.debug(`vcxProof = ${JSON.stringify(vcxProof)}`)
     logger.debug(`proofState = ${proofProtocolState}`)
-    while (![2, 3].includes(proofProtocolState)) { // even if revoked credential was used, state should in final state be StateType.Accepted
+    while (![VerifierStateType.Finished, VerifierStateType.Failed].includes(proofProtocolState)) {
       await sleepPromise(2000)
       proofProtocolState = await vcxProof.updateStateV2(connectionToAlice)
       logger.info(`proofState=${proofProtocolState}`)
-      if (proofProtocolState === 3) {
+      if (proofProtocolState === VerifierStateType.Failed) {
         logger.error(`Faber proof protocol state is ${3} which an error has ocurred.`)
         logger.error(`Serialized proof state = ${JSON.stringify(await vcxProof.serialize())}`)
         process.exit(-1)

--- a/agents/node/vcxagent-core/src/agent.js
+++ b/agents/node/vcxagent-core/src/agent.js
@@ -30,6 +30,7 @@ async function createVcxAgent ({ agentName, genesisPath, agencyUrl, seed, usePos
     await storageService.saveAgentProvision(agentProvision)
   }
   const agentProvision = await storageService.loadAgentProvision()
+  const issuerDid = agentProvision.issuerConfig["institution_did"]
 
   async function agentInitVcx () {
     logger.info(`Initializing ${agentName} vcx session.`)
@@ -93,7 +94,8 @@ async function createVcxAgent ({ agentName, genesisPath, agencyUrl, seed, usePos
     loadCredDef: storageService.loadCredentialDefinition,
     saveIssuerCredential: storageService.saveCredIssuer,
     loadIssuerCredential: storageService.loadCredIssuer,
-    listIssuerCredentialIds: storageService.listCredIssuerKeys
+    listIssuerCredentialIds: storageService.listCredIssuerKeys,
+    issuerDid
   })
   const serviceCredHolder = createServiceCredHolder({
     logger,

--- a/agents/node/vcxagent-core/src/services/service-connections.js
+++ b/agents/node/vcxagent-core/src/services/service-connections.js
@@ -2,7 +2,7 @@ const { getMessagesForConnection } = require('../utils/messages')
 const {
   updateMessages,
   Connection,
-  InviterStateType
+  ConnectionStateType
 } = require('@hyperledger/node-vcx-wrapper')
 const { pollFunction } = require('../common')
 
@@ -50,7 +50,7 @@ module.exports.createServiceConnections = function createServiceConnections ({ l
 
   async function _progressConnectionToAcceptedState (connection, attemptsThreshold, timeoutMs) {
     async function progressToAcceptedState () {
-      if (await connection.updateState() !== InviterStateType.Completed) {
+      if (await connection.updateState() !== ConnectionStateType.Finished) {
         return { result: undefined, isFinished: false }
       } else {
         return { result: null, isFinished: true }

--- a/agents/node/vcxagent-core/src/services/service-connections.js
+++ b/agents/node/vcxagent-core/src/services/service-connections.js
@@ -50,7 +50,7 @@ module.exports.createServiceConnections = function createServiceConnections ({ l
 
   async function _progressConnectionToAcceptedState (connection, attemptsThreshold, timeoutMs) {
     async function progressToAcceptedState () {
-      if (await connection.updateState() !== StateType.Accepted) {
+      if (await connection.updateState() !== 4) {
         return { result: undefined, isFinished: false }
       } else {
         return { result: null, isFinished: true }

--- a/agents/node/vcxagent-core/src/services/service-connections.js
+++ b/agents/node/vcxagent-core/src/services/service-connections.js
@@ -2,7 +2,7 @@ const { getMessagesForConnection } = require('../utils/messages')
 const {
   updateMessages,
   Connection,
-  StateType
+  InviterStateType
 } = require('@hyperledger/node-vcx-wrapper')
 const { pollFunction } = require('../common')
 
@@ -50,7 +50,7 @@ module.exports.createServiceConnections = function createServiceConnections ({ l
 
   async function _progressConnectionToAcceptedState (connection, attemptsThreshold, timeoutMs) {
     async function progressToAcceptedState () {
-      if (await connection.updateState() !== 4) {
+      if (await connection.updateState() !== InviterStateType.Completed) {
         return { result: undefined, isFinished: false }
       } else {
         return { result: null, isFinished: true }

--- a/agents/node/vcxagent-core/src/services/service-cred-holder.js
+++ b/agents/node/vcxagent-core/src/services/service-cred-holder.js
@@ -2,7 +2,7 @@ const {filterOffersByCredentialName} = require('../utils/credentials')
 const { filterOffersByAttr } = require('../utils/credentials')
 const { filterOffersBySchema } = require('../utils/credentials')
 const {
-  StateType,
+  HolderStateType,
   Credential
 } = require('@hyperledger/node-vcx-wrapper')
 const { pollFunction } = require('../common')
@@ -50,7 +50,7 @@ module.exports.createServiceCredHolder = function createServiceCredHolder ({ log
   async function waitForCredential (connectionId, holderCredentialId, attemptsThreshold = 10, timeoutMs = 2000) {
     const connection = await loadConnection(connectionId)
     const credential = await loadHolderCredential(holderCredentialId)
-    await _progressCredentialToState(credential, connection, 2, attemptsThreshold, timeoutMs)
+    await _progressCredentialToState(credential, connection, HolderStateType.Finished, attemptsThreshold, timeoutMs)
     logger.info('Credential has been received.')
     await saveHolderCredential(holderCredentialId, credential)
     return getCredentialData(holderCredentialId)

--- a/agents/node/vcxagent-core/src/services/service-cred-holder.js
+++ b/agents/node/vcxagent-core/src/services/service-cred-holder.js
@@ -11,6 +11,7 @@ module.exports.createServiceCredHolder = function createServiceCredHolder ({ log
   async function _getOffers (connection, filter, attemptsThreshold, timeoutMs) {
     async function findSomeCredOffer () {
       let offers = await Credential.getOffers(connection)
+      logger.info(`Offers: ${offers}`)
       if (filter && filter.schemaIdRegex) {
         offers = filterOffersBySchema(offers, filter.schemaIdRegex)
       }
@@ -49,7 +50,7 @@ module.exports.createServiceCredHolder = function createServiceCredHolder ({ log
   async function waitForCredential (connectionId, holderCredentialId, attemptsThreshold = 10, timeoutMs = 2000) {
     const connection = await loadConnection(connectionId)
     const credential = await loadHolderCredential(holderCredentialId)
-    await _progressCredentialToState(credential, connection, StateType.Accepted, attemptsThreshold, timeoutMs)
+    await _progressCredentialToState(credential, connection, 2, attemptsThreshold, timeoutMs)
     logger.info('Credential has been received.')
     await saveHolderCredential(holderCredentialId, credential)
     return getCredentialData(holderCredentialId)

--- a/agents/node/vcxagent-core/src/services/service-cred-issuer.js
+++ b/agents/node/vcxagent-core/src/services/service-cred-issuer.js
@@ -1,5 +1,5 @@
 const {
-  StateType,
+  IssuerStateType,
   IssuerCredential
 } = require('@hyperledger/node-vcx-wrapper')
 const { pollFunction } = require('../common')
@@ -37,7 +37,7 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
     const issuerCred = await loadIssuerCredential(issuerCredId)
     const connection = await loadConnection(connectionId)
     logger.debug('Going to wait until credential request is received.')
-    await _progressIssuerCredentialToState(issuerCred, connection, 2, 10, 2000)
+    await _progressIssuerCredentialToState(issuerCred, connection, IssuerStateType.RequestReceived, 10, 2000)
     await saveIssuerCredential(issuerCredId, issuerCred)
   }
 
@@ -46,7 +46,7 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
     const connection = await loadConnection(connectionId)
     const issuerCred = await loadIssuerCredential(issuerCredId)
     logger.info('Going to wait until counterparty accepts the credential.')
-    await _progressIssuerCredentialToState(issuerCred, connection, 4, 10, 2000)
+    await _progressIssuerCredentialToState(issuerCred, connection, IssuerStateType.Finished, 10, 2000)
     await saveIssuerCredential(issuerCredId, issuerCred)
   }
 

--- a/agents/node/vcxagent-core/src/services/service-cred-issuer.js
+++ b/agents/node/vcxagent-core/src/services/service-cred-issuer.js
@@ -4,7 +4,7 @@ const {
 } = require('@hyperledger/node-vcx-wrapper')
 const { pollFunction } = require('../common')
 
-module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ logger, loadConnection, loadCredDef, saveIssuerCredential, loadIssuerCredential, listIssuerCredentialIds }) {
+module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ logger, loadConnection, loadCredDef, saveIssuerCredential, loadIssuerCredential, listIssuerCredentialIds, issuerDid }) {
   async function sendOffer (issuerCredId, connectionId, credDefId, schemaAttrs) {
     const connection = await loadConnection(connectionId)
     const credDef = await loadCredDef(credDefId)
@@ -14,7 +14,8 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
       sourceId: 'alice_degree',
       credDefHandle: credDef.handle,
       credentialName: 'cred',
-      price: '0'
+      price: '0',
+      issuerDid
     })
     logger.info(`Per issuer credential ${issuerCredId}, sending cred offer to connection ${connectionId}`)
     await issuerCred.sendOffer(connection)
@@ -36,7 +37,7 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
     const issuerCred = await loadIssuerCredential(issuerCredId)
     const connection = await loadConnection(connectionId)
     logger.debug('Going to wait until credential request is received.')
-    await _progressIssuerCredentialToState(issuerCred, connection, StateType.RequestReceived, 10, 2000)
+    await _progressIssuerCredentialToState(issuerCred, connection, 2, 10, 2000)
     await saveIssuerCredential(issuerCredId, issuerCred)
   }
 
@@ -45,7 +46,7 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
     const connection = await loadConnection(connectionId)
     const issuerCred = await loadIssuerCredential(issuerCredId)
     logger.info('Going to wait until counterparty accepts the credential.')
-    await _progressIssuerCredentialToState(issuerCred, connection, StateType.Accepted, 10, 2000)
+    await _progressIssuerCredentialToState(issuerCred, connection, 4, 10, 2000)
     await saveIssuerCredential(issuerCredId, issuerCred)
   }
 

--- a/agents/node/vcxagent-core/src/services/service-prover.js
+++ b/agents/node/vcxagent-core/src/services/service-prover.js
@@ -35,7 +35,7 @@ module.exports.createServiceProver = function createServiceProver ({ logger, loa
       }
     }
 
-    const [error, proofRequests] = await pollFunction(findSomeRequests, 'Get credential offer', logger, attemptsThreshold, timeoutMs)
+    const [error, proofRequests] = await pollFunction(findSomeRequests, 'Get proof request', logger, attemptsThreshold, timeoutMs)
     if (error) {
       throw Error(`Couldn't find any proof request. ${error}`)
     }
@@ -84,7 +84,7 @@ module.exports.createServiceProver = function createServiceProver ({ logger, loa
     await sendDisclosedProof(disclosedProofId, connectionId)
     const disclosedProof = await loadDisclosedProof(disclosedProofId)
     const connection = await loadConnection(connectionId)
-    await _progressProofToState(disclosedProof, connection, [StateType.Accepted, StateType.None])
+    await _progressProofToState(disclosedProof, connection, [2, 3])
     const state = await disclosedProof.getState()
     await saveDisclosedProof(disclosedProofId, disclosedProof)
     return state

--- a/agents/node/vcxagent-core/src/services/service-prover.js
+++ b/agents/node/vcxagent-core/src/services/service-prover.js
@@ -2,7 +2,7 @@ const { pollFunction } = require('../common')
 const { holderSelectCredentialsForProof } = require('../utils/proofs')
 const {
   DisclosedProof,
-  StateType
+  ProverStateType
 } = require('@hyperledger/node-vcx-wrapper')
 
 module.exports.createServiceProver = function createServiceProver ({ logger, loadConnection, saveDisclosedProof, loadDisclosedProof, listDislosedProofIds }) {
@@ -84,7 +84,7 @@ module.exports.createServiceProver = function createServiceProver ({ logger, loa
     await sendDisclosedProof(disclosedProofId, connectionId)
     const disclosedProof = await loadDisclosedProof(disclosedProofId)
     const connection = await loadConnection(connectionId)
-    await _progressProofToState(disclosedProof, connection, [2, 3])
+    await _progressProofToState(disclosedProof, connection, [ProverStateType.PresentationPreparationFailed, ProverStateType.PresentationSent])
     const state = await disclosedProof.getState()
     await saveDisclosedProof(disclosedProofId, disclosedProof)
     return state

--- a/agents/node/vcxagent-core/src/utils/vcx-workflows.js
+++ b/agents/node/vcxagent-core/src/utils/vcx-workflows.js
@@ -85,9 +85,10 @@ async function provisionAgentInAgency (agentName, genesisPath, agencyUrl, seed, 
   logger.debug(`Configuring issuer's wallet with seed: ${seed}`)
   const issuerConfig = JSON.parse(await configureIssuerWallet(seed))
   issuerConfig.institution_name = agentName
+  logger.debug(`Configured issuer wallet with config: ${JSON.stringify(issuerConfig, null, 2)}`)
   logger.debug(`Provisioning agent with config: ${JSON.stringify(agencyConfig, null, 2)}`)
   agencyConfig = JSON.parse(await provisionCloudAgent(agencyConfig))
-  logger.debug(`Provisined agent with config: ${JSON.stringify(agencyConfig, null, 2)}`)
+  logger.debug(`Provisioned agent with config: ${JSON.stringify(agencyConfig, null, 2)}`)
   await closeMainWallet()
 
   return { agencyConfig, issuerConfig, walletConfig }

--- a/agents/node/vcxagent-core/test/distribute-tails.spec.js
+++ b/agents/node/vcxagent-core/test/distribute-tails.spec.js
@@ -5,7 +5,7 @@ const axios = require('axios')
 const { buildRevocationDetails } = require('../src')
 const { createPairedAliceAndFaber } = require('./utils/utils')
 const { initRustapi } = require('../src/index')
-const { StateType } = require('@hyperledger/node-vcx-wrapper')
+const { IssuerStateType, HolderStateType, VerifierStateType, ProverStateType } = require('@hyperledger/node-vcx-wrapper')
 const uuid = require('uuid')
 const sleep = require('sleep-promise')
 const fs = require('fs')
@@ -27,9 +27,9 @@ describe('test tails distribution', () => {
       const tailsUrl = `http://127.0.0.1:${port}/${tailsUrlId}`
       await faber.sendCredentialOffer(buildRevocationDetails({ supportRevocation: true, tailsFile: `${__dirname}/tmp/faber/tails`, tailsUrl, maxCreds: 5 }))
       await alice.acceptCredentialOffer()
-      await faber.updateStateCredentialV2(StateType.RequestReceived)
+      await faber.updateStateCredentialV2(IssuerStateType.RequestReceived)
       await faber.sendCredential()
-      await alice.updateStateCredentialV2(StateType.Accepted)
+      await alice.updateStateCredentialV2(HolderStateType.Finished)
 
       const faberTailsHash = await faber.getTailsHash()
       const app = express()
@@ -47,8 +47,8 @@ describe('test tails distribution', () => {
 
       const request = await faber.requestProofFromAlice()
       await alice.sendHolderProof(JSON.parse(request), revRegId => aliceTailsFileDir)
-      await faber.updateStateVerifierProofV2(StateType.Accepted)
-      await alice.updateStateHolderProofV2(StateType.Accepted)
+      await faber.updateStateVerifierProofV2(VerifierStateType.Finished)
+      await alice.updateStateHolderProofV2(ProverStateType.Finished)
     } catch (err) {
       console.error(`err = ${err.message} stack = ${err.stack}`)
       if (server) {

--- a/agents/node/vcxagent-core/test/feature-discovery.spec.js
+++ b/agents/node/vcxagent-core/test/feature-discovery.spec.js
@@ -10,7 +10,6 @@ beforeAll(async () => {
 })
 
 describe('send ping, get ping', () => {
-
   it('Faber should send credential to Alice', async () => {
     try {
       const { alice, faber } = await createPairedAliceAndFaber()

--- a/agents/node/vcxagent-core/test/sign-messaging.spec.js
+++ b/agents/node/vcxagent-core/test/sign-messaging.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 require('jest')
-const {createPairedAliceAndFaber} = require('./utils/utils')
-const {initRustapi} = require('../src/index')
+const { createPairedAliceAndFaber } = require('./utils/utils')
+const { initRustapi } = require('../src/index')
 const sleep = require('sleep-promise')
 
 beforeAll(async () => {

--- a/agents/node/vcxagent-core/test/update-state-v2.spec.js
+++ b/agents/node/vcxagent-core/test/update-state-v2.spec.js
@@ -1,9 +1,8 @@
 /* eslint-env jest */
 require('jest')
-const { shutdownVcx } = require('@hyperledger/node-vcx-wrapper')
 const { createPairedAliceAndFaber } = require('./utils/utils')
 const { initRustapi } = require('../src/index')
-const { StateType } = require('@hyperledger/node-vcx-wrapper')
+const { IssuerStateType, HolderStateType, ProverStateType, VerifierStateType } = require('@hyperledger/node-vcx-wrapper')
 const sleep = require('sleep-promise')
 
 beforeAll(async () => {
@@ -19,14 +18,14 @@ describe('test update state', () => {
       await faber.sendCredentialOffer()
       await alice.acceptCredentialOffer()
 
-      await faber.updateStateCredentialV2(StateType.RequestReceived)
+      await faber.updateStateCredentialV2(IssuerStateType.RequestReceived)
       await faber.sendCredential()
-      await alice.updateStateCredentialV2(StateType.Accepted)
+      await alice.updateStateCredentialV2(HolderStateType.Finished)
 
       const request = await faber.requestProofFromAlice()
       await alice.sendHolderProof(JSON.parse(request))
-      await faber.updateStateVerifierProofV2(StateType.Accepted)
-      await alice.updateStateHolderProofV2(StateType.Accepted)
+      await faber.updateStateVerifierProofV2(VerifierStateType.Finished)
+      await alice.updateStateHolderProofV2(ProverStateType.Finished)
     } catch (err) {
       console.error(`err = ${err.message} stack = ${err.stack}`)
       await sleep(2000)

--- a/agents/node/vcxagent-core/test/utils/alice.js
+++ b/agents/node/vcxagent-core/test/utils/alice.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 const { createVcxAgent } = require('../../src/index')
-const { InviteeStateType, ProverStateType } = require('@hyperledger/node-vcx-wrapper')
+const { ConnectionStateType, ProverStateType } = require('@hyperledger/node-vcx-wrapper')
 
 module.exports.createAlice = async function createAlice () {
   const agentName = `alice-${Math.floor(new Date() / 1000)}`
@@ -26,7 +26,7 @@ module.exports.createAlice = async function createAlice () {
 
     await vcxAgent.serviceConnections.inviteeConnectionAcceptFromInvitation(connectionId, invite)
     const connection = await vcxAgent.serviceConnections.getVcxConnection(connectionId)
-    expect(await connection.getState()).toBe(InviteeStateType.Requested)
+    expect(await connection.getState()).toBe(ConnectionStateType.Requested)
 
     await vcxAgent.agentShutdownVcx()
   }

--- a/agents/node/vcxagent-core/test/utils/alice.js
+++ b/agents/node/vcxagent-core/test/utils/alice.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 const { createVcxAgent } = require('../../src/index')
-const { StateType } = require('@hyperledger/node-vcx-wrapper')
+const { InviteeStateType, ProverStateType } = require('@hyperledger/node-vcx-wrapper')
 
 module.exports.createAlice = async function createAlice () {
   const agentName = `alice-${Math.floor(new Date() / 1000)}`
@@ -26,7 +26,7 @@ module.exports.createAlice = async function createAlice () {
 
     await vcxAgent.serviceConnections.inviteeConnectionAcceptFromInvitation(connectionId, invite)
     const connection = await vcxAgent.serviceConnections.getVcxConnection(connectionId)
-    expect(await connection.getState()).toBe(StateType.OfferSent)
+    expect(await connection.getState()).toBe(InviteeStateType.Requested)
 
     await vcxAgent.agentShutdownVcx()
   }
@@ -56,7 +56,7 @@ module.exports.createAlice = async function createAlice () {
     const { selectedCreds } = await vcxAgent.serviceProver.selectCredentials(disclosedProofId, mapRevRegId)
     const selfAttestedAttrs = { attribute_3: 'Smith' }
     await vcxAgent.serviceProver.generateProof(disclosedProofId, selectedCreds, selfAttestedAttrs)
-    expect(await vcxAgent.serviceProver.sendDisclosedProof(disclosedProofId, connectionId)).toBe(StateType.OfferSent)
+    expect(await vcxAgent.serviceProver.sendDisclosedProof(disclosedProofId, connectionId)).toBe(ProverStateType.PresentationSent)
 
     await vcxAgent.agentShutdownVcx()
   }

--- a/agents/node/vcxagent-core/test/utils/faber.js
+++ b/agents/node/vcxagent-core/test/utils/faber.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 const { buildRevocationDetails } = require('../../src')
 const { createVcxAgent, getSampleSchemaData } = require('../../src')
-const { StateType } = require('@hyperledger/node-vcx-wrapper')
+const { InviterStateType, IssuerStateType, VerifierStateType } = require('@hyperledger/node-vcx-wrapper')
 const { getAliceSchemaAttrs, getFaberCredDefName, getFaberProofData } = require('./data')
 
 module.exports.createFaber = async function createFaber () {
@@ -30,7 +30,7 @@ module.exports.createFaber = async function createFaber () {
     const invite = await vcxAgent.serviceConnections.inviterConnectionCreate(connectionId, undefined)
     logger.info(`Faber generated invite:\n${invite}`)
     const connection = await vcxAgent.serviceConnections.getVcxConnection(connectionId)
-    expect(await connection.getState()).toBe(StateType.Initialized)
+    expect(await connection.getState()).toBe(InviterStateType.Invited)
 
     await vcxAgent.agentShutdownVcx()
 
@@ -41,7 +41,7 @@ module.exports.createFaber = async function createFaber () {
     logger.info('Faber is going to generate invite')
     await vcxAgent.agentInitVcx()
 
-    expect(await vcxAgent.serviceConnections.connectionUpdate(connectionId)).toBe(StateType.RequestReceived)
+    expect(await vcxAgent.serviceConnections.connectionUpdate(connectionId)).toBe(InviterStateType.Responded)
 
     await vcxAgent.agentShutdownVcx()
   }
@@ -90,7 +90,7 @@ module.exports.createFaber = async function createFaber () {
     await vcxAgent.agentInitVcx()
 
     logger.info('Issuer sending credential')
-    expect(await vcxAgent.serviceCredIssuer.sendCredential(issuerCredId, connectionId)).toBe(StateType.Accepted)
+    expect(await vcxAgent.serviceCredIssuer.sendCredential(issuerCredId, connectionId)).toBe(IssuerStateType.Finished)
     logger.info('Credential sent')
 
     await vcxAgent.agentShutdownVcx()
@@ -105,7 +105,7 @@ module.exports.createFaber = async function createFaber () {
     await vcxAgent.serviceVerifier.createProof(proofId, proofData)
     logger.info(`Faber is sending proof request to connection ${connectionId}`)
     const { state, proofRequestMessage } = await vcxAgent.serviceVerifier.sendProofRequest(connectionId, proofId)
-    expect(state).toBe(StateType.OfferSent)
+    expect(state).toBe(VerifierStateType.PresentationRequestSent)
     await vcxAgent.agentShutdownVcx()
     return proofRequestMessage
   }

--- a/agents/node/vcxagent-core/test/utils/faber.js
+++ b/agents/node/vcxagent-core/test/utils/faber.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 const { buildRevocationDetails } = require('../../src')
 const { createVcxAgent, getSampleSchemaData } = require('../../src')
-const { InviterStateType, IssuerStateType, VerifierStateType } = require('@hyperledger/node-vcx-wrapper')
+const { ConnectionStateType, IssuerStateType, VerifierStateType } = require('@hyperledger/node-vcx-wrapper')
 const { getAliceSchemaAttrs, getFaberCredDefName, getFaberProofData } = require('./data')
 
 module.exports.createFaber = async function createFaber () {
@@ -30,7 +30,7 @@ module.exports.createFaber = async function createFaber () {
     const invite = await vcxAgent.serviceConnections.inviterConnectionCreate(connectionId, undefined)
     logger.info(`Faber generated invite:\n${invite}`)
     const connection = await vcxAgent.serviceConnections.getVcxConnection(connectionId)
-    expect(await connection.getState()).toBe(InviterStateType.Invited)
+    expect(await connection.getState()).toBe(ConnectionStateType.Invited)
 
     await vcxAgent.agentShutdownVcx()
 
@@ -41,7 +41,7 @@ module.exports.createFaber = async function createFaber () {
     logger.info('Faber is going to generate invite')
     await vcxAgent.agentInitVcx()
 
-    expect(await vcxAgent.serviceConnections.connectionUpdate(connectionId)).toBe(InviterStateType.Responded)
+    expect(await vcxAgent.serviceConnections.connectionUpdate(connectionId)).toBe(ConnectionStateType.Responded)
 
     await vcxAgent.agentShutdownVcx()
   }

--- a/agents/node/vcxagent-core/test/utils/utils.js
+++ b/agents/node/vcxagent-core/test/utils/utils.js
@@ -1,14 +1,14 @@
 const { createFaber } = require('./faber')
 const { createAlice } = require('./alice')
-const { StateType } = require('@hyperledger/node-vcx-wrapper')
+const { ConnectionStateType } = require('@hyperledger/node-vcx-wrapper')
 
 module.exports.createPairedAliceAndFaber = async function createPairedAliceAndFaber () {
   const alice = await createAlice()
   const faber = await createFaber()
   const invite = await faber.createInvite()
   await alice.acceptInvite(invite)
-  await faber.updateConnection(StateType.RequestReceived)
-  await alice.updateConnection(StateType.Accepted)
-  await faber.updateConnection(StateType.Accepted)
+  await faber.updateConnection(ConnectionStateType.Responded)
+  await alice.updateConnection(ConnectionStateType.Finished)
+  await faber.updateConnection(ConnectionStateType.Finished)
   return { alice, faber }
 }

--- a/ci/indy-pool.dockerfile
+++ b/ci/indy-pool.dockerfile
@@ -33,7 +33,7 @@ ARG python3_orderedset_ver=2.0
 ARG python3_psutil_ver=5.4.3
 ARG python3_pympler_ver=0.5
 
-RUN apt-get update -y && apt-get install -y \
+RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
         python3-pyzmq=${python3_pyzmq_ver} \
         indy-plenum=${indy_plenum_ver} \
         indy-node=${indy_node_ver} \

--- a/ci/indy-pool.dockerfile
+++ b/ci/indy-pool.dockerfile
@@ -33,7 +33,7 @@ ARG python3_orderedset_ver=2.0
 ARG python3_psutil_ver=5.4.3
 ARG python3_pympler_ver=0.5
 
-RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
+RUN apt-get update -y && apt-get install -y \
         python3-pyzmq=${python3_pyzmq_ver} \
         indy-plenum=${indy_plenum_ver} \
         indy-node=${indy_node_ver} \

--- a/libvcx/src/api_lib/api_c/connection.rs
+++ b/libvcx/src/api_lib/api_c/connection.rs
@@ -8,7 +8,6 @@ use crate::api_lib::api_handle::connection;
 use crate::api_lib::utils_c;
 use crate::api_lib::utils_c::cstring::CStringUtils;
 use crate::api_lib::utils_c::runtime::execute;
-use crate::aries::messages::a2a::A2AMessage;
 use crate::error::prelude::*;
 use crate::libindy;
 use crate::utils::error;
@@ -548,13 +547,8 @@ pub extern fn vcx_connection_update_state_with_message(command_handle: CommandHa
         return VcxError::from(VcxErrorKind::InvalidConnectionHandle).into();
     }
 
-    let message: A2AMessage = match serde_json::from_str(&message) {
-        Ok(x) => x,
-        Err(_) => return VcxError::from(VcxErrorKind::InvalidJson).into(),
-    };
-
     execute(move || {
-        let result = update_state_with_message(connection_handle, message);
+        let result = update_state_with_message(connection_handle, &message);
 
         let rc = match result {
             Ok(x) => {

--- a/libvcx/src/api_lib/api_c/credential.rs
+++ b/libvcx/src/api_lib/api_c/credential.rs
@@ -1065,21 +1065,6 @@ mod tests {
 
     #[test]
     #[cfg(feature = "general_test")]
-    fn test_vcx_credential_send_request() {
-        let _setup = SetupMocks::init();
-
-        let handle = credential::credential_create_with_offer("test_send_request", ARIES_CREDENTIAL_OFFER).unwrap();
-        assert_eq!(credential::get_state(handle).unwrap(), HolderState::OfferReceived as u32);
-
-        let connection_handle = connection::tests::build_test_connection_inviter_requested();
-
-        let cb = return_types_u32::Return_U32::new().unwrap();
-        assert_eq!(vcx_credential_send_request(cb.command_handle, handle, connection_handle, 0, Some(cb.get_callback())), error::SUCCESS.code_num);
-        cb.receive(TimeoutUtils::some_medium()).unwrap();
-    }
-
-    #[test]
-    #[cfg(feature = "general_test")]
     fn test_vcx_credential_get_new_offers() {
         let _setup = SetupMocks::init();
 

--- a/libvcx/src/api_lib/api_c/credential_def.rs
+++ b/libvcx/src/api_lib/api_c/credential_def.rs
@@ -2,7 +2,6 @@ use std::ptr;
 
 use indy_sys::CommandHandle;
 use libc::c_char;
-use serde_json;
 
 use crate::api_lib::api_handle::credential_def;
 use crate::api_lib::utils_c::cstring::CStringUtils;
@@ -516,11 +515,9 @@ pub extern fn vcx_credentialdef_get_rev_reg_id(command_handle: CommandHandle,
 
 #[cfg(test)]
 mod tests {
-    extern crate serde_json;
-
     use std::ffi::CString;
 
-    use crate::{api_lib, settings, utils};
+    use crate::{api_lib, utils};
     use crate::api_lib::utils_c::return_types_u32;
     use crate::api_lib::utils_c::timeout::TimeoutUtils;
     use crate::utils::constants::SCHEMA_ID;

--- a/libvcx/src/api_lib/api_c/disclosed_proof.rs
+++ b/libvcx/src/api_lib/api_c/disclosed_proof.rs
@@ -947,8 +947,6 @@ pub extern fn vcx_disclosed_proof_release(handle: u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    extern crate serde_json;
-
     use std::ffi::CString;
 
     use serde_json::Value;
@@ -963,6 +961,7 @@ mod tests {
     use crate::utils::mockdata::mock_settings::MockBuilder;
     use crate::utils::mockdata::mockdata_credex::ARIES_CREDENTIAL_REQUEST;
     use crate::utils::mockdata::mockdata_proof::ARIES_PROOF_REQUEST_PRESENTATION;
+    use crate::aries::handlers::proof_presentation::prover::prover::ProverState;
 
     use super::*;
 
@@ -1079,7 +1078,7 @@ mod tests {
         let _setup = SetupMocks::init();
 
         let handle_proof = _vcx_disclosed_proof_create_with_request_c_closure(ARIES_PROOF_REQUEST_PRESENTATION).unwrap();
-        assert_eq!(disclosed_proof::get_state(handle_proof).unwrap(), VcxStateType::VcxStateRequestReceived as u32);
+        assert_eq!(disclosed_proof::get_state(handle_proof).unwrap(), ProverState::Initial as u32);
 
         let handle_conn = connection::tests::build_test_connection_inviter_requested();
 
@@ -1094,7 +1093,7 @@ mod tests {
         let _setup = SetupMocks::init();
 
         let handle = _vcx_disclosed_proof_create_with_request_c_closure(ARIES_PROOF_REQUEST_PRESENTATION).unwrap();
-        assert_eq!(disclosed_proof::get_state(handle).unwrap(), VcxStateType::VcxStateRequestReceived as u32);
+        assert_eq!(disclosed_proof::get_state(handle).unwrap(), ProverState::Initial as u32);
 
         let connection_handle = connection::tests::build_test_connection_inviter_requested();
 
@@ -1111,7 +1110,7 @@ mod tests {
 
         let handle = _vcx_disclosed_proof_create_with_request_c_closure(ARIES_PROOF_REQUEST_PRESENTATION).unwrap();
 
-        assert_eq!(disclosed_proof::get_state(handle).unwrap(), VcxStateType::VcxStateRequestReceived as u32);
+        assert_eq!(disclosed_proof::get_state(handle).unwrap(), ProverState::Initial as u32);
 
         let _connection_handle = connection::tests::build_test_connection_inviter_requested();
 
@@ -1145,7 +1144,7 @@ mod tests {
         let cb = return_types_u32::Return_U32_U32::new().unwrap();
         assert_eq!(vcx_disclosed_proof_get_state(cb.command_handle, handle, Some(cb.get_callback())), error::SUCCESS.code_num);
         let state = cb.receive(TimeoutUtils::some_medium()).unwrap();
-        assert_eq!(state, VcxStateType::VcxStateRequestReceived as u32);
+        assert_eq!(state, ProverState::Initial as u32);
     }
 
     #[test]

--- a/libvcx/src/api_lib/api_c/proof.rs
+++ b/libvcx/src/api_lib/api_c/proof.rs
@@ -623,6 +623,7 @@ mod tests {
     use crate::utils::devsetup::*;
     use crate::utils::mockdata::mock_settings::MockBuilder;
     use crate::utils::mockdata::mockdata_proof;
+    use crate::aries::handlers::proof_presentation::verifier::verifier::VerifierState;
 
     use super::*;
 
@@ -725,7 +726,7 @@ mod tests {
                                              Some(cb.get_callback())),
                    error::SUCCESS.code_num);
         let state = cb.receive(TimeoutUtils::some_medium()).unwrap();
-        assert_eq!(state, VcxStateType::VcxStateInitialized as u32);
+        assert_eq!(state, VerifierState::Initial as u32);
     }
 
     #[test]
@@ -737,7 +738,7 @@ mod tests {
 
         let proof_handle = create_proof_util().unwrap();
 
-        assert_eq!(proof::get_state(proof_handle).unwrap(), VcxStateType::VcxStateInitialized as u32);
+        assert_eq!(proof::get_state(proof_handle).unwrap(), VerifierState::Initial as u32);
 
         let connection_handle = build_test_connection_inviter_requested();
 
@@ -749,7 +750,7 @@ mod tests {
                    error::SUCCESS.code_num);
         cb.receive(TimeoutUtils::some_medium()).unwrap();
 
-        assert_eq!(proof::get_state(proof_handle).unwrap(), VcxStateType::VcxStateOfferSent as u32);
+        assert_eq!(proof::get_state(proof_handle).unwrap(), VerifierState::PresentationRequestSent as u32);
 
         let cb = return_types_u32::Return_U32_U32::new().unwrap();
         assert_eq!(vcx_v2_proof_update_state_with_message(cb.command_handle,
@@ -760,7 +761,7 @@ mod tests {
                    error::SUCCESS.code_num);
         let _state = cb.receive(TimeoutUtils::some_medium()).unwrap();
 
-        assert_eq!(proof::get_state(proof_handle).unwrap(), VcxStateType::VcxStateAccepted as u32);
+        assert_eq!(proof::get_state(proof_handle).unwrap(), VerifierState::Finished as u32);
     }
 
     #[test]
@@ -808,6 +809,6 @@ mod tests {
         let rc = vcx_proof_get_state(cb.command_handle, handle, Some(cb.get_callback()));
         assert_eq!(rc, error::SUCCESS.code_num);
         let state = cb.receive(TimeoutUtils::some_short()).unwrap();
-        assert_eq!(state, VcxStateType::VcxStateOfferSent as u32);
+        assert_eq!(state, VerifierState::PresentationRequestSent as u32);
     }
 }

--- a/libvcx/src/api_lib/api_c/wallet.rs
+++ b/libvcx/src/api_lib/api_c/wallet.rs
@@ -13,7 +13,6 @@ use crate::init::open_as_main_wallet;
 use crate::libindy::utils::payments::{create_address, get_wallet_token_info, pay_a_payee, sign_with_address, verify_with_address};
 use crate::libindy::utils::wallet;
 use crate::libindy::utils::wallet::{export_main_wallet, import, RestoreWalletConfigs, WalletConfig};
-use crate::utils;
 use crate::utils::error;
 
 /// Creates new wallet and master secret using provided config. Keeps wallet closed.

--- a/libvcx/src/api_lib/utils_c/fsm_states.rs
+++ b/libvcx/src/api_lib/utils_c/fsm_states.rs
@@ -1,6 +1,10 @@
 use crate::aries::handlers::connection::connection::ConnectionState;
 use crate::aries::handlers::connection::invitee::state_machine::InviteeState;
 use crate::aries::handlers::connection::inviter::state_machine::InviterState;
+use crate::aries::handlers::issuance::holder::holder::HolderState;
+use crate::aries::handlers::issuance::issuer::issuer::IssuerState;
+use crate::aries::handlers::proof_presentation::prover::prover::ProverState;
+use crate::aries::handlers::proof_presentation::verifier::verifier::VerifierState;
 
 impl From<ConnectionState> for u32 {
     fn from(state: ConnectionState) -> u32 {
@@ -23,6 +27,54 @@ impl From<ConnectionState> for u32 {
                     InviteeState::Completed => 4,
                 }
             }
+        }
+    }
+}
+
+impl From<HolderState> for u32 {
+    fn from(state: HolderState) -> u32 {
+        match state {
+            HolderState::OfferReceived => 0,
+            HolderState::RequestSent => 1,
+            HolderState::Finished => 2,
+            HolderState::Failed => 3
+        }
+    }
+}
+
+impl From<IssuerState> for u32 {
+    fn from(state: IssuerState) -> u32 {
+        match state {
+            IssuerState::Initial => 0,
+            IssuerState::OfferSent => 1,
+            IssuerState::RequestReceived => 2,
+            IssuerState::CredentialSent => 3,
+            IssuerState::Finished => 4,
+            IssuerState::Failed => 5
+        }
+    }
+}
+
+impl From<ProverState> for u32 {
+    fn from(state: ProverState) -> u32 {
+        match state {
+            ProverState::Initial => 0,
+            ProverState::PresentationPrepared => 1,
+            ProverState::PresentationPreparationFailed => 2,
+            ProverState::PresentationSent => 3,
+            ProverState::Finished => 4,
+            ProverState::Failed => 5
+        }
+    }
+}
+
+impl From<VerifierState> for u32 {
+    fn from(state: VerifierState) -> u32 {
+        match state {
+            VerifierState::Initial => 0,
+            VerifierState::PresentationRequestSent => 1,
+            VerifierState::Finished => 2,
+            VerifierState::Failed => 3
         }
     }
 }

--- a/libvcx/src/aries/handlers/connection/connection.rs
+++ b/libvcx/src/aries/handlers/connection/connection.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::{EnumAccess, Error, MapAccess, SeqAccess, Unexpected, Visitor};
 use serde_json::Value;
 
-use agency_client::get_message::{Message, MessageByConnection};
+use agency_client::get_message::Message;
 use agency_client::MessageStatusCode;
 
 use crate::aries::handlers::connection::cloud_agent::CloudAgentInfo;
@@ -53,7 +53,6 @@ pub enum ConnectionState {
     Inviter(InviterState),
     Invitee(InviteeState),
 }
-
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -745,6 +744,19 @@ impl<'de> Deserialize<'de> for Connection {
         deserializer.deserialize_map(ConnectionVisitor)
     }
 }
+
+impl Into<(SmConnectionState, PairwiseInfo, CloudAgentInfo, String)> for Connection {
+    fn into(self) -> (SmConnectionState, PairwiseInfo, CloudAgentInfo, String) {
+        (self.state_object(), self.pairwise_info().to_owned(), self.cloud_agent_info().to_owned(), self.source_id())
+    }
+}
+
+impl From<(SmConnectionState, PairwiseInfo, CloudAgentInfo, String)> for Connection {
+    fn from((state, pairwise_info, cloud_agent_info, source_id): (SmConnectionState, PairwiseInfo, CloudAgentInfo, String)) -> Connection {
+        Connection::from_parts(source_id, pairwise_info, cloud_agent_info, state, true)
+    }
+}
+
 
 #[cfg(test)]
 pub mod tests {

--- a/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/invitee/state_machine.rs
@@ -38,7 +38,7 @@ pub enum InviteeFullState {
     Completed(CompleteState),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum InviteeState {
     Null,
     Invited,

--- a/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
+++ b/libvcx/src/aries/handlers/connection/inviter/state_machine.rs
@@ -37,7 +37,7 @@ pub enum InviterFullState {
     Completed(CompleteState),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum InviterState {
     Null,
     Invited,

--- a/libvcx/src/aries/handlers/issuance/holder/holder.rs
+++ b/libvcx/src/aries/handlers/issuance/holder/holder.rs
@@ -12,6 +12,14 @@ pub struct Holder {
     holder_sm: HolderSM
 }
 
+#[derive(Debug, PartialEq)]
+pub enum HolderState {
+    OfferReceived,
+    RequestSent,
+    Finished,
+    Failed
+}
+
 impl Holder {
     pub fn create(credential_offer: CredentialOffer, source_id: &str) -> VcxResult<Holder> {
         trace!("Holder::holder_create_credential >>> credential_offer: {:?}, source_id: {:?}", credential_offer, source_id);
@@ -33,8 +41,8 @@ impl Holder {
         self.holder_sm.find_message_to_handle(messages)
     }
 
-    pub fn get_state(&self) -> u32 {
-        self.holder_sm.state()
+    pub fn get_state(&self) -> HolderState {
+        self.holder_sm.get_state()
     }
 
     pub fn get_source_id(&self) -> String {
@@ -84,7 +92,7 @@ impl Holder {
 
     pub fn update_state(&mut self, connection: &Connection) -> VcxResult<u32> {
         trace!("Holder::update_state >>> ");
-        if self.is_terminal_state() { return Ok(self.get_state()); }
+        if self.is_terminal_state() { return Ok(self.get_state().into()); }
         let send_message = connection.send_message_closure()?;
 
         let messages = connection.get_messages()?;
@@ -92,6 +100,6 @@ impl Holder {
             self.step(msg.into(), Some(&send_message))?;
             connection.update_message_status(uid)?;
         }
-        Ok(self.get_state())
+        Ok(self.get_state().into())
     }
 }

--- a/libvcx/src/aries/handlers/issuance/holder/holder.rs
+++ b/libvcx/src/aries/handlers/issuance/holder/holder.rs
@@ -90,9 +90,9 @@ impl Holder {
         Ok(())
     }
 
-    pub fn update_state(&mut self, connection: &Connection) -> VcxResult<u32> {
+    pub fn update_state(&mut self, connection: &Connection) -> VcxResult<HolderState> {
         trace!("Holder::update_state >>> ");
-        if self.is_terminal_state() { return Ok(self.get_state().into()); }
+        if self.is_terminal_state() { return Ok(self.get_state()); }
         let send_message = connection.send_message_closure()?;
 
         let messages = connection.get_messages()?;
@@ -100,6 +100,6 @@ impl Holder {
             self.step(msg.into(), Some(&send_message))?;
             connection.update_message_status(uid)?;
         }
-        Ok(self.get_state().into())
+        Ok(self.get_state())
     }
 }

--- a/libvcx/src/aries/handlers/issuance/issuer/issuer.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/issuer.rs
@@ -18,6 +18,16 @@ pub struct IssuerConfig {
     pub tails_file: Option<String>
 }
 
+#[derive(Debug, PartialEq)]
+pub enum IssuerState {
+    Initial,
+    OfferSent,
+    RequestReceived,
+    CredentialSent,
+    Finished,
+    Failed
+}
+
 impl Issuer {
     pub fn create(issuer_config: &IssuerConfig, credential_data: &str, source_id: &str) -> VcxResult<Issuer> {
         trace!("Issuer::issuer_create_credential >>> issuer_config: {:?}, credential_data: {:?}, source_id: {:?}", issuer_config, credential_data, source_id);
@@ -34,8 +44,8 @@ impl Issuer {
         self.step(CredentialIssuanceMessage::CredentialSend(), Some(&send_message))
     }
 
-    pub fn get_state(&self) -> VcxResult<u32> {
-        Ok(self.issuer_sm.state())
+    pub fn get_state(&self) -> IssuerState {
+        self.issuer_sm.get_state()
     }
 
     pub fn get_source_id(&self) -> VcxResult<String> {
@@ -73,7 +83,7 @@ impl Issuer {
 
     pub fn update_state(&mut self, connection: &Connection) -> VcxResult<u32> {
         trace!("Issuer::update_state >>> ");
-        if self.is_terminal_state() { return self.get_state(); }
+        if self.is_terminal_state() { return Ok(self.get_state().into()); }
         let send_message = connection.send_message_closure()?;
 
         let messages = connection.get_messages()?;
@@ -81,6 +91,6 @@ impl Issuer {
             self.step(msg.into(), Some(&send_message))?;
             connection.update_message_status(uid)?;
         }
-        self.get_state()
+        Ok(self.get_state().into())
     }
 }

--- a/libvcx/src/aries/handlers/issuance/issuer/issuer.rs
+++ b/libvcx/src/aries/handlers/issuance/issuer/issuer.rs
@@ -81,9 +81,9 @@ impl Issuer {
         Ok(())
     }
 
-    pub fn update_state(&mut self, connection: &Connection) -> VcxResult<u32> {
-        trace!("Issuer::update_state >>> ");
-        if self.is_terminal_state() { return Ok(self.get_state().into()); }
+    pub fn update_state(&mut self, connection: &Connection) -> VcxResult<IssuerState> {
+        trace!("Issuer::update_state >>>");
+        if self.is_terminal_state() { return Ok(self.get_state()); }
         let send_message = connection.send_message_closure()?;
 
         let messages = connection.get_messages()?;
@@ -91,6 +91,6 @@ impl Issuer {
             self.step(msg.into(), Some(&send_message))?;
             connection.update_message_status(uid)?;
         }
-        Ok(self.get_state().into())
+        Ok(self.get_state())
     }
 }

--- a/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
+++ b/libvcx/src/aries/handlers/proof_presentation/prover/prover.rs
@@ -15,6 +15,16 @@ pub struct Prover {
     prover_sm: ProverSM,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum ProverState {
+    Initial,
+    PresentationPrepared,
+    PresentationPreparationFailed,
+    PresentationSent,
+    Finished,
+    Failed
+}
+
 impl Prover {
     pub fn create(source_id: &str, presentation_request: PresentationRequest) -> VcxResult<Prover> {
         trace!("Prover::create >>> source_id: {}, presentation_request: {:?}", source_id, presentation_request);
@@ -23,7 +33,7 @@ impl Prover {
         })
     }
 
-    pub fn state(&self) -> u32 { self.prover_sm.state() }
+    pub fn get_state(&self) -> ProverState { self.prover_sm.get_state() }
 
     pub fn presentation_status(&self) -> u32 {
         trace!("Prover::presentation_state >>>");
@@ -113,9 +123,9 @@ impl Prover {
         }
     }
 
-    pub fn update_state(&mut self, connection: &Connection) -> VcxResult<u32> {
+    pub fn update_state(&mut self, connection: &Connection) -> VcxResult<ProverState> {
         trace!("Prover::update_state >>> ");
-        if !self.has_transitions() { return Ok(self.state()); }
+        if !self.has_transitions() { return Ok(self.get_state()); }
         let send_message = connection.send_message_closure()?;
 
         let messages = connection.get_messages()?;
@@ -123,7 +133,7 @@ impl Prover {
             self.step(msg.into(), Some(&send_message))?;
             connection.update_message_status(uid)?;
         }
-        Ok(self.state())
+        Ok(self.get_state())
     }
 }
 

--- a/libvcx/src/aries/mod.rs
+++ b/libvcx/src/aries/mod.rs
@@ -164,7 +164,7 @@ pub mod test {
             alice.credential_handle = credential_handle;
 
             credential::send_credential_request(alice.credential_handle, alice_connection_by_handle).unwrap();
-            assert_eq!(2, credential::get_state(alice.credential_handle).unwrap());
+            assert_eq!(1, credential::get_state(alice.credential_handle).unwrap());
         }
 
         faber.send_credential();
@@ -183,11 +183,11 @@ pub mod test {
             let credentials = alice.get_credentials_for_presentation();
 
             disclosed_proof::generate_proof(alice.presentation_handle, credentials.to_string(), String::from("{}")).unwrap();
-            assert_eq!(3, disclosed_proof::get_state(alice.presentation_handle).unwrap());
+            assert_eq!(1, disclosed_proof::get_state(alice.presentation_handle).unwrap());
 
             let alice_connection_by_handle = connection::store_connection(alice.connection.clone()).unwrap();
             disclosed_proof::send_proof(alice.presentation_handle, alice_connection_by_handle).unwrap();
-            assert_eq!(2, disclosed_proof::get_state(alice.presentation_handle).unwrap());
+            assert_eq!(3, disclosed_proof::get_state(alice.presentation_handle).unwrap());
         }
 
         faber.verify_presentation();
@@ -235,7 +235,7 @@ pub mod test {
 
             let alice_connection_by_handle = connection::store_connection(alice.connection.clone()).unwrap();
             credential::send_credential_request(alice.credential_handle, alice_connection_by_handle).unwrap();
-            assert_eq!(2, credential::get_state(alice.credential_handle).unwrap());
+            assert_eq!(1, credential::get_state(alice.credential_handle).unwrap());
         }
 
         faber.send_credential();
@@ -255,11 +255,11 @@ pub mod test {
             let credentials = alice.get_credentials_for_presentation();
 
             disclosed_proof::generate_proof(alice.presentation_handle, credentials.to_string(), String::from("{}")).unwrap();
-            assert_eq!(3, disclosed_proof::get_state(alice.presentation_handle).unwrap());
+            assert_eq!(1, disclosed_proof::get_state(alice.presentation_handle).unwrap());
 
             let alice_connection_by_handle = connection::store_connection(alice.connection.clone()).unwrap();
             disclosed_proof::send_proof(alice.presentation_handle, alice_connection_by_handle).unwrap();
-            assert_eq!(2, disclosed_proof::get_state(alice.presentation_handle).unwrap());
+            assert_eq!(3, disclosed_proof::get_state(alice.presentation_handle).unwrap());
         }
 
         faber.verify_presentation();

--- a/libvcx/src/lib.rs
+++ b/libvcx/src/lib.rs
@@ -928,4 +928,15 @@ mod tests {
         proof::update_state(proof_handle_verifier, None, verifier_to_consumer).unwrap();
         assert_eq!(proof::get_proof_state(proof_handle_verifier).unwrap(), ProofStateType::ProofInvalid as u32);
     }
+
+    #[test]
+    #[cfg(feature = "agency_pool_tests")]
+    pub fn test_two_enterprise_connections() {
+        let _setup = SetupLibraryAgencyV2ZeroFees::init();
+        let mut institution = Faber::setup();
+        let mut consumer1 = Alice::setup();
+
+        let (_faber, _alice) = connection::tests::create_and_store_connected_connections(&mut consumer1, &mut institution);
+        let (_faber, _alice) = connection::tests::create_and_store_connected_connections(&mut consumer1, &mut institution);
+    }
 }

--- a/libvcx/src/lib.rs
+++ b/libvcx/src/lib.rs
@@ -60,7 +60,6 @@ mod tests {
     use crate::api_lib::api_handle::issuer_credential;
     use crate::api_lib::api_handle::proof;
     use crate::api_lib::ProofStateType;
-    use crate::api_lib::VcxStateType;
     use crate::filters;
     use crate::settings;
     use crate::utils::{
@@ -69,6 +68,10 @@ mod tests {
     };
     use crate::utils::devsetup::*;
     use crate::utils::devsetup_agent::test::{Alice, Faber, TestAgent};
+    use crate::aries::handlers::issuance::holder::holder::HolderState;
+    use crate::aries::handlers::issuance::issuer::issuer::IssuerState;
+    use crate::aries::handlers::proof_presentation::prover::prover::ProverState;
+    use crate::aries::handlers::proof_presentation::verifier::verifier::VerifierState;
 
     use super::*;
 
@@ -179,7 +182,7 @@ mod tests {
         let offers = serde_json::to_string(&offers[0]).unwrap();
         info!("send_cred_req :: creating credential from offer");
         let credential = credential::credential_create_with_offer("TEST_CREDENTIAL", &offers).unwrap();
-        assert_eq!(VcxStateType::VcxStateRequestReceived as u32, credential::get_state(credential).unwrap());
+        assert_eq!(HolderState::OfferReceived as u32, credential::get_state(credential).unwrap());
         info!("send_cred_req :: sending credential request");
         credential::send_credential_request(credential, connection).unwrap();
         thread::sleep(Duration::from_millis(2000));
@@ -191,7 +194,7 @@ mod tests {
         info!("send_credential >>> getting offers");
         assert_eq!(issuer_credential::is_revokable(handle_issuer_credential).unwrap(), revokable);
         issuer_credential::update_state(handle_issuer_credential, None, issuer_to_consumer).unwrap();
-        assert_eq!(VcxStateType::VcxStateRequestReceived as u32, issuer_credential::get_state(handle_issuer_credential).unwrap());
+        assert_eq!(IssuerState::RequestReceived as u32, issuer_credential::get_state(handle_issuer_credential).unwrap());
         assert_eq!(issuer_credential::is_revokable(handle_issuer_credential).unwrap(), revokable);
 
         info!("send_credential >>> sending credential");
@@ -202,7 +205,7 @@ mod tests {
         info!("send_credential >>> storing credential");
         assert_eq!(credential::is_revokable(handle_holder_credential).unwrap(), revokable);
         credential::update_state(handle_holder_credential, None, consumer_to_issuer).unwrap();
-        assert_eq!(VcxStateType::VcxStateAccepted as u32, credential::get_state(handle_holder_credential).unwrap());
+        assert_eq!(HolderState::Finished as u32, credential::get_state(handle_holder_credential).unwrap());
         assert_eq!(credential::is_revokable(handle_holder_credential).unwrap(), revokable);
 
         if revokable {
@@ -254,7 +257,7 @@ mod tests {
         disclosed_proof::send_proof(proof_handle, connection_handle).unwrap();
         info!("generate_and_send_proof :: proof sent");
 
-        assert_eq!(VcxStateType::VcxStateOfferSent as u32, disclosed_proof::get_state(proof_handle).unwrap());
+        assert_eq!(ProverState::PresentationSent as u32, disclosed_proof::get_state(proof_handle).unwrap());
         thread::sleep(Duration::from_millis(5000));
     }
 

--- a/libvcx/src/libindy/utils/wallet.rs
+++ b/libvcx/src/libindy/utils/wallet.rs
@@ -357,8 +357,6 @@ pub fn import(restore_config: &RestoreWalletConfigs) -> VcxResult<()> {
 pub mod tests {
     use agency_client::agency_settings;
 
-    use crate::api_lib;
-    use crate::api_lib::api_c;
     use crate::libindy::utils::signus::create_and_store_my_did;
     use crate::utils::devsetup::{SetupDefaults, SetupLibraryWallet, TempFile};
     use crate::utils::get_temp_dir_path;
@@ -544,7 +542,7 @@ pub mod tests {
         let id = "id1";
         let value = "value1";
 
-        api_c::vcx::vcx_shutdown(true);
+        // api_c::vcx::vcx_shutdown(true);
 
         let import_config = RestoreWalletConfigs {
             wallet_name: wallet_name.clone(),

--- a/libvcx/src/utils/devsetup.rs
+++ b/libvcx/src/utils/devsetup.rs
@@ -15,7 +15,6 @@ use crate::utils::devsetup_agent::test::{Alice, Faber, TestAgent};
 use crate::utils::file::write_file;
 use crate::utils::get_temp_dir_path;
 use crate::utils::logger::LibvcxDefaultLogger;
-use crate::api_lib::api_handle::object_cache::ObjectCache;
 use crate::utils::plugins::init_plugin;
 
 pub struct SetupEmpty; // clears settings, setups up logging
@@ -427,23 +426,5 @@ impl TempFile {
 impl Drop for TempFile {
     fn drop(&mut self) {
         fs::remove_file(&self.path).unwrap()
-    }
-}
-
-#[cfg(feature = "agency_pool_tests")]
-mod tests {
-    use crate::api_lib::api_handle::connection;
-
-    use super::*;
-
-    #[cfg(feature = "agency_pool_tests")]
-    #[test]
-    pub fn test_two_enterprise_connections() {
-        let _setup = SetupLibraryAgencyV2ZeroFees::init();
-        let mut institution = Faber::setup();
-        let mut consumer1 = Alice::setup();
-
-        let (_faber, _alice) = connection::tests::create_and_store_connected_connections(&mut consumer1, &mut institution);
-        let (_faber, _alice) = connection::tests::create_and_store_connected_connections(&mut consumer1, &mut institution);
     }
 }

--- a/libvcx/src/utils/devsetup_agent.rs
+++ b/libvcx/src/utils/devsetup_agent.rs
@@ -240,14 +240,14 @@ pub mod test {
             let connection_by_handle = connection::store_connection(self.connection.clone()).unwrap();
             issuer_credential::send_credential_offer(self.credential_handle, connection_by_handle, None).unwrap();
             issuer_credential::update_state(self.credential_handle, None, connection_by_handle).unwrap();
-            assert_eq!(2, issuer_credential::get_state(self.credential_handle).unwrap());
+            assert_eq!(1, issuer_credential::get_state(self.credential_handle).unwrap());
         }
 
         pub fn send_credential(&mut self) {
             self.activate().unwrap();
             let connection_by_handle = connection::store_connection(self.connection.clone()).unwrap();
             issuer_credential::update_state(self.credential_handle, None, connection_by_handle).unwrap();
-            assert_eq!(3, issuer_credential::get_state(self.credential_handle).unwrap());
+            assert_eq!(2, issuer_credential::get_state(self.credential_handle).unwrap());
 
             issuer_credential::send_credential(self.credential_handle, connection_by_handle).unwrap();
             issuer_credential::update_state(self.credential_handle, None, connection_by_handle).unwrap();
@@ -258,18 +258,18 @@ pub mod test {
         pub fn request_presentation(&mut self) {
             self.activate().unwrap();
             self.presentation_handle = self.create_presentation_request();
-            assert_eq!(1, proof::get_state(self.presentation_handle).unwrap());
+            assert_eq!(0, proof::get_state(self.presentation_handle).unwrap());
 
             let connection_by_handle = connection::store_connection(self.connection.clone()).unwrap();
             proof::send_proof_request(self.presentation_handle, connection_by_handle, None).unwrap();
             proof::update_state(self.presentation_handle, None, connection_by_handle).unwrap();
 
-            assert_eq!(2, proof::get_state(self.presentation_handle).unwrap());
+            assert_eq!(1, proof::get_state(self.presentation_handle).unwrap());
         }
 
         pub fn verify_presentation(&mut self) {
             self.activate().unwrap();
-            self.update_proof_state(4, aries::messages::status::Status::Success.code())
+            self.update_proof_state(2, aries::messages::status::Status::Success.code())
         }
 
         pub fn update_proof_state(&mut self, expected_state: u32, expected_status: u32) {
@@ -363,17 +363,17 @@ pub mod test {
             let offer_json = serde_json::to_string(&offer).unwrap();
 
             self.credential_handle = credential::credential_create_with_offer("degree", &offer_json).unwrap();
-            assert_eq!(3, credential::get_state(self.credential_handle).unwrap());
+            assert_eq!(0, credential::get_state(self.credential_handle).unwrap());
 
             credential::send_credential_request(self.credential_handle, connection_by_handle).unwrap();
-            assert_eq!(2, credential::get_state(self.credential_handle).unwrap());
+            assert_eq!(1, credential::get_state(self.credential_handle).unwrap());
         }
 
         pub fn accept_credential(&mut self) {
             self.activate().unwrap();
             let connection_by_handle = connection::store_connection(self.connection.clone()).unwrap();
             credential::update_state(self.credential_handle, None, connection_by_handle).unwrap();
-            assert_eq!(4, credential::get_state(self.credential_handle).unwrap());
+            assert_eq!(2, credential::get_state(self.credential_handle).unwrap());
             assert_eq!(aries::messages::status::Status::Success.code(), credential::get_credential_status(self.credential_handle).unwrap());
         }
 
@@ -410,11 +410,11 @@ pub mod test {
             let credentials = self.get_credentials_for_presentation();
 
             disclosed_proof::generate_proof(self.presentation_handle, credentials.to_string(), String::from("{}")).unwrap();
-            assert_eq!(3, disclosed_proof::get_state(self.presentation_handle).unwrap());
+            assert_eq!(1, disclosed_proof::get_state(self.presentation_handle).unwrap());
 
             let connection_by_handle = connection::store_connection(self.connection.clone()).unwrap();
             disclosed_proof::send_proof(self.presentation_handle, connection_by_handle).unwrap();
-            assert_eq!(2, disclosed_proof::get_state(self.presentation_handle).unwrap());
+            assert_eq!(3, disclosed_proof::get_state(self.presentation_handle).unwrap());
         }
 
         pub fn decline_presentation_request(&mut self) {

--- a/wrappers/node/src/api/common.ts
+++ b/wrappers/node/src/api/common.ts
@@ -105,33 +105,12 @@ export enum VCXCode {
   INVALID_REDIRECT_DETAILS = 1104,
   NO_AGENT_INFO = 1106,
 }
-export enum StateType {
-  None = 0,
-  Initialized = 1,
-  OfferSent = 2,
-  RequestReceived = 3,
-  Accepted = 4,
-  Unfulfilled = 5,
-  Expired = 6,
-  Revoked = 7,
-  Redirected = 8,
-  Rejected = 9,
-}
-
-export enum InviterStateType {
+export enum ConnectionStateType {
   Null = 0,
   Invited = 1,
   Requested = 2,
   Responded = 3,
-  Completed = 4
-}
-
-export enum InviteeStateType {
-  Null = 0,
-  Invited = 1,
-  Requested = 2,
-  Responded = 3,
-  Completed = 4
+  Finished = 4,
 }
 
 export enum HolderStateType {

--- a/wrappers/node/src/api/common.ts
+++ b/wrappers/node/src/api/common.ts
@@ -118,6 +118,55 @@ export enum StateType {
   Rejected = 9,
 }
 
+export enum InviterStateType {
+  Null = 0,
+  Invited = 1,
+  Requested = 2,
+  Responded = 3,
+  Completed = 4
+}
+
+export enum InviteeStateType {
+  Null = 0,
+  Invited = 1,
+  Requested = 2,
+  Responded = 3,
+  Completed = 4
+}
+
+export enum HolderStateType {
+  OfferReceived = 0,
+  RequestSent = 1,
+  Finished = 2,
+  Failed = 3,
+}
+
+export enum IssuerStateType {
+  Initial = 0,
+  OfferSent = 1,
+  RequestReceived = 2,
+  CredentialSent = 3,
+  Finished = 4,
+  Failed = 5,
+}
+
+export enum ProverStateType {
+  Initial = 0,
+  PresentationPrepared = 1,
+  PresentationPreparationFailed = 2,
+  PresentationSent = 3,
+  Finished = 4,
+  Failed = 5,
+}
+
+export enum VerifierStateType {
+  Initial = 0,
+  PresentationRequestSent = 1,
+  Finished = 2,
+  Failed = 3,
+}
+
+
 export interface IInitVCXOptions {
   libVCXPath?: string;
 }

--- a/wrappers/node/src/api/connection.ts
+++ b/wrappers/node/src/api/connection.ts
@@ -3,7 +3,7 @@ import * as ref from 'ref-napi';
 import { VCXInternalError } from '../errors';
 import { rustAPI } from '../rustlib';
 import { createFFICallbackPromise, ICbRef } from '../utils/ffi-helpers';
-import { ISerializedData, StateType } from './common';
+import { ISerializedData } from './common';
 import { VCXBaseWithState } from './vcx-base-with-state';
 import { PtrBuffer } from './utils';
 
@@ -105,7 +105,7 @@ export interface IConnectionData {
   endpoint: string;
   uuid: string;
   wallet: string;
-  state: StateType;
+  state: number;
 }
 
 /**
@@ -335,14 +335,14 @@ export class Connection extends VCXBaseWithState<IConnectionData> {
             cb,
           );
           if (rc) {
-            resolve(StateType.None);
+            resolve(0);
           }
         },
         (resolve, reject) =>
           ffi.Callback(
             'void',
             ['uint32', 'uint32', 'uint32'],
-            (handle: number, err: number, _state: StateType) => {
+            (handle: number, err: number, _state: number) => {
               if (err) {
                 reject(err);
               }
@@ -373,14 +373,14 @@ export class Connection extends VCXBaseWithState<IConnectionData> {
               (resolve, reject, cb) => {
                   const rc = this._updateStFn(commandHandle, this.handle, cb);
                   if (rc) {
-                      resolve(StateType.None);
+                      resolve(0);
                   }
               },
               (resolve, reject) =>
                   ffi.Callback(
                       'void',
                       ['uint32', 'uint32', 'uint32'],
-                      (handle: number, err: number, _state: StateType) => {
+                      (handle: number, err: number, _state: number) => {
                           if (err) {
                               reject(err);
                           }

--- a/wrappers/node/src/api/connection.ts
+++ b/wrappers/node/src/api/connection.ts
@@ -3,7 +3,7 @@ import * as ref from 'ref-napi';
 import { VCXInternalError } from '../errors';
 import { rustAPI } from '../rustlib';
 import { createFFICallbackPromise, ICbRef } from '../utils/ffi-helpers';
-import { ISerializedData } from './common';
+import { ISerializedData, ConnectionStateType } from './common';
 import { VCXBaseWithState } from './vcx-base-with-state';
 import { PtrBuffer } from './utils';
 
@@ -105,7 +105,7 @@ export interface IConnectionData {
   endpoint: string;
   uuid: string;
   wallet: string;
-  state: number;
+  state: ConnectionStateType;
 }
 
 /**
@@ -237,7 +237,7 @@ export async function downloadMessagesV2({
 /**
  * @class Class representing a Connection
  */
-export class Connection extends VCXBaseWithState<IConnectionData> {
+export class Connection extends VCXBaseWithState<IConnectionData, ConnectionStateType> {
     /**
    * Create a connection object, represents a single endpoint and can be used for sending and receiving
    * credentials and proofs

--- a/wrappers/node/src/api/credential.ts
+++ b/wrappers/node/src/api/credential.ts
@@ -3,7 +3,7 @@ import { Callback } from 'ffi-napi';
 import { VCXInternalError } from '../errors';
 import { rustAPI } from '../rustlib';
 import { createFFICallbackPromise } from '../utils/ffi-helpers';
-import { ISerializedData } from './common';
+import { ISerializedData, HolderStateType } from './common';
 import { Connection } from './connection';
 import { VCXBaseWithState } from './vcx-base-with-state';
 import { PaymentManager } from './vcx-payment-txn';
@@ -104,7 +104,7 @@ export class CredentialPaymentManager extends PaymentManager {
 /**
  * A Credential Object, which is issued by the issuing party to the prover and stored in the prover's wallet.
  */
-export class Credential extends VCXBaseWithState<ICredentialStructData> {
+export class Credential extends VCXBaseWithState<ICredentialStructData, HolderStateType> {
   /**
    * Creates a credential with an offer.
    *

--- a/wrappers/node/src/api/disclosed-proof.ts
+++ b/wrappers/node/src/api/disclosed-proof.ts
@@ -3,7 +3,7 @@ import { Callback } from 'ffi-napi';
 import { VCXInternalError } from '../errors';
 import { rustAPI } from '../rustlib';
 import { createFFICallbackPromise } from '../utils/ffi-helpers';
-import { ISerializedData } from './common';
+import { ISerializedData, ProverStateType } from './common';
 import { Connection } from './connection';
 import { VCXBaseWithState } from './vcx-base-with-state';
 
@@ -126,7 +126,7 @@ export interface IDeclinePresentationRequestData {
   proposal?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
-export class DisclosedProof extends VCXBaseWithState<IDisclosedProofData> {
+export class DisclosedProof extends VCXBaseWithState<IDisclosedProofData, ProverStateType> {
   /**
    * Create a proof for fulfilling a corresponding proof request
    *

--- a/wrappers/node/src/api/issuer-credential.ts
+++ b/wrappers/node/src/api/issuer-credential.ts
@@ -2,7 +2,7 @@ import * as ffi from 'ffi-napi';
 import { VCXInternalError } from '../errors';
 import { rustAPI } from '../rustlib';
 import { createFFICallbackPromise } from '../utils/ffi-helpers';
-import { ISerializedData } from './common';
+import { ISerializedData, IssuerStateType } from './common';
 import { Connection } from './connection';
 import { VCXBaseWithState } from './vcx-base-with-state';
 import { PaymentManager } from './vcx-payment-txn';
@@ -97,7 +97,7 @@ export class IssuerCredentialPaymentManager extends PaymentManager {
 /**
  * A Credential created by the issuing party (institution)
  */
-export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData> {
+export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData, IssuerStateType> {
   /**
    * Create a Issuer Credential object that provides a credential for an enterprise's user
    * Assumes a credential definition has been already written to the ledger.

--- a/wrappers/node/src/api/issuer-credential.ts
+++ b/wrappers/node/src/api/issuer-credential.ts
@@ -289,15 +289,6 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData> {
    * Sends the credential to the end user.
    *
    * Credential is made up of the data sent during Credential Offer
-   * ```
-   * connection = await connectionCreateConnect()
-   * issuerCredential = await issuerCredentialCreate()
-   * await issuerCredential.sendOffer(connection)
-   * await issuerCredential.updateState()
-   * assert.equal(await issuerCredential.getState(), StateType.RequestReceived)
-   * await issuerCredential.sendCredential(connection)
-   * ```
-   *
    */
   public async sendCredential(connection: Connection): Promise<void> {
     try {
@@ -326,15 +317,6 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData> {
    * Gets the credential message for sending to connection.
    *
    * Credential is made up of the data sent during Credential Offer
-   * ```
-   * connection = await connectionCreateConnect()
-   * issuerCredential = await issuerCredentialCreate()
-   * await issuerCredential.sendOffer(connection)
-   * await issuerCredential.updateState()
-   * assert.equal(await issuerCredential.getState(), StateType.RequestReceived)
-   * await issuerCredential.getCredentialMsg()
-   * ```
-   *
    */
   public async getCredentialMsg(myPwDid: string): Promise<string> {
     try {
@@ -371,16 +353,6 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData> {
    * Revokes credential.
    *
    * Credential is made up of the data sent during Credential Offer
-   * ```
-   * connection = await connectionCreateConnect()
-   * issuerCredential = await issuerCredentialCreate()
-   * await issuerCredential.sendOffer(connection)
-   * await issuerCredential.updateState()
-   * assert.equal(await issuerCredential.getState(), StateType.RequestReceived)
-   * await issuerCredential.sendCredential(connection)
-   * await issuerCredential.revokeCredential()
-   * ```
-   *
    */
   public async revokeCredential(): Promise<void> {
     try {

--- a/wrappers/node/src/api/issuer-credential.ts
+++ b/wrappers/node/src/api/issuer-credential.ts
@@ -66,6 +66,7 @@ export interface IIssuerCredentialCreateData {
   credentialName: string;
   // price of credential
   price: string;
+  issuerDid: string;
 }
 
 export interface IIssuerCredentialVCXAttributes {
@@ -112,6 +113,7 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData> {
     credDefHandle,
     credentialName,
     price,
+    issuerDid,
   }: IIssuerCredentialCreateData): Promise<IssuerCredential> {
     try {
       const attrsVCX: IIssuerCredentialVCXAttributes = attr;
@@ -123,7 +125,6 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData> {
       });
       const attrsStringified = attrsVCX ? JSON.stringify(attrsVCX) : attrsVCX;
       const commandHandle = 0;
-      const issuerDid = null;
       await credential._create((cb) =>
         rustAPI().vcx_issuer_create_credential(
           commandHandle,

--- a/wrappers/node/src/api/proof.ts
+++ b/wrappers/node/src/api/proof.ts
@@ -2,7 +2,7 @@ import * as ffi from 'ffi-napi';
 import { VCXInternalError } from '../errors';
 import { rustAPI } from '../rustlib';
 import { createFFICallbackPromise } from '../utils/ffi-helpers';
-import { ISerializedData } from './common';
+import { ISerializedData, VerifierStateType } from './common';
 import { Connection } from './connection';
 import { VCXBaseWithState } from './vcx-base-with-state';
 
@@ -166,7 +166,7 @@ export interface IRevocationInterval {
 /**
  * Class representing a Proof
  */
-export class Proof extends VCXBaseWithState<IProofData> {
+export class Proof extends VCXBaseWithState<IProofData, VerifierStateType> {
   /**
    * Get the state of the proof
    */

--- a/wrappers/node/src/api/proof.ts
+++ b/wrappers/node/src/api/proof.ts
@@ -2,7 +2,7 @@ import * as ffi from 'ffi-napi';
 import { VCXInternalError } from '../errors';
 import { rustAPI } from '../rustlib';
 import { createFFICallbackPromise } from '../utils/ffi-helpers';
-import { ISerializedData, StateType } from './common';
+import { ISerializedData } from './common';
 import { Connection } from './connection';
 import { VCXBaseWithState } from './vcx-base-with-state';
 
@@ -78,7 +78,7 @@ export interface IProofData {
   requested_attrs: string;
   requested_predicates: string;
   prover_did: string;
-  state: StateType;
+  state: number;
   name: string;
   proof_state: ProofState;
   proof: any; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -169,43 +169,12 @@ export interface IRevocationInterval {
 export class Proof extends VCXBaseWithState<IProofData> {
   /**
    * Get the state of the proof
-   *
-   * Example
-   * ```
-   * data = {
-   *   attrs: [
-   *     { name: 'attr1' },
-   *     { name: 'attr2' }],
-   *   name: 'Proof',
-   *   sourceId: 'testProofSourceId'
-   * }
-   * proof = await Proof.create(data)
-   * await proof.requestProof(connection)
-   * assert.equal(await proof.getState(), StateType.OfferSent)
-   * ```
    */
   get proofState(): ProofState | null {
     return this._proofState;
   }
   /**
    * Get the attributes of the proof
-   *
-   * Example
-   * ```
-   * data = {
-   *   attrs: [
-   *     { name: 'attr1' },
-   *     { name: 'attr2' }],
-   *   name: 'Proof',
-   *   sourceId: 'testProofSourceId'
-   * }
-   * proof = await Proof.create(data)
-   * await proof.requestProof(connection)
-   * assert.equal(await proof.getState(), StateType.OfferSent)
-   * proofData = await proof.getProof(connection)
-   * await proof.updateState()
-   * assert.equal(await proof.requestedAttributes(), data.attrs)
-   * ```
    */
   get requestedAttributes(): IProofAttr[] {
     return this._requestedAttributes;
@@ -217,23 +186,6 @@ export class Proof extends VCXBaseWithState<IProofData> {
 
   /**
    * Get the name of the proof
-   *
-   * Example
-   * ```
-   * data = {
-   *   attrs: [
-   *     { name: 'attr1' },
-   *     { name: 'attr2' }],
-   *   name: 'Proof',
-   *   sourceId: 'testProofSourceId'
-   * }
-   * proof = await Proof.create(data)
-   * await proof.requestProof(connection)
-   * assert.equal(await proof.getState(), StateType.OfferSent)
-   * proofData = await proof.getProof(connection)
-   * await proof.updateState()
-   * assert.equal(await proof.name(), data.name)
-   * ```
    */
   get name(): string {
     return this._name;

--- a/wrappers/node/src/api/vcx-base-with-state.ts
+++ b/wrappers/node/src/api/vcx-base-with-state.ts
@@ -10,24 +10,24 @@ export abstract class VCXBaseWithState<SerializedData, StateType> extends VCXBas
     handle: number,
     connHandle: number,
     cb: ICbRef,
-  ) => StateType | number;
-  protected abstract _getStFn: (commandHandle: number, handle: number, cb: ICbRef) => StateType | number;
+  ) => number;
+  protected abstract _getStFn: (commandHandle: number, handle: number, cb: ICbRef) => number;
 
-  public async updateStateV2(connection: Connection): Promise<StateType | number> {
+  public async updateStateV2(connection: Connection): Promise<StateType> {
     try {
       const commandHandle = 0;
-      const state = await createFFICallbackPromise<StateType | number>(
+      const state = await createFFICallbackPromise<StateType>(
         (resolve, reject, cb) => {
           const rc = this._updateStFnV2(commandHandle, this.handle, connection.handle, cb);
           if (rc) {
-            resolve(0);
+            reject(rc);
           }
         },
         (resolve, reject) =>
           ffi.Callback(
             'void',
             ['uint32', 'uint32', 'uint32'],
-            (handle: number, err: number, _state: StateType | number) => {
+            (handle: number, err: number, _state: StateType) => {
               if (err) {
                 reject(err);
               }
@@ -48,23 +48,23 @@ export abstract class VCXBaseWithState<SerializedData, StateType> extends VCXBas
    * ```
    * state = await object.getState()
    * ```
-   * @returns {Promise<StateType | number>}
+   * @returns {Promise<StateType>}
    */
-  public async getState(): Promise<StateType | number> {
+  public async getState(): Promise<StateType> {
     try {
       const commandHandle = 0;
-      const stateRes = await createFFICallbackPromise<StateType | number>(
+      const stateRes = await createFFICallbackPromise<StateType>(
         (resolve, reject, cb) => {
           const rc = this._getStFn(commandHandle, this.handle, cb);
           if (rc) {
-            resolve(0);
+            reject(rc);
           }
         },
         (resolve, reject) =>
           ffi.Callback(
             'void',
             ['uint32', 'uint32', 'uint32'],
-            (handle: number, err: number, state: StateType | number) => {
+            (handle: number, err: number, state: StateType) => {
               if (err) {
                 reject(err);
               }

--- a/wrappers/node/src/api/vcx-base-with-state.ts
+++ b/wrappers/node/src/api/vcx-base-with-state.ts
@@ -1,7 +1,6 @@
 import * as ffi from 'ffi-napi';
 import { VCXInternalError } from '../errors';
 import { createFFICallbackPromise, ICbRef } from '../utils/ffi-helpers';
-import { StateType } from './common';
 import { Connection } from './connection';
 import { VCXBase } from './vcx-base';
 
@@ -21,14 +20,14 @@ export abstract class VCXBaseWithState<SerializedData> extends VCXBase<Serialize
         (resolve, reject, cb) => {
           const rc = this._updateStFnV2(commandHandle, this.handle, connection.handle, cb);
           if (rc) {
-            resolve(StateType.None);
+            resolve(0);
           }
         },
         (resolve, reject) =>
           ffi.Callback(
             'void',
             ['uint32', 'uint32', 'uint32'],
-            (handle: number, err: number, _state: StateType) => {
+            (handle: number, err: number, _state: number) => {
               if (err) {
                 reject(err);
               }
@@ -49,23 +48,23 @@ export abstract class VCXBaseWithState<SerializedData> extends VCXBase<Serialize
    * ```
    * state = await object.getState()
    * ```
-   * @returns {Promise<StateType>}
+   * @returns {Promise<number>}
    */
-  public async getState(): Promise<StateType> {
+  public async getState(): Promise<number> {
     try {
       const commandHandle = 0;
-      const stateRes = await createFFICallbackPromise<StateType>(
+      const stateRes = await createFFICallbackPromise<number>(
         (resolve, reject, cb) => {
           const rc = this._getStFn(commandHandle, this.handle, cb);
           if (rc) {
-            resolve(StateType.None);
+            resolve(0);
           }
         },
         (resolve, reject) =>
           ffi.Callback(
             'void',
             ['uint32', 'uint32', 'uint32'],
-            (handle: number, err: number, state: StateType) => {
+            (handle: number, err: number, state: number) => {
               if (err) {
                 reject(err);
               }

--- a/wrappers/node/src/api/vcx-base-with-state.ts
+++ b/wrappers/node/src/api/vcx-base-with-state.ts
@@ -4,19 +4,19 @@ import { createFFICallbackPromise, ICbRef } from '../utils/ffi-helpers';
 import { Connection } from './connection';
 import { VCXBase } from './vcx-base';
 
-export abstract class VCXBaseWithState<SerializedData> extends VCXBase<SerializedData> {
+export abstract class VCXBaseWithState<SerializedData, StateType> extends VCXBase<SerializedData> {
   protected abstract _updateStFnV2: (
     commandHandle: number,
     handle: number,
     connHandle: number,
     cb: ICbRef,
-  ) => number;
-  protected abstract _getStFn: (commandHandle: number, handle: number, cb: ICbRef) => number;
+  ) => StateType | number;
+  protected abstract _getStFn: (commandHandle: number, handle: number, cb: ICbRef) => StateType | number;
 
-  public async updateStateV2(connection: Connection): Promise<number> {
+  public async updateStateV2(connection: Connection): Promise<StateType | number> {
     try {
       const commandHandle = 0;
-      const state = await createFFICallbackPromise<number>(
+      const state = await createFFICallbackPromise<StateType | number>(
         (resolve, reject, cb) => {
           const rc = this._updateStFnV2(commandHandle, this.handle, connection.handle, cb);
           if (rc) {
@@ -27,7 +27,7 @@ export abstract class VCXBaseWithState<SerializedData> extends VCXBase<Serialize
           ffi.Callback(
             'void',
             ['uint32', 'uint32', 'uint32'],
-            (handle: number, err: number, _state: number) => {
+            (handle: number, err: number, _state: StateType | number) => {
               if (err) {
                 reject(err);
               }
@@ -48,12 +48,12 @@ export abstract class VCXBaseWithState<SerializedData> extends VCXBase<Serialize
    * ```
    * state = await object.getState()
    * ```
-   * @returns {Promise<number>}
+   * @returns {Promise<StateType | number>}
    */
-  public async getState(): Promise<number> {
+  public async getState(): Promise<StateType | number> {
     try {
       const commandHandle = 0;
-      const stateRes = await createFFICallbackPromise<number>(
+      const stateRes = await createFFICallbackPromise<StateType | number>(
         (resolve, reject, cb) => {
           const rc = this._getStFn(commandHandle, this.handle, cb);
           if (rc) {
@@ -64,7 +64,7 @@ export abstract class VCXBaseWithState<SerializedData> extends VCXBase<Serialize
           ffi.Callback(
             'void',
             ['uint32', 'uint32', 'uint32'],
-            (handle: number, err: number, state: number) => {
+            (handle: number, err: number, state: StateType | number) => {
               if (err) {
                 reject(err);
               }

--- a/wrappers/node/test/helpers/entities.ts
+++ b/wrappers/node/test/helpers/entities.ts
@@ -214,6 +214,7 @@ export const dataIssuerCredentialCreate = async (): Promise<IIssuerCredentialCre
     },
     credDefHandle: Number(credDef.handle),
     credentialName: 'Credential Name',
+    issuerDid: 'V4SGRU86Z58d6TV7PBUe6f',
     price: '1',
     sourceId: 'testCredentialSourceId',
   };

--- a/wrappers/node/test/suite1/ariesvcx-connection.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-connection.test.ts
@@ -130,15 +130,15 @@ describe('Connection:', () => {
   });
 
   describe('updateState:', () => {
-    it(`throws error when not initialized`, async () => {
-      let caught_error
+    it('throws error when not initialized', async () => {
+      let caught_error;
       const connection = new (Connection as any)();
       try {
         await connection.updateState();
       } catch (err) {
-        caught_error = err
+        caught_error = err;
       }
-      assert.isNotNull(caught_error)
+      assert.isNotNull(caught_error);
     });
 
     it(`returns ${ConnectionStateType.Null}: not connected`, async () => {

--- a/wrappers/node/test/suite1/ariesvcx-connection.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-connection.test.ts
@@ -9,7 +9,7 @@ import {
 } from 'helpers/entities';
 import { INVITE_ACCEPTED_MESSAGE } from 'helpers/test-constants';
 import { initVcxTestMode, shouldThrow, sleep } from 'helpers/utils';
-import { Connection, StateType, VCXCode, VCXMock, VCXMockMessage } from 'src';
+import { Connection, ConnectionStateType, VCXCode, VCXMock, VCXMockMessage } from 'src';
 
 describe('Connection:', () => {
   before(() => initVcxTestMode());
@@ -130,45 +130,45 @@ describe('Connection:', () => {
   });
 
   describe('updateState:', () => {
-    it(`returns ${StateType.None}: not initialized`, async () => {
+    it(`returns ${ConnectionStateType.Null}: not initialized`, async () => {
       const connection = new (Connection as any)();
       const state1 = await connection.updateState();
       const state2 = await connection.getState();
       assert.equal(state1, state2);
-      assert.equal(state2, StateType.None);
+      assert.equal(state2, ConnectionStateType.Null);
     });
 
-    it(`returns ${StateType.Initialized}: not connected`, async () => {
+    it(`returns ${ConnectionStateType.Null}: not connected`, async () => {
       const connection = await connectionCreateInviterNull({ id: 'alice' });
       await connection.updateState();
-      assert.equal(await connection.getState(), StateType.None);
+      assert.equal(await connection.getState(), ConnectionStateType.Null);
     });
 
     // todo : restore for aries
-    it.skip(`returns ${StateType.OfferSent}: connected`, async () => {
+    it.skip(`returns ${ConnectionStateType.Finished}: connected`, async () => {
       const connection = await createConnectionInviterRequested();
       VCXMock.setVcxMock(VCXMockMessage.AcceptInvite); // todo: must return Aries mock data
       await connection.updateState();
-      assert.equal(await connection.getState(), StateType.Accepted);
+      assert.equal(await connection.getState(), ConnectionStateType.Finished);
     });
 
     // todo : restore for aries
-    it.skip(`returns ${StateType.Accepted}: mocked accepted`, async () => {
+    it.skip(`returns ${ConnectionStateType.Finished}: mocked accepted`, async () => {
       const connection = await createConnectionInviterRequested();
       VCXMock.setVcxMock(VCXMockMessage.GetMessages);
       await connection.updateState();
-      assert.equal(await connection.getState(), StateType.Accepted);
+      assert.equal(await connection.getState(), ConnectionStateType.Finished);
     });
 
     // todo : restore for aries
-    it.skip(`returns ${StateType.Accepted}: mocked accepted`, async () => {
+    it.skip(`returns ${ConnectionStateType.Finished}: mocked accepted`, async () => {
       const connection = await createConnectionInviterRequested();
       await connection.updateStateWithMessage(INVITE_ACCEPTED_MESSAGE);
-      assert.equal(await connection.getState(), StateType.Accepted);
+      assert.equal(await connection.getState(), ConnectionStateType.Finished);
     });
 
     // todo : restore for aries
-    it.skip(`returns ${StateType.Accepted}: mocked accepted in parallel`, async () => {
+    it.skip(`returns ${ConnectionStateType.Finished}: mocked accepted in parallel`, async () => {
       const numConnections = 50;
       const interval = 50;
       const sleepTime = 100;
@@ -184,7 +184,7 @@ describe('Connection:', () => {
         const states = await Promise.all(
           connectionsWithTimers.map(({ connection }) => connection.getState()),
         );
-        cond = states.every((state) => state === StateType.Accepted);
+        cond = states.every((state) => state === ConnectionStateType.Finished);
         VCXMock.setVcxMock(VCXMockMessage.GetMessages);
         await sleep(sleepTime);
       }

--- a/wrappers/node/test/suite1/ariesvcx-connection.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-connection.test.ts
@@ -130,12 +130,15 @@ describe('Connection:', () => {
   });
 
   describe('updateState:', () => {
-    it(`returns ${ConnectionStateType.Null}: not initialized`, async () => {
+    it(`throws error when not initialized`, async () => {
+      let caught_error
       const connection = new (Connection as any)();
-      const state1 = await connection.updateState();
-      const state2 = await connection.getState();
-      assert.equal(state1, state2);
-      assert.equal(state2, ConnectionStateType.Null);
+      try {
+        await connection.updateState();
+      } catch (err) {
+        caught_error = err
+      }
+      assert.isNotNull(caught_error)
     });
 
     it(`returns ${ConnectionStateType.Null}: not connected`, async () => {

--- a/wrappers/node/test/suite1/ariesvcx-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-credential.test.ts
@@ -14,7 +14,7 @@ import { initVcxTestMode, shouldThrow } from 'helpers/utils';
 import {
   Credential,
   CredentialPaymentManager,
-  StateType,
+  HolderStateType,
   VCXCode,
   VCXMock,
   VCXMockMessage,
@@ -94,9 +94,9 @@ describe('Credential:', () => {
       const connection = await createConnectionInviterRequested();
       const data = await dataCredentialCreateWithOffer();
       const credential = await Credential.create(data);
-      assert.equal(await credential.getState(), 0);
+      assert.equal(await credential.getState(), HolderStateType.OfferReceived);
       credential.sendRequest({ connection, payment: 0 });
-      assert.equal(await credential.getState(), 1);
+      assert.equal(await credential.getState(), HolderStateType.RequestSent);
     });
   });
 
@@ -105,14 +105,14 @@ describe('Credential:', () => {
       const data = await dataCredentialCreateWithOffer();
       const credential = await credentialCreateWithOffer(data);
       await credential.sendRequest({ connection: data.connection, payment: 0 });
-      assert.equal(await credential.getState(), 1);
+      assert.equal(await credential.getState(), HolderStateType.RequestSent);
     });
 
     it('success: with message id', async () => {
       const data = await dataCredentialCreateWithMsgId();
       const credential = await credentialCreateWithMsgId(data);
       await credential.sendRequest({ connection: data.connection, payment: 0 });
-      assert.equal(await credential.getState(), 1);
+      assert.equal(await credential.getState(), HolderStateType.RequestSent);
     });
   });
 

--- a/wrappers/node/test/suite1/ariesvcx-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-credential.test.ts
@@ -94,9 +94,9 @@ describe('Credential:', () => {
       const connection = await createConnectionInviterRequested();
       const data = await dataCredentialCreateWithOffer();
       const credential = await Credential.create(data);
-      assert.equal(await credential.getState(), StateType.RequestReceived);
+      assert.equal(await credential.getState(), 0);
       credential.sendRequest({ connection, payment: 0 });
-      assert.equal(await credential.getState(), StateType.OfferSent);
+      assert.equal(await credential.getState(), 1);
     });
   });
 
@@ -105,14 +105,14 @@ describe('Credential:', () => {
       const data = await dataCredentialCreateWithOffer();
       const credential = await credentialCreateWithOffer(data);
       await credential.sendRequest({ connection: data.connection, payment: 0 });
-      assert.equal(await credential.getState(), StateType.OfferSent);
+      assert.equal(await credential.getState(), 1);
     });
 
     it('success: with message id', async () => {
       const data = await dataCredentialCreateWithMsgId();
       const credential = await credentialCreateWithMsgId(data);
       await credential.sendRequest({ connection: data.connection, payment: 0 });
-      assert.equal(await credential.getState(), StateType.OfferSent);
+      assert.equal(await credential.getState(), 1);
     });
   });
 

--- a/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
@@ -11,7 +11,7 @@ import {
 } from 'helpers/entities'
 import { initVcxTestMode, shouldThrow } from 'helpers/utils';
 import { mapValues } from 'lodash';
-import { DisclosedProof, StateType, VCXCode } from 'src';
+import { DisclosedProof, ProverStateType, VCXCode } from 'src';
 
 describe('DisclosedProof', () => {
   before(() => initVcxTestMode());
@@ -120,20 +120,20 @@ describe('DisclosedProof', () => {
   });
 
   describe('updateState:', () => {
-    it(`returns ${StateType.None}: not initialized`, async () => {
+    it(`returns ${ProverStateType.Initial}: not initialized`, async () => {
       const disclosedProof = new (DisclosedProof as any)();
       const connection = await createConnectionInviterRequested();
       const state1 = await disclosedProof.updateStateV2(connection);
       const state2 = await disclosedProof.getState();
       assert.equal(state1, state2);
-      assert.equal(state2, StateType.None);
+      assert.equal(state2, ProverStateType.Initial);
     });
 
-    it(`returns ${StateType.RequestReceived}: created`, async () => {
+    it(`returns ${ProverStateType.Initial}: created`, async () => {
       const disclosedProof = await disclosedProofCreateWithRequest();
       const connection = await createConnectionInviterRequested();
       await disclosedProof.updateStateV2(connection);
-      assert.equal(await disclosedProof.getState(), 0);
+      assert.equal(await disclosedProof.getState(), ProverStateType.Initial);
     });
   });
 
@@ -142,7 +142,7 @@ describe('DisclosedProof', () => {
       const data = await dataDisclosedProofCreateWithRequest();
       const disclosedProof = await disclosedProofCreateWithRequest(data);
       await disclosedProof.sendProof(data.connection);
-      assert.equal(await disclosedProof.getState(), StateType.Accepted);
+      assert.equal(await disclosedProof.getState(), ProverStateType.PresentationSent);
     });
   });
 
@@ -159,7 +159,7 @@ describe('DisclosedProof', () => {
         sourceId: 'disclosedProofTestSourceId',
       });
       await disclosedProof.updateStateV2(connection);
-      assert.equal(await disclosedProof.getState(), StateType.RequestReceived);
+      assert.equal(await disclosedProof.getState(), ProverStateType.Finished);
     });
   });
 

--- a/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
@@ -120,13 +120,16 @@ describe('DisclosedProof', () => {
   });
 
   describe('updateState:', () => {
-    it(`returns ${ProverStateType.Initial}: not initialized`, async () => {
+    it('Throws error when not initialized', async () => {
+      let caught_error;
       const disclosedProof = new (DisclosedProof as any)();
       const connection = await createConnectionInviterRequested();
-      const state1 = await disclosedProof.updateStateV2(connection);
-      const state2 = await disclosedProof.getState();
-      assert.equal(state1, state2);
-      assert.equal(state2, ProverStateType.Initial);
+      try {
+        await disclosedProof.updateStateV2(connection);
+      } catch (err) {
+        caught_error = err;
+      }
+      assert.isNotNull(caught_error);
     });
 
     it(`returns ${ProverStateType.Initial}: created`, async () => {

--- a/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
@@ -133,7 +133,7 @@ describe('DisclosedProof', () => {
       const disclosedProof = await disclosedProofCreateWithRequest();
       const connection = await createConnectionInviterRequested();
       await disclosedProof.updateStateV2(connection);
-      assert.equal(await disclosedProof.getState(), StateType.RequestReceived);
+      assert.equal(await disclosedProof.getState(), 0);
     });
   });
 

--- a/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
@@ -7,7 +7,7 @@ import {
   issuerCredentialCreate,
 } from 'helpers/entities';
 import { initVcxTestMode, shouldThrow } from 'helpers/utils';
-import { Connection, IssuerCredential, StateType, VCXCode } from 'src';
+import { Connection, IssuerCredential, IssuerStateType, VCXCode } from 'src';
 
 describe('IssuerCredential:', () => {
   before(() => initVcxTestMode());
@@ -120,7 +120,7 @@ describe('IssuerCredential:', () => {
       const issuerCredential = await issuerCredentialCreate();
       const connection = await createConnectionInviterRequested();
       await issuerCredential.sendOffer(connection);
-      assert.equal(await issuerCredential.getState(), 1);
+      assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
     });
   });
 
@@ -129,7 +129,7 @@ describe('IssuerCredential:', () => {
       const connection = await createConnectionInviterRequested();
       const issuerCredential = await issuerCredentialCreate();
       await issuerCredential.sendOffer(connection);
-      assert.equal(await issuerCredential.getState(), 1);
+      assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
     });
 
     it('throws: not initialized', async () => {

--- a/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
@@ -120,7 +120,7 @@ describe('IssuerCredential:', () => {
       const issuerCredential = await issuerCredentialCreate();
       const connection = await createConnectionInviterRequested();
       await issuerCredential.sendOffer(connection);
-      assert.equal(await issuerCredential.getState(), StateType.OfferSent);
+      assert.equal(await issuerCredential.getState(), 1);
     });
   });
 
@@ -129,7 +129,7 @@ describe('IssuerCredential:', () => {
       const connection = await createConnectionInviterRequested();
       const issuerCredential = await issuerCredentialCreate();
       await issuerCredential.sendOffer(connection);
-      assert.equal(await issuerCredential.getState(), StateType.OfferSent);
+      assert.equal(await issuerCredential.getState(), 1);
     });
 
     it('throws: not initialized', async () => {

--- a/wrappers/node/test/suite1/ariesvcx-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-proof.test.ts
@@ -115,14 +115,14 @@ describe('Proof:', () => {
       const state1 = await proof.updateStateV2(connection);
       const state2 = await proof.getState();
       assert.equal(state1, state2);
-      assert.equal(state2, StateType.None);
+      assert.equal(state2, 0);
     });
 
     it(`returns ${StateType.Initialized}: created`, async () => {
       const connection = await createConnectionInviterRequested();
       const proof = await proofCreate();
       await proof.updateStateV2(connection);
-      assert.equal(await proof.getState(), StateType.Initialized);
+      assert.equal(await proof.getState(), 0);
     });
   });
 
@@ -131,7 +131,7 @@ describe('Proof:', () => {
       const connection = await createConnectionInviterRequested();
       const proof = await proofCreate();
       await proof.requestProof(connection);
-      assert.equal(await proof.getState(), StateType.OfferSent);
+      assert.equal(await proof.getState(), 1);
     });
 
     it('successfully get request message', async () => {

--- a/wrappers/node/test/suite1/ariesvcx-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-proof.test.ts
@@ -109,13 +109,16 @@ describe('Proof:', () => {
   });
 
   describe('updateState:', () => {
-    it(`returns ${VerifierStateType.Initial}: created`, async () => {
+    it(`throws error when not initialized`, async () => {
+      let caught_error;
       const proof = new Proof(null as any, {} as any);
       const connection = await createConnectionInviterRequested();
-      const state1 = await proof.updateStateV2(connection);
-      const state2 = await proof.getState();
-      assert.equal(state1, state2);
-      assert.equal(state2, VerifierStateType.Initial);
+      try {
+        await proof.updateStateV2(connection);
+      } catch (err) {
+        caught_error = err;
+      }
+      assert.isNotNull(caught_error);
     });
   });
 

--- a/wrappers/node/test/suite1/ariesvcx-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-proof.test.ts
@@ -8,7 +8,7 @@ import {
   DisclosedProof,
   Proof,
   ProofState,
-  StateType,
+  VerifierStateType,
   VCXCode,
   VCXMock,
   VCXMockMessage,
@@ -109,20 +109,13 @@ describe('Proof:', () => {
   });
 
   describe('updateState:', () => {
-    it(`returns ${StateType.None}: not initialized`, async () => {
+    it(`returns ${VerifierStateType.Initial}: created`, async () => {
       const proof = new Proof(null as any, {} as any);
       const connection = await createConnectionInviterRequested();
       const state1 = await proof.updateStateV2(connection);
       const state2 = await proof.getState();
       assert.equal(state1, state2);
-      assert.equal(state2, 0);
-    });
-
-    it(`returns ${StateType.Initialized}: created`, async () => {
-      const connection = await createConnectionInviterRequested();
-      const proof = await proofCreate();
-      await proof.updateStateV2(connection);
-      assert.equal(await proof.getState(), 0);
+      assert.equal(state2, VerifierStateType.Initial);
     });
   });
 
@@ -131,7 +124,7 @@ describe('Proof:', () => {
       const connection = await createConnectionInviterRequested();
       const proof = await proofCreate();
       await proof.requestProof(connection);
-      assert.equal(await proof.getState(), 1);
+      assert.equal(await proof.getState(), VerifierStateType.PresentationRequestSent);
     });
 
     it('successfully get request message', async () => {


### PR DESCRIPTION
This PR adds new enums representing current state of `IssuerSM`, `HolderSM`, `ProverSM` and `VerifierSM`: `IssuerState`, `HolderState`, `ProverState` and `VerifierState` respectively. Function `get_state()` returns variants of said enums on the internal `aries` level, and these are converted to numeric representations on the C-callable level.

Wrapper now exports enums representing these states in place of `StateType`: `IssuerStateType`, `HolderStateType`, `VerifierStateType`, `IssuerStateType`, `ConnectionStateType`.

This is a breaking change, since the variant representations corresponding to the states returned by `get_state()` function has changed, as well as the numeric representations. For the numeric values, see [here](https://github.com/hyperledger/aries-vcx/pull/314/files#diff-dd5350e4ee5378b3a042f96e8a6fe1cfe838a8a937b55104953acd10d83d8040R34-R80), and for the changes to `get_state()` return values, see corresponding implementations for each of the concerned SMs.

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>