### PR TITLE
Remove unused service module, split service into enum

### DIFF
--- a/aries_vcx/src/handlers/connection/public_agent.rs
+++ b/aries_vcx/src/handlers/connection/public_agent.rs
@@ -2,7 +2,7 @@ use crate::error::prelude::*;
 use crate::handlers::connection::cloud_agent::CloudAgentInfo;
 use crate::handlers::connection::pairwise_info::PairwiseInfo;
 use crate::messages::connection::invite::PublicInvitation;
-use crate::messages::connection::did_doc::Service;
+use crate::messages::connection::did_doc::FullService;
 use crate::libindy::utils::ledger::add_service;
 use crate::settings::get_agency_client;
 use crate::messages::connection::request::Request;
@@ -22,7 +22,7 @@ impl PublicAgent {
         let agent_info = CloudAgentInfo::create(&pairwise_info)?;
         let institution_did = String::from(institution_did);
         let source_id = String::from(source_id);
-        let service = Service {
+        let service = FullService {
             service_endpoint: get_agency_client()?.get_agency_url()?,
             recipient_keys: vec![pairwise_info.pw_vk.clone()],
             routing_keys: agent_info.routing_keys()?,

--- a/aries_vcx/src/handlers/connection/public_agent.rs
+++ b/aries_vcx/src/handlers/connection/public_agent.rs
@@ -22,12 +22,10 @@ impl PublicAgent {
         let agent_info = CloudAgentInfo::create(&pairwise_info)?;
         let institution_did = String::from(institution_did);
         let source_id = String::from(source_id);
-        let service = FullService {
-            service_endpoint: get_agency_client()?.get_agency_url()?,
-            recipient_keys: vec![pairwise_info.pw_vk.clone()],
-            routing_keys: agent_info.routing_keys()?,
-            ..Default::default()
-        };
+        let service = FullService::create()
+            .set_service_endpoint(get_agency_client()?.get_agency_url()?)
+            .set_recipient_keys(vec![pairwise_info.pw_vk.clone()])
+            .set_routing_keys(agent_info.routing_keys()?);
         add_service(&institution_did, &service)?;
         Ok(Self { source_id, agent_info, pairwise_info, institution_did })
     }

--- a/aries_vcx/src/handlers/connection/public_agent.rs
+++ b/aries_vcx/src/handlers/connection/public_agent.rs
@@ -2,7 +2,7 @@ use crate::error::prelude::*;
 use crate::handlers::connection::cloud_agent::CloudAgentInfo;
 use crate::handlers::connection::pairwise_info::PairwiseInfo;
 use crate::messages::connection::invite::PublicInvitation;
-use crate::messages::connection::did_doc::FullService;
+use crate::messages::connection::service::FullService;
 use crate::libindy::utils::ledger::add_service;
 use crate::settings::get_agency_client;
 use crate::messages::connection::request::Request;

--- a/aries_vcx/src/libindy/utils/ledger.rs
+++ b/aries_vcx/src/libindy/utils/ledger.rs
@@ -10,7 +10,7 @@ use crate::error::prelude::*;
 use crate::libindy::utils::pool::get_pool_handle;
 use crate::libindy::utils::wallet::get_wallet_handle;
 use crate::utils::random::generate_random_did;
-use crate::messages::connection::did_doc::FullService;
+use crate::messages::connection::service::FullService;
 use crate::messages::connection::did_doc::Did;
 
 pub fn multisign_request(did: &str, request: &str) -> VcxResult<String> {

--- a/aries_vcx/src/libindy/utils/ledger.rs
+++ b/aries_vcx/src/libindy/utils/ledger.rs
@@ -10,7 +10,8 @@ use crate::error::prelude::*;
 use crate::libindy::utils::pool::get_pool_handle;
 use crate::libindy::utils::wallet::get_wallet_handle;
 use crate::utils::random::generate_random_did;
-use crate::messages::connection::did_doc::Service;
+use crate::messages::connection::did_doc::FullService;
+use crate::messages::connection::did_doc::Did;
 
 pub fn multisign_request(did: &str, request: &str) -> VcxResult<String> {
     ledger::multi_sign_request(get_wallet_handle(), did, request)
@@ -463,7 +464,7 @@ pub fn get_attr(did: &str, attr_name: &str) -> VcxResult<String> {
 }
 
 // TODO: This should be responsibility of the service struct?
-pub fn get_service(did: &str) -> VcxResult<Service> {
+pub fn get_service(did: &Did) -> VcxResult<FullService> {
     let attr_resp = get_attr(did, "service")?;
     let data = get_data_from_response(&attr_resp)?;
     let ser_service = data["service"]
@@ -472,7 +473,7 @@ pub fn get_service(did: &str) -> VcxResult<Service> {
         .map_err(|err| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to deserialize service read from the ledger: {:?}", err)))
 }
 
-pub fn add_service(did: &str, service: &Service) -> VcxResult<String> {
+pub fn add_service(did: &str, service: &FullService) -> VcxResult<String> {
     let ser_service = serde_json::to_string(service)
         .map_err(|err| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to serialize service before writing to ledger: {:?}", err)))?;
     add_attr(did, "service", &ser_service)
@@ -536,7 +537,7 @@ mod test {
         let _setup = SetupLibraryWalletPoolZeroFees::init();
 
         let did = settings::get_config_value(settings::CONFIG_INSTITUTION_DID).unwrap();
-        let expect_service = Service::default();
+        let expect_service = FullService::default();
         add_service(&did, &expect_service).unwrap();
         thread::sleep(Duration::from_millis(50));
         let service = get_service(&did).unwrap();

--- a/aries_vcx/src/messages/connection/did_doc.rs
+++ b/aries_vcx/src/messages/connection/did_doc.rs
@@ -3,13 +3,12 @@ use url::Url;
 use crate::error::prelude::*;
 use crate::libindy::utils::ledger;
 use crate::messages::connection::invite::{Invitation, PairwiseInvitation};
+use crate::messages::connection::service::FullService;
 use crate::utils::validation::validate_verkey;
 
 pub const CONTEXT: &str = "https://w3id.org/did/v1";
 pub const KEY_TYPE: &str = "Ed25519VerificationKey2018";
 pub const KEY_AUTHENTICATION_TYPE: &str = "Ed25519SignatureAuthentication2018";
-pub const SERVICE_SUFFIX: &str = "indy";
-pub const SERVICE_TYPE: &str = "IndyAgent";
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct DidDoc {
@@ -46,39 +45,6 @@ pub struct Authentication {
 }
 
 pub type Did = String;
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum Service {
-    FullService(FullService),
-    Did(Did)
-}
-
-impl Service {
-    pub fn resolve(&self) -> VcxResult<FullService> {
-        match self {
-            Service::FullService(full_service) => Ok(full_service.clone()),
-            Service::Did(did) => ledger::get_service(&did)
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-pub struct FullService {
-    pub id: String,
-    #[serde(rename = "type")]
-    pub type_: String,
-    #[serde(default)]
-    pub priority: u32,
-    #[serde(default)]
-    #[serde(rename = "recipientKeys")]
-    pub recipient_keys: Vec<String>,
-    #[serde(default)]
-    #[serde(rename = "routingKeys")]
-    pub routing_keys: Vec<String>,
-    #[serde(rename = "serviceEndpoint")]
-    pub service_endpoint: String,
-}
 
 impl Default for DidDoc {
     fn default() -> DidDoc {
@@ -293,20 +259,6 @@ impl DidDoc {
     fn _parse_key_reference(key_reference: &str) -> String {
         let pars: Vec<&str> = DidDoc::_key_parts(key_reference);
         pars.get(1).or(pars.get(0)).map(|s| s.to_string()).unwrap_or_default()
-    }
-}
-
-impl Default for FullService {
-    fn default() -> FullService {
-        FullService {
-            // TODO: FIXME Several services????
-            id: format!("did:example:123456789abcdefghi;{}", SERVICE_SUFFIX),
-            type_: String::from(SERVICE_TYPE),
-            priority: 0,
-            service_endpoint: String::new(),
-            recipient_keys: Vec::new(),
-            routing_keys: Vec::new(),
-        }
     }
 }
 

--- a/aries_vcx/src/messages/connection/invite.rs
+++ b/aries_vcx/src/messages/connection/invite.rs
@@ -1,4 +1,5 @@
 use crate::messages::a2a::{A2AMessage, MessageId};
+use crate::messages::connection::did_doc::Did;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
@@ -26,7 +27,7 @@ pub struct PublicInvitation {
     #[serde(rename = "@id")]
     pub id: MessageId,
     pub label: String,
-    pub did: String,
+    pub did: Did,
 }
 
 impl PairwiseInvitation {

--- a/aries_vcx/src/messages/connection/mod.rs
+++ b/aries_vcx/src/messages/connection/mod.rs
@@ -3,3 +3,4 @@ pub mod invite;
 pub mod problem_report;
 pub mod request;
 pub mod response;
+pub mod service;

--- a/aries_vcx/src/messages/connection/mod.rs
+++ b/aries_vcx/src/messages/connection/mod.rs
@@ -3,4 +3,3 @@ pub mod invite;
 pub mod problem_report;
 pub mod request;
 pub mod response;
-pub mod service;

--- a/aries_vcx/src/messages/connection/service.rs
+++ b/aries_vcx/src/messages/connection/service.rs
@@ -7,16 +7,16 @@ pub const SERVICE_TYPE: &str = "IndyAgent";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
-pub enum Service {
+pub enum ServiceResolvable {
     FullService(FullService),
     Did(Did)
 }
 
-impl Service {
+impl ServiceResolvable {
     pub fn resolve(&self) -> VcxResult<FullService> {
         match self {
-            Service::FullService(full_service) => Ok(full_service.clone()),
-            Service::Did(did) => ledger::get_service(&did)
+            ServiceResolvable::FullService(full_service) => Ok(full_service.clone()),
+            ServiceResolvable::Did(did) => ledger::get_service(&did)
         }
     }
 }

--- a/aries_vcx/src/messages/connection/service.rs
+++ b/aries_vcx/src/messages/connection/service.rs
@@ -21,9 +21,9 @@ impl ServiceResolvable {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct FullService {
-    pub id: String,
+    pub id: Did,
     #[serde(rename = "type")]
     pub type_: String,
     #[serde(default)]
@@ -38,6 +38,27 @@ pub struct FullService {
     pub service_endpoint: String,
 }
 
+impl FullService {
+    pub fn create() -> Self {
+        Self::default()
+    }
+
+    pub fn set_service_endpoint(mut self, service_endpoint: String) -> Self {
+        self.service_endpoint = service_endpoint;
+        self
+    }
+
+    pub fn set_routing_keys(mut self, routing_keys: Vec<String>) -> Self {
+        self.routing_keys = routing_keys;
+        self
+    }
+
+    pub fn set_recipient_keys(mut self, recipient_keys: Vec<String>) -> Self {
+        self.recipient_keys = recipient_keys;
+        self
+    }
+}
+
 impl Default for FullService {
     fn default() -> FullService {
         FullService {
@@ -49,5 +70,41 @@ impl Default for FullService {
             recipient_keys: Vec::new(),
             routing_keys: Vec::new(),
         }
+    }
+}
+
+impl PartialEq for FullService {
+    fn eq(&self, other: &Self) -> bool {
+        self.recipient_keys == other.recipient_keys
+            && self.routing_keys == other.routing_keys
+            && self.service_endpoint == other.service_endpoint
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::messages::connection::did_doc::test_utils::{_recipient_keys, _routing_keys, _service_endpoint};
+    use super::*;
+
+    #[test]
+    #[cfg(feature = "general_test")]
+    fn test_service_comparison() {
+        let service1 = FullService::create()
+            .set_service_endpoint(_service_endpoint())
+            .set_recipient_keys(_recipient_keys())
+            .set_routing_keys(_routing_keys());
+
+        let service2 = FullService::create()
+            .set_service_endpoint(_service_endpoint())
+            .set_recipient_keys(_recipient_keys())
+            .set_routing_keys(_routing_keys());
+
+        let service3 = FullService::create()
+            .set_service_endpoint("bogus_endpoint".to_string())
+            .set_recipient_keys(_recipient_keys())
+            .set_routing_keys(_routing_keys());
+
+        assert!(service1 == service2);
+        assert!(service1 != service3);
     }
 }


### PR DESCRIPTION
Removes unused `service` module, replaces used `Service` struct with an enum allowing for easy interchangeability between a did and a service (becomes slightly useful in Out-of-Band implementation).

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>