### PR TITLE
Do not serialize None Filter fields

### DIFF
--- a/aries_vcx/src/libindy/proofs/proof_request.rs
+++ b/aries_vcx/src/libindy/proofs/proof_request.rs
@@ -17,6 +17,7 @@ pub struct ProofRequestData {
     pub requested_attributes: HashMap<String, AttrInfo>,
     #[serde(default)]
     pub requested_predicates: HashMap<String, PredicateInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub non_revoked: Option<NonRevokedInterval>,
 }
 

--- a/aries_vcx/src/libindy/proofs/proof_request_internal.rs
+++ b/aries_vcx/src/libindy/proofs/proof_request_internal.rs
@@ -1,10 +1,16 @@
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Filter {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub schema_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub schema_issuer_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub schema_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub schema_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub issuer_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cred_def_id: Option<String>,
 }
 


### PR DESCRIPTION
Serialized `null` values in the `Filter` were throwing acapy off.

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>