### PR TITLE
Issuer SM stores aries cred offer instead of libindy offer

### DIFF
--- a/aries_vcx/src/handlers/issuance/issuer/states/initial.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/states/initial.rs
@@ -1,11 +1,11 @@
 use crate::handlers::issuance::issuer::states::offer_sent::OfferSentState;
-use crate::messages::issuance::credential_offer::OfferInfo;
+use crate::messages::issuance::credential_offer::{CredentialOffer, OfferInfo};
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 pub struct InitialIssuerState {}
 
-impl From<(OfferInfo, String)> for OfferSentState {
-    fn from((offer_info, offer): (OfferInfo, String)) -> Self {
+impl From<(OfferInfo, CredentialOffer)> for OfferSentState {
+    fn from((offer_info, offer): (OfferInfo, CredentialOffer)) -> Self {
         trace!("SM is now in OfferSent state");
         OfferSentState {
             offer,

--- a/aries_vcx/src/handlers/issuance/issuer/states/offer_sent.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/states/offer_sent.rs
@@ -2,12 +2,13 @@ use crate::handlers::issuance::issuer::state_machine::RevocationInfoV1;
 use crate::handlers::issuance::issuer::states::finished::FinishedState;
 use crate::handlers::issuance::issuer::states::requested_received::RequestReceivedState;
 use crate::messages::error::ProblemReport;
+use crate::messages::issuance::credential_offer::CredentialOffer;
 use crate::messages::issuance::credential_request::CredentialRequest;
 use crate::messages::status::Status;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OfferSentState {
-    pub offer: String,
+    pub offer: CredentialOffer,
     pub cred_data: String,
     pub rev_reg_id: Option<String>,
     pub tails_file: Option<String>,

--- a/aries_vcx/src/handlers/issuance/issuer/states/proposal_received.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/states/proposal_received.rs
@@ -2,7 +2,7 @@ use crate::error::prelude::*;
 use crate::messages::issuance::credential_proposal::CredentialProposal;
 use crate::handlers::issuance::is_cred_def_revokable;
 use crate::handlers::issuance::issuer::states::offer_sent::OfferSentState;
-use crate::messages::issuance::credential_offer::OfferInfo;
+use crate::messages::issuance::credential_offer::{CredentialOffer, OfferInfo};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ProposalReceivedState {
@@ -23,8 +23,8 @@ impl ProposalReceivedState {
     }
 }
 
-impl From<(String, OfferInfo)> for OfferSentState {
-    fn from((offer, offer_info): (String, OfferInfo)) -> Self {
+impl From<(CredentialOffer, OfferInfo)> for OfferSentState {
+    fn from((offer, offer_info): (CredentialOffer, OfferInfo)) -> Self {
         trace!("SM is now in OfferSent state");
         OfferSentState {
             offer,

--- a/aries_vcx/src/handlers/issuance/issuer/states/requested_received.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/states/requested_received.rs
@@ -3,13 +3,14 @@ use crate::handlers::issuance::issuer::states::credential_sent::CredentialSentSt
 use crate::handlers::issuance::issuer::states::finished::FinishedState;
 use crate::messages::a2a::MessageId;
 use crate::messages::error::ProblemReport;
+use crate::messages::issuance::credential_offer::CredentialOffer;
 use crate::messages::issuance::credential_request::CredentialRequest;
 use crate::messages::status::Status;
 
 // TODO: Use OfferInfo instead of ind. fields
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RequestReceivedState {
-    pub offer: String,
+    pub offer: CredentialOffer,
     pub cred_data: String,
     pub rev_reg_id: Option<String>,
     pub tails_file: Option<String>,


### PR DESCRIPTION
- Issuer state machine stores generic Aries Credential Offer message, rather than specific libindy offer structure. 
- Libindy offer structure is needed to issue indy credential, hence upon issuance, libindy structure is retrieved from Aries Cred Offer attachment - it's assumed the attachment is libindy offer.

This is one of small steps towards decoupling Aries FSM layer and libindy.

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>