### PR TITLE
Hotfix/include missed vcx v2 messages download method

### DIFF
--- a/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -600,6 +600,9 @@ public abstract class LibVcx {
         /** Get messages for given uids or pairwise did from agency endpoint */
         public int vcx_messages_download(int command_handle, String messageStatus, String uids, String pwdids, Callback cb);
 
+        /** Get messages for given connectionHandles from agency endpoint */
+        public int vcx_v2_messages_download(int command_handle, String connectionHandles, String messageStatus, String uids, Callback cb);
+
         /** Update message status for a object of uids */
         public int vcx_messages_update_status(int command_handle, String messageStatus, String msgJson, Callback cb);
 

--- a/wrappers/java/src/main/java/com/evernym/sdk/vcx/utils/UtilsApi.java
+++ b/wrappers/java/src/main/java/com/evernym/sdk/vcx/utils/UtilsApi.java
@@ -81,6 +81,23 @@ public class UtilsApi extends VcxJava.API {
         return future;
     }
 
+    public static CompletableFuture<String> vcxV2GetMessages(String connectionHandles, String messageStatus, String uids) throws VcxException {
+        ParamGuard.notNullOrWhiteSpace(connectionHandles, "connectionHandles");
+        logger.debug("vcxGetMessages() called with: connectionHandles = [" + connectionHandles + "], messageStatus = [" + messageStatus + "], uids = [" + uids + "]");
+        CompletableFuture<String> future = new CompletableFuture<String>();
+        int commandHandle = addFuture(future);
+
+        int result = LibVcx.api.vcx_v2_messages_download(
+                commandHandle,
+                connectionHandles,
+                messageStatus,
+                uids,
+                vcxGetMessagesCB
+        );
+        checkResult(result);
+        return future;
+    }
+
     private static Callback vcxUpdateMessagesCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err) {
@@ -147,7 +164,7 @@ public class UtilsApi extends VcxJava.API {
     }
 
     public static void setActiveTxnAuthorAgreementMeta(String text, String version,
-                                                         String hash, String accMechType, long timeOfAcceptance) throws VcxException {
+                                                       String hash, String accMechType, long timeOfAcceptance) throws VcxException {
         ParamGuard.notNull(accMechType, "accMechType");
         logger.debug("vcxProvisionAgent() called with: text = [" + text + "], version = [" + version + "]," +
                 " hash = [" + hash + "], accMechType = [" + accMechType + "], timeOfAcceptance = [" + timeOfAcceptance + "]");


### PR DESCRIPTION
Hotfix

* included vcx_v2_messages_download method in java wrapper

New Methods

* In LibVcx.API, it was included/exposed vcx_v2_messages_download
* In UtilsApi, it was included vcxV2GetMessages method to retrieve messages from agent in a more secure way (better than vcxGetMessages)
