### PR TITLE
Set correct thread id when responding to public invite

### DIFF
--- a/aries_vcx/src/messages/connection/invite.rs
+++ b/aries_vcx/src/messages/connection/invite.rs
@@ -4,6 +4,7 @@ use crate::error::prelude::*;
 use crate::messages::a2a::{A2AMessage, MessageId};
 use crate::messages::connection::did_doc::Did;
 use crate::messages::connection::service::ServiceResolvable;
+use crate::utils::uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
@@ -130,6 +131,20 @@ pub mod test_utils {
             id: MessageId::id(),
             label: _label(),
             did: _did(),
+        }
+    }
+
+    pub fn _pairwise_invitation_random_id() -> PairwiseInvitation {
+        PairwiseInvitation {
+            id: MessageId(uuid::uuid()),
+            .._pairwise_invitation()
+        }
+    }
+
+    pub fn _public_invitation_random_id() -> PublicInvitation {
+        PublicInvitation {
+            id: MessageId(uuid::uuid()),
+            .._public_invitation()
         }
     }
 

--- a/aries_vcx/src/messages/connection/request.rs
+++ b/aries_vcx/src/messages/connection/request.rs
@@ -46,6 +46,11 @@ impl Request {
         self.connection.did_doc.set_keys(recipient_keys, routing_keys);
         self
     }
+
+    pub fn set_thread_id_matching_id(mut self) -> Request {
+        self = self.clone().set_thread_id(&self.id.0);
+        self
+    }
 }
 
 a2a_message!(Request, ConnectionRequest);


### PR DESCRIPTION
When responding to public invite, set parent thread id corresponding to the id of the invite, thread id corresponding to the id of the request message and set this thread id as the thread id of the connection object.

Signed-off-by: Miroslav Kovar <miroslavkovar@protonmail.com>