### PR TITLE
Fallback thread id comparison to pthid

### DIFF
--- a/aries_vcx/src/messages/thread.rs
+++ b/aries_vcx/src/messages/thread.rs
@@ -34,7 +34,7 @@ impl Thread {
     }
 
     pub fn is_reply(&self, id: &str) -> bool {
-        self.thid.clone().unwrap_or_default() == id.to_string()
+        [self.thid.clone(), self.pthid.clone()].contains(&Some(id.to_string()))
     }
 }
 


### PR DESCRIPTION
acapy changed the thread decorators on connection request so that `pthid` matches the `@id` of the invitation and `thid` matches the `@id` of the connection request. 

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>