### PR TITLE
Use GITHUB_TOKEN, GITHUB_ACTOR in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1015,8 +1015,8 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ghcr.io
-          username: Patrik-Stas
-          password: ${{ secrets.PUBLISH_PKG_GITHUB_PATRIK }}
+          username: $GITHUB_ACTOR
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish image
         run: |


### PR DESCRIPTION
Use GITHUB_TOKEN, GITHUB_ACTOR to publish libvcx image to github registry

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>