### PR TITLE
Install cargo via rustup in alpine image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,4 @@ Specs/
 docs/
 .github/
 .idea/
+**/*.dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -453,7 +453,7 @@ jobs:
         run: |
           set -x
           sudo rm -rf "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY" "/usr/local/lib/android" "/usr/share/dotnet"
-          docker run --rm -i --name libvcx --network host -e X86_64_ALPINE_LINUX_MUSL_OPENSSL_NO_VENDOR=true $DOCKER_IMG_NAME_LIBVCX \
+          docker run --rm -i --name libvcx --network host -e X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_NO_VENDOR=true $DOCKER_IMG_NAME_LIBVCX \
                               bash -c '(cd $HOME/libvcx && \
                                 RUST_TEST_THREADS=1 cargo test --release --features "general_test" && \
                                 cd $HOME/agency_client && \
@@ -514,7 +514,7 @@ jobs:
       - name: Run pool integration tests
         run: |
           set -x
-          docker run --rm -i --name libvcx --network host -e X86_64_ALPINE_LINUX_MUSL_OPENSSL_NO_VENDOR=true $DOCKER_IMG_NAME_LIBVCX \
+          docker run --rm -i --name libvcx --network host -e X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_NO_VENDOR=true $DOCKER_IMG_NAME_LIBVCX \
                               bash -c '(cd $HOME/libvcx && \
                               RUST_TEST_THREADS=1 TEST_POOL_IP=127.0.0.1 cargo test --release --features "pool_tests agency_v2")'
 
@@ -573,7 +573,7 @@ jobs:
       - name: Run agency+pool integration tests
         run: |
           set -x
-          docker run --rm -i --name libvcx --network host -e X86_64_ALPINE_LINUX_MUSL_OPENSSL_NO_VENDOR=true $DOCKER_IMG_NAME_LIBVCX \
+          docker run --rm -i --name libvcx --network host -e X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_NO_VENDOR=true $DOCKER_IMG_NAME_LIBVCX \
                               bash -c '(cd $HOME/libvcx && \
                               cargo --version && \
                               rustc --version && \

--- a/ci/alpine_core.dockerfile
+++ b/ci/alpine_core.dockerfile
@@ -14,18 +14,19 @@ RUN addgroup -g $GID indy && adduser -u $UID -D -G indy indy
 RUN apk update && apk upgrade && \
     apk add --no-cache \
         build-base \
-        cargo \
         git \
+        curl \
         libsodium-dev \
         libzmq \
         openssl-dev \
         zeromq-dev
 
-ARG RUST_VER="1.53.0"
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
-
 USER indy
 WORKDIR /home/indy
+
+ARG RUST_VER="1.53.0"
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
+ENV PATH="/home/indy/.cargo/bin:$PATH" RUSTFLAGS="-C target-feature=-crt-static"
 
 RUN git clone $INDYSDK_REPO && cd indy-sdk && git checkout $INDYSDK_REVISION
 

--- a/ci/alpine_core.dockerfile
+++ b/ci/alpine_core.dockerfile
@@ -25,7 +25,7 @@ USER indy
 WORKDIR /home/indy
 
 ARG RUST_VER="1.53.0"
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER --default-host x86_64-unknown-linux-musl
 ENV PATH="/home/indy/.cargo/bin:$PATH" RUSTFLAGS="-C target-feature=-crt-static"
 
 RUN git clone $INDYSDK_REPO && cd indy-sdk && git checkout $INDYSDK_REVISION

--- a/ci/libvcx.dockerfile
+++ b/ci/libvcx.dockerfile
@@ -7,10 +7,10 @@ COPY --chown=indy  ./ ./
 
 USER indy
 ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_NO_VENDOR "true"
-RUN cargo build --manifest-path=/home/indy/Cargo.toml
+RUN cargo build --release --manifest-path=/home/indy/Cargo.toml
 
 USER root
-RUN mv /home/indy/target/debug/libvcx.so .
+RUN mv /home/indy/target/release/libvcx.so .
 
 FROM alpine:3.12
 

--- a/ci/libvcx.dockerfile
+++ b/ci/libvcx.dockerfile
@@ -6,11 +6,11 @@ WORKDIR /home/indy
 COPY --chown=indy  ./ ./
 
 USER indy
-ENV X86_64_ALPINE_LINUX_MUSL_OPENSSL_NO_VENDOR "true"
-RUN cargo build --release --manifest-path=/home/indy/Cargo.toml
+ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_NO_VENDOR "true"
+RUN cargo build --manifest-path=/home/indy/Cargo.toml
 
 USER root
-RUN mv /home/indy/target/release/libvcx.so .
+RUN mv /home/indy/target/debug/libvcx.so .
 
 FROM alpine:3.12
 
@@ -32,7 +32,7 @@ RUN echo '@alpine38 http://dl-cdn.alpinelinux.org/alpine/v3.8/main' >> /etc/apk/
 RUN apk update && apk upgrade
 RUN apk add --no-cache \
         bash \
-        cargo \
+        curl \
         g++ \
         gcc \
         git \
@@ -45,15 +45,13 @@ RUN apk add --no-cache \
         python2 \
         zeromq-dev
 
-ARG RUST_VER="1.53.0"
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER
+USER node
 
+ARG RUST_VER="1.53.0"
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VER --default-host x86_64-unknown-linux-musl
+ENV PATH="/home/node/.cargo/bin:$PATH" RUSTFLAGS="-C target-feature=-crt-static"
 
 # copy cargo caches - this way we don't have to redownload dependencies on subsequent builds
 RUN mkdir -p /home/node/.cargo/registry
 COPY --from=builder /home/indy/.cargo/registry /home/node/.cargo/registry
 RUN chown -R node:node /home/node/.cargo/registry
-RUN echo "Cargo registry cache: "
-RUN ls -lah /home/node/.cargo/registry
-
-USER node


### PR DESCRIPTION
Cargo has been installed via apk until now, limiting us with regards to the toolchain version we used to compile our images. Via rustup, we have more freedom to choose the toolchain version.

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>