### PR TITLE
Download messages via a connection handle as u32

### DIFF
--- a/agents/node/vcxagent-core/src/services/service-connections.js
+++ b/agents/node/vcxagent-core/src/services/service-connections.js
@@ -112,7 +112,7 @@ module.exports.createServiceConnections = function createServiceConnections ({ l
 
   async function getMessages (connectionId, filterStatuses = [], filterUids = []) {
     const connection = await loadConnection(connectionId)
-    return getMessagesForConnection([connection], filterStatuses, filterUids)
+    return getMessagesForConnection(connection, filterStatuses, filterUids)
   }
 
   async function getState (connectionId) {
@@ -138,7 +138,7 @@ module.exports.createServiceConnections = function createServiceConnections ({ l
 
   async function getMessagesV2 (connectionId, filterStatuses = [], filterUids = []) {
     const connection = await getVcxConnection(connectionId)
-    return getMessagesForConnection([connection], filterStatuses, filterUids)
+    return getMessagesForConnection(connection, filterStatuses, filterUids)
   }
 
   async function updateMessagesStatus (connectionId, uids) {

--- a/agents/node/vcxagent-core/src/utils/messages.js
+++ b/agents/node/vcxagent-core/src/utils/messages.js
@@ -28,15 +28,14 @@ async function parseDownloadMessagesResult (msgs) {
 }
 
 module.exports.getMessagesForConnection = async function getMessagesForConnection (
-  connections,
+  connection,
   filterStatuses = ['MS-102', 'MS-103', 'MS-104', 'MS-105', 'MS-106'],
   filterUids = []
 ) {
   filterStatuses = filterStatuses || ['MS-102', 'MS-103', 'MS-104', 'MS-105', 'MS-106'] // explicit null or undefined interpreted as "no filter"
   const downloadInstructions = {
-    connections,
     status: await maybeJoinWithComma(filterStatuses),
     uids: await maybeJoinWithComma(filterUids)
   }
-  return parseDownloadMessagesResult(await downloadMessagesV2(downloadInstructions))
+  return parseDownloadMessagesResult(await connection.downloadMessages(downloadInstructions))
 }

--- a/libvcx/src/api_lib/api_c/connection.rs
+++ b/libvcx/src/api_lib/api_c/connection.rs
@@ -11,6 +11,7 @@ use crate::api_lib::utils::runtime::execute;
 use crate::error::prelude::*;
 use aries_vcx::libindy;
 use aries_vcx::utils::error;
+use aries_vcx::agency_client::get_message::{parse_connection_handles, parse_status_codes};
 
 /*
     Tha API represents a pairwise connection with another identity owner.
@@ -1188,6 +1189,83 @@ pub extern fn vcx_connection_get_their_pw_did(command_handle: u32,
                 warn!("vcx_connection_get_their_pw_did_cb(command_handle: {}, connection_handle: {}, rc: {}, their_pw_did: {}), source_id: {:?}",
                       command_handle, connection_handle, x, "null", source_id);
                 cb(command_handle, x.into(), ptr::null_mut());
+            }
+        };
+
+        Ok(())
+    });
+
+    error::SUCCESS.code_num
+}
+
+#[no_mangle]
+pub extern fn vcx_connection_messages_download(command_handle: CommandHandle,
+                                               connection_handle: u32,
+                                               message_statuses: *const c_char,
+                                               uids: *const c_char,
+                                               cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, messages: *const c_char)>) -> u32 {
+    info!("vcx_connection_messages_download >>>");
+
+    check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
+
+    if !is_valid_handle(connection_handle) {
+        error!("vcx_connection_messages_download - invalid handle");
+        return VcxError::from(VcxErrorKind::InvalidConnectionHandle).into();
+    }
+
+    let message_statuses = if !message_statuses.is_null() {
+        check_useful_c_str!(message_statuses, VcxErrorKind::InvalidOption);
+        let v: Vec<&str> = message_statuses.split(',').collect();
+        let v = v.iter().map(|s| s.to_string()).collect::<Vec<String>>();
+        Some(v.to_owned())
+    } else {
+        None
+    };
+
+    let message_statuses = match parse_status_codes(message_statuses) {
+        Ok(statuses) => statuses,
+        Err(_err) => return VcxError::from(VcxErrorKind::InvalidConnectionHandle).into()
+    };
+
+    let uids = if !uids.is_null() {
+        check_useful_c_str!(uids, VcxErrorKind::InvalidOption);
+        let v: Vec<&str> = uids.split(',').collect();
+        let v = v.iter().map(|s| s.to_string()).collect::<Vec<String>>();
+        Some(v.to_owned())
+    } else {
+        None
+    };
+
+    let connection_handles: Vec<u32> = Vec::from([connection_handle]);
+
+    trace!("vcx_connection_messages_download(command_handle: {}, message_statuses: {:?}, uids: {:?})",
+           command_handle, message_statuses, uids);
+
+    execute(move || {
+        match connection::download_messages(connection_handles, message_statuses, uids) {
+            Ok(x) => {
+                match serde_json::to_string(&x) {
+                    Ok(x) => {
+                        trace!("vcx_connection_messages_download_cb(command_handle: {}, rc: {}, messages: {})",
+                               command_handle, error::SUCCESS.message, x);
+
+                        let msg = CStringUtils::string_to_cstring(x);
+                        cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
+                    }
+                    Err(e) => {
+                        let err = VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot serialize messages: {}", e));
+                        warn!("vcx_connection_messages_download_cb(command_handle: {}, rc: {}, messages: {})",
+                              command_handle, err, "null");
+
+                        cb(command_handle, err.into(), ptr::null_mut());
+                    }
+                };
+            }
+            Err(e) => {
+                warn!("vcx_messages_download_cb(command_handle: {}, rc: {}, messages: {})",
+                      command_handle, e, "null");
+
+                cb(command_handle, e.into(), ptr::null_mut());
             }
         };
 

--- a/libvcx/src/api_lib/api_c/utils.rs
+++ b/libvcx/src/api_lib/api_c/utils.rs
@@ -184,7 +184,8 @@ pub extern fn vcx_set_next_agency_response(message_index: u32) {
 /// Error code as a u32
 #[no_mangle]
 #[deprecated(since = "0.12.0", note = "This is dangerous because downloaded messages are not \
-authenticated and a message appearing to be received from certain connection might have been spoofed.")]
+authenticated and a message appearing to be received from certain connection might have been spoofed. \
+Use vcx_connection_messages_download instead.")]
 pub extern fn vcx_messages_download(command_handle: CommandHandle,
                                     message_status: *const c_char,
                                     uids: *const c_char,
@@ -290,6 +291,7 @@ pub extern fn vcx_messages_download(command_handle: CommandHandle,
 /// #Returns
 /// Error code as a u32
 #[no_mangle]
+#[deprecated(since = "0.20.0", note = "Deprecated in favor of vcx_connection_messages_download.")]
 pub extern fn vcx_v2_messages_download(command_handle: CommandHandle,
                                        conn_handles: *const c_char,
                                        message_statuses: *const c_char,

--- a/wrappers/ios/vcx/ConnectMeVcx.h
+++ b/wrappers/ios/vcx/ConnectMeVcx.h
@@ -350,7 +350,7 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
                   pwdids:(NSString *)pwdids
               completion:(void (^)(NSError *error, NSString* messages))completion;
 
-- (void)downloadMessagesV2:(NSString *)connection_handles
+- (void)downloadMessagesV2:(NSString *)connectionHandles
             messageStatus:(NSString *)messageStatus
                     uid_s:(NSString *)uid_s
               completion:(void (^)(NSError *error, NSString* messages))completion;

--- a/wrappers/ios/vcx/ConnectMeVcx.h
+++ b/wrappers/ios/vcx/ConnectMeVcx.h
@@ -345,6 +345,11 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
                   pwdids:(NSString *)pwdids
               completion:(void (^)(NSError *error, NSString* messages))completion;
 
+- (void)downloadMessagesV2:(NSString *)connection_handles
+            messageStatus:(NSString *)messageStatus
+                    uid_s:(NSString *)uid_s
+              completion:(void (^)(NSError *error, NSString* messages))completion;
+
 - (void)updateMessages:(NSString *)messageStatus
             pwdidsJson:(NSString *)pwdidsJson
             completion:(void (^)(NSError *error))completion;

--- a/wrappers/ios/vcx/ConnectMeVcx.h
+++ b/wrappers/ios/vcx/ConnectMeVcx.h
@@ -149,6 +149,11 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
                 withSignatureData:(NSData *)signatureRaw
                    withCompletion:(void (^)(NSError *error, vcx_bool_t valid))completion;
 
+- (void)connectionDownloadMessages:(VcxHandle)connectionHandle
+                    messageStatus:(NSString *)messageStatus
+                            uid_s:(NSString *)uid_s
+                      completion:(void (^)(NSError *error, NSString* messages))completion;
+
 - (void)agentUpdateInfo:(NSString *)config
              completion:(void (^)(NSError *error))completion;
 

--- a/wrappers/ios/vcx/ConnectMeVcx.m
+++ b/wrappers/ios/vcx/ConnectMeVcx.m
@@ -694,6 +694,26 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
+- (void)connectionDownloadMessages:(VcxHandle)connectionHandle
+                    messageStatus:(NSString *)messageStatus
+                            uid_s:(NSString *)uid_s
+                      completion:(void (^)(NSError *error, NSString* messages))completion {
+    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    const char * message_status = [messageStatus cStringUsingEncoding:NSUTF8StringEncoding];
+    const char * uids = [uid_s cStringUsingEncoding:NSUTF8StringEncoding];
+    vcx_error_t ret = vcx_connection_messages_download(handle, connection_handle, message_status, uids, VcxWrapperCommonStringCallback);
+
+    if( ret != 0 )
+    {
+        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion([NSError errorFromVcxError: ret], nil);
+        });
+    }
+
+}
+
 - (void)getCredential:(NSInteger)credentialHandle
            completion:(void (^)(NSError *error, NSString *credential))completion {
     vcx_error_t ret;

--- a/wrappers/ios/vcx/ConnectMeVcx.m
+++ b/wrappers/ios/vcx/ConnectMeVcx.m
@@ -1622,6 +1622,27 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     }
 }
 
+- (void)downloadMessagesV2:(NSString *)connection_handles
+            messageStatus:(NSString *)messageStatus
+                    uid_s:(NSString *)uid_s
+              completion:(void (^)(NSError *error, NSString* messages))completion{
+    vcx_error_t ret;
+    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    const char * message_status = [messageStatus cStringUsingEncoding:NSUTF8StringEncoding];
+    const char * uids = [uid_s cStringUsingEncoding:NSUTF8StringEncoding];
+    const char * connection_handles = [connection_handles cStringUsingEncoding:NSUTF8StringEncoding];
+    ret = vcx_v2_messages_download(handle, connection_handles, message_status, uids, VcxWrapperCommonStringCallback);
+
+    if( ret != 0 )
+    {
+        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion([NSError errorFromVcxError: ret], nil);
+        });
+    }
+}
+
 - (void)updateMessages:(NSString *)messageStatus
                  pwdidsJson:(NSString *)pwdidsJson
               completion:(void (^)(NSError *error))completion{

--- a/wrappers/ios/vcx/ConnectMeVcx.m
+++ b/wrappers/ios/vcx/ConnectMeVcx.m
@@ -701,7 +701,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char * message_status = [messageStatus cStringUsingEncoding:NSUTF8StringEncoding];
     const char * uids = [uid_s cStringUsingEncoding:NSUTF8StringEncoding];
-    vcx_error_t ret = vcx_connection_messages_download(handle, connection_handle, message_status, uids, VcxWrapperCommonStringCallback);
+    vcx_error_t ret = vcx_connection_messages_download(handle, connectionHandle, message_status, uids, VcxWrapperCommonStringCallback);
 
     if( ret != 0 )
     {
@@ -1642,7 +1642,7 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     }
 }
 
-- (void)downloadMessagesV2:(NSString *)connection_handles
+- (void)downloadMessagesV2:(NSString *)connectionHandles
             messageStatus:(NSString *)messageStatus
                     uid_s:(NSString *)uid_s
               completion:(void (^)(NSError *error, NSString* messages))completion{
@@ -1650,7 +1650,7 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char * message_status = [messageStatus cStringUsingEncoding:NSUTF8StringEncoding];
     const char * uids = [uid_s cStringUsingEncoding:NSUTF8StringEncoding];
-    const char * connection_handles = [connection_handles cStringUsingEncoding:NSUTF8StringEncoding];
+    const char * connection_handles = [connectionHandles cStringUsingEncoding:NSUTF8StringEncoding];
     ret = vcx_v2_messages_download(handle, connection_handles, message_status, uids, VcxWrapperCommonStringCallback);
 
     if( ret != 0 )

--- a/wrappers/ios/vcx/include/libvcx.h
+++ b/wrappers/ios/vcx/include/libvcx.h
@@ -428,7 +428,9 @@ vcx_error_t vcx_wallet_send_tokens(vcx_command_handle_t chandle, vcx_payment_han
 vcx_error_t vcx_shutdown(vcx_bool_t deleteWallet);
 
 /** Get Messages (Connections) of given status */
-vcx_error_t vcx_messages_download( vcx_command_handle_t command_handle, const char *message_status, const char *uids, const char *pw_dids, void(*cb)(vcx_command_handle_t xhandle, vcx_error_t err, const char *messages));
+vcx_error_t vcx_messages_download(vcx_command_handle_t command_handle, const char *message_status, const char *uids, const char *pw_dids, void(*cb)(vcx_command_handle_t xhandle, vcx_error_t err, const char *messages));
+
+vcx_error_t vcx_v2_messages_download(vcx_command_handle_t command_handle, const char *connection_handles, const char *message_status, const char *uids, void(*cb)(vcx_command_handle_t xhandle, vcx_error_t err, const char *messages));
 
 /** Update Message status */
 vcx_error_t vcx_messages_update_status( vcx_command_handle_t command_handle, const char *message_status, const char *msg_json, void(*cb)(vcx_command_handle_t xhandle, vcx_error_t err));

--- a/wrappers/ios/vcx/include/libvcx.h
+++ b/wrappers/ios/vcx/include/libvcx.h
@@ -161,6 +161,8 @@ vcx_error_t vcx_connection_get_pw_did(vcx_command_handle_t command_handle, vcx_c
 /** Retrieves their_pw_did from Connection object. */
 vcx_error_t vcx_connection_get_their_pw_did(vcx_command_handle_t command_handle, vcx_connection_handle_t connection_handle, void (*cb)(vcx_command_handle_t xcommand_handle, vcx_error_t err, const char *their_pw_did));
 
+vcx_error_t vcx_connection_messages_download(vcx_command_handle_t command_handle,  vcx_connection_handle_t connection_handle, const char *message_status, const char *uids, void(*cb)(vcx_command_handle_t xhandle, vcx_error_t err, const char *messages));
+
 /** Send a message to the specified connection
 ///
 /// #params

--- a/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -178,6 +178,8 @@ public abstract class LibVcx {
          */
         public int vcx_connection_info(int command_handle, int connection_handle, Callback cb);
 
+        public int vcx_connection_messages_download(int command_handle, int connection_handle, String messageStatus, String uids, Callback cb);
+
         /**
          * credential issuer object
          *

--- a/wrappers/java/src/main/java/com/evernym/sdk/vcx/connection/ConnectionApi.java
+++ b/wrappers/java/src/main/java/com/evernym/sdk/vcx/connection/ConnectionApi.java
@@ -529,4 +529,31 @@ public class ConnectionApi extends VcxJava.API {
 		checkResult(result);
 		return future;
 	}
+
+	private static Callback downloadMessagesCB = new Callback() {
+		@SuppressWarnings({"unused", "unchecked"})
+		public void callback(int commandHandle, int err, String info) {
+			logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "], info = [" + info + "]");
+			CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(commandHandle);
+			if (! checkCallback(future, err)) return;
+			future.complete(info);
+		}
+	};
+
+    public static CompletableFuture<String> downloadMessages(int connectionHandle, String messageStatus, String uids) throws VcxException {
+        logger.debug("downloadMessages() called with: connectionHandle = [" + connectionHandle + "], messageStatus = [" + messageStatus + "], uids = [" + uids + "]");
+        CompletableFuture<String> future = new CompletableFuture<String>();
+        int commandHandle = addFuture(future);
+
+        int result = LibVcx.api.vcx_connection_messages_download(
+                commandHandle,
+                connectionHandle,
+                messageStatus,
+                uids,
+                downloadMessagesCB
+        );
+
+        checkResult(result);
+        return future;
+    }
 }

--- a/wrappers/java/src/main/java/com/evernym/sdk/vcx/utils/UtilsApi.java
+++ b/wrappers/java/src/main/java/com/evernym/sdk/vcx/utils/UtilsApi.java
@@ -83,7 +83,7 @@ public class UtilsApi extends VcxJava.API {
 
     public static CompletableFuture<String> vcxV2GetMessages(String connectionHandles, String messageStatus, String uids) throws VcxException {
         ParamGuard.notNullOrWhiteSpace(connectionHandles, "connectionHandles");
-        logger.debug("vcxGetMessages() called with: connectionHandles = [" + connectionHandles + "], messageStatus = [" + messageStatus + "], uids = [" + uids + "]");
+        logger.debug("vcxV2GetMessages() called with: connectionHandles = [" + connectionHandles + "], messageStatus = [" + messageStatus + "], uids = [" + uids + "]");
         CompletableFuture<String> future = new CompletableFuture<String>();
         int commandHandle = addFuture(future);
 

--- a/wrappers/node/package-lock.json
+++ b/wrappers/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/node-vcx-wrapper",
-  "version": "0.17.3",
+  "version": "0.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/wrappers/node/src/api/connection.ts
+++ b/wrappers/node/src/api/connection.ts
@@ -202,6 +202,11 @@ export interface IDownloadMessagesConfigsV2 {
   uids: string;
 }
 
+export interface IConnectionDownloadMessages {
+  status: string;
+  uids: string;
+}
+
 export async function downloadMessagesV2({
   connections,
   status,
@@ -821,6 +826,33 @@ export class Connection extends VCXBaseWithState<IConnectionData, ConnectionStat
           ),
       );
       return data;
+    } catch (err) {
+      throw new VCXInternalError(err);
+    }
+  }
+
+  public async downloadMessages({ status, uids }: IConnectionDownloadMessages): Promise<string> {
+    try {
+      return await createFFICallbackPromise<string>(
+        (resolve, reject, cb) => {
+          const rc = rustAPI().vcx_connection_messages_download(0, this.handle, status, uids, cb);
+          if (rc) {
+            reject(rc);
+          }
+        },
+        (resolve, reject) =>
+          ffi.Callback(
+            'void',
+            ['uint32', 'uint32', 'string'],
+            (xhandle: number, err: number, messages: string) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+              resolve(messages);
+            },
+          ),
+      );
     } catch (err) {
       throw new VCXInternalError(err);
     }

--- a/wrappers/node/src/rustlib.ts
+++ b/wrappers/node/src/rustlib.ts
@@ -269,6 +269,13 @@ export interface IFFIEntryPoint {
   vcx_connection_get_pw_did: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_connection_get_their_pw_did: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_connection_info: (commandId: number, handle: number, cb: ICbRef) => number;
+  vcx_connection_messages_download: (
+    commandId: number,
+    handle: number,
+    status: string,
+    uids: string,
+    cb: ICbRef,
+  ) => number;
 
   // issuer
   vcx_issuer_credential_release: (handle: number) => number;
@@ -745,6 +752,10 @@ export const FFIConfiguration: { [Key in keyof IFFIEntryPoint]: any } = {
   vcx_connection_info: [
     FFI_ERROR_CODE,
     [FFI_COMMAND_HANDLE, FFI_CONNECTION_HANDLE, FFI_CALLBACK_PTR],
+  ],
+  vcx_connection_messages_download: [
+    FFI_ERROR_CODE,
+    [FFI_COMMAND_HANDLE, FFI_CONNECTION_HANDLE, FFI_STRING_DATA, FFI_STRING_DATA, FFI_CALLBACK_PTR],
   ],
 
   // issuer


### PR DESCRIPTION
The Java wrapper currently stores handles as `int` datatypes, which are converted back to `u32` when calling Rust FFI. However, the signature of `vcx_v2_messages_download` takes a list of handles as string. When passed the handles represented as `int`s through the Java API, the function fails. To enable safe message downloads from Java wrappers, this PR exposes a function which takes a single connection handle instead of a string. See #330 .

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>