### PR TITLE
Decouple generating and sending credential offer

### DIFF
--- a/agents/node/vcxagent-core/src/services/service-agents.js
+++ b/agents/node/vcxagent-core/src/services/service-agents.js
@@ -7,6 +7,7 @@ module.exports.createServiceAgents = function createServiceAgents ({ logger, sav
     logger.info(`Creating public agent with id ${agentId} for institution did ${institutionDid}`)
     const agent = await Agent.create(agentId, institutionDid)
     await saveAgent(agentId, agent)
+    logger.info(`Created public agent with id ${agentId} for institution did ${institutionDid}`)
     return agent
   }
 

--- a/agents/node/vcxagent-core/src/services/service-cred-issuer.js
+++ b/agents/node/vcxagent-core/src/services/service-cred-issuer.js
@@ -43,7 +43,7 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
   async function sendCredential (issuerCredId, connectionId) {
     const connection = await loadConnection(connectionId)
     const issuerCred = await loadIssuerCredential(issuerCredId)
-    logger.info(`Sending credential ${issuerCredId} to ${connectionId}`)
+    logger.info(`Sending credential '${issuerCredId}' to ${connectionId}`)
     await issuerCred.sendCredential(connection)
     const state = await issuerCred.getState()
     await saveIssuerCredential(issuerCredId, issuerCred)

--- a/agents/node/vcxagent-core/src/services/service-out-of-band.js
+++ b/agents/node/vcxagent-core/src/services/service-out-of-band.js
@@ -1,10 +1,22 @@
 const { OutOfBandSender, OutOfBandReceiver } = require('@hyperledger/node-vcx-wrapper')
 
 module.exports.createServiceOutOfBand = function createServiceOutOfBand ({ logger, saveConnection, loadConnection }) {
-  async function createOobMsg (agent, label) {
+  async function createOobMsg (agent, label, message) {
+    logger.info(`createOobMsg >>>`)
     const oob = await OutOfBandSender.create({ label })
     const service = await agent.getService()
+    logger.info(`createOobMsg >>> appending service ${service}`)
     await oob.appendService(service)
+    if (message) {
+      const msgParsed = JSON.parse(message)
+      const msgType = msgParsed["@type"]
+      if (!msgType) {
+        throw Error(`Message appended to OOB message must have @type. Invalid message: ${msgParsed}`)
+      }
+      logger.info(`createOobMsg >>> appending message of type ${msgType}`)
+      await oob.appendMessage(message)
+      logger.info(`createOobMsg >>> append message`)
+    }
     return oob.toMessage()
   }
 

--- a/agents/node/vcxagent-core/src/services/service-verifier.js
+++ b/agents/node/vcxagent-core/src/services/service-verifier.js
@@ -1,8 +1,7 @@
 const {
-  Proof, IssuerCredential, IssuerStateType
+  Proof, IssuerCredential, IssuerStateType, VerifierStateType
 } = require('@hyperledger/node-vcx-wrapper')
 const sleep = require('sleep-promise')
-const {VerifierStateType} = require('../../../../../wrappers/node')
 
 module.exports.createServiceVerifier = function createServiceVerifier ({ logger, loadConnection, saveProof, loadProof, listProofIds }) {
   async function createProof (proofId, proofData) {

--- a/agents/node/vcxagent-core/test/distribute-tails.spec.js
+++ b/agents/node/vcxagent-core/test/distribute-tails.spec.js
@@ -25,7 +25,8 @@ describe('test tails distribution', () => {
       const port = 5468
       const tailsUrlId = uuid.v4()
       const tailsUrl = `http://127.0.0.1:${port}/${tailsUrlId}`
-      await faber.sendCredentialOffer(buildRevocationDetails({ supportRevocation: true, tailsFile: `${__dirname}/tmp/faber/tails`, maxCreds: 5 }), tailsUrl)
+      await faber.buildLedgerPrimitives(buildRevocationDetails({ supportRevocation: true, tailsFile: `${__dirname}/tmp/faber/tails`, maxCreds: 5 }), tailsUrl)
+      await faber.sendCredentialOffer()
       await alice.acceptCredentialOffer()
       await faber.updateStateCredentialV2(IssuerStateType.RequestReceived)
       await faber.sendCredential()

--- a/agents/node/vcxagent-core/test/out-of-band.spec.js
+++ b/agents/node/vcxagent-core/test/out-of-band.spec.js
@@ -41,14 +41,11 @@ describe('test out of band communication', () => {
     try {
       const {alice, faber} = await createAliceAndFaber()
       await faber.createCredDef(undefined, undefined)
-      console.log(`Creating oob offer`)
       const oobCredOfferMsg = await faber.createOobCredOffer()
 
       await connectViaOobMessage(alice, faber, oobCredOfferMsg)
 
-      console.log(`Going to accept credential offer`)
       await alice.acceptOobCredentialOffer(oobCredOfferMsg)
-      console.log(`Accepted credential offer`)
       await faber.updateStateCredentialV2(IssuerStateType.RequestReceived)
       await faber.sendCredential()
       await alice.updateStateCredentialV2(HolderStateType.Finished)

--- a/agents/node/vcxagent-core/test/update-state-v2.spec.js
+++ b/agents/node/vcxagent-core/test/update-state-v2.spec.js
@@ -7,14 +7,14 @@ const sleep = require('sleep-promise')
 
 beforeAll(async () => {
   jest.setTimeout(1000 * 60 * 4)
-  await initRustapi(process.env.VCX_LOG_LEVEL || 'vcx=error')
+  await initRustapi(process.env.VCX_LOG_LEVEL || 'vcx=warn')
 })
 
 describe('test update state', () => {
   it('Faber should send credential to Alice', async () => {
     try {
       const { alice, faber } = await createPairedAliceAndFaber()
-
+      await faber.buildLedgerPrimitives()
       await faber.sendCredentialOffer()
       await alice.acceptCredentialOffer()
 

--- a/agents/node/vcxagent-core/test/utils/alice.js
+++ b/agents/node/vcxagent-core/test/utils/alice.js
@@ -32,7 +32,7 @@ module.exports.createAlice = async function createAlice () {
 
   async function createConnectionUsingOobMessage (oobMsg) {
     logger.info(`createConnectionUsingOobMessage >> Alice going to create connection using oob message`)
-    logger.debug(`createConnectionUsingOobMessage>> ${oobMsg}`)
+    logger.debug(`createConnectionUsingOobMessage >> oobMsg = ${oobMsg}`)
     await vcxAgent.agentInitVcx()
 
     await vcxAgent.serviceOutOfBand.createConnectionFromOobMsg(connectionId, oobMsg)

--- a/agents/node/vcxagent-core/test/utils/faber.js
+++ b/agents/node/vcxagent-core/test/utils/faber.js
@@ -103,14 +103,15 @@ module.exports.createFaber = async function createFaber () {
     await vcxAgent.agentShutdownVcx()
   }
 
-  async function createCredDef (_revocationDetails, tailsUrl) {
+  async function createCredDef (revocationDetails, tailsUrl) {
+    revocationDetails = revocationDetails || buildRevocationDetails({ supportRevocation: false })
+
     await vcxAgent.agentInitVcx()
 
     logger.info('Faber writing schema on ledger')
     const schemaId = await vcxAgent.serviceLedgerSchema.createSchema(getSampleSchemaData())
 
     logger.info('Faber writing credential definition on ledger')
-    const revocationDetails = _revocationDetails || buildRevocationDetails({ supportRevocation: false })
     credDefId = getFaberCredDefName()
     await vcxAgent.serviceLedgerCredDef.createCredentialDefinition(
       schemaId,

--- a/agents/node/vcxagent-core/test/utils/faber.js
+++ b/agents/node/vcxagent-core/test/utils/faber.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 const { buildRevocationDetails } = require('../../src')
 const { createVcxAgent, getSampleSchemaData } = require('../../src')
-const { ConnectionStateType, IssuerStateType, VerifierStateType } = require('@hyperledger/node-vcx-wrapper')
+const { ConnectionStateType, IssuerStateType, VerifierStateType, HolderStateType} = require('@hyperledger/node-vcx-wrapper')
 const { getAliceSchemaAttrs, getFaberCredDefName, getFaberProofData } = require('./data')
 
 module.exports.createFaber = async function createFaber () {
@@ -51,16 +51,25 @@ module.exports.createFaber = async function createFaber () {
     return invite
   }
 
-  async function createOobMsg () {
+  async function createOobMsg (wrappedMessage) {
     logger.info('Faber is going to generate out of band message')
     await vcxAgent.agentInitVcx()
 
     const agent = await vcxAgent.serviceAgent.publicAgentCreate(agentId, vcxAgent.getInstitutionDid())
-    const oobMsg = await vcxAgent.serviceOutOfBand.createOobMsg(agent, 'faber-oob-msg')
+    const oobMsg = await vcxAgent.serviceOutOfBand.createOobMsg(agent, 'faber-oob-msg', wrappedMessage)
 
     await vcxAgent.agentShutdownVcx()
 
     return oobMsg
+  }
+
+  async function createOobCredOffer () {
+    await vcxAgent.agentInitVcx()
+    const schemaAttrs = getAliceSchemaAttrs()
+    const credOfferMsg = await vcxAgent.serviceCredIssuer.buildOfferAndMarkAsSent(issuerCredId, credDefId, schemaAttrs)
+    await vcxAgent.agentShutdownVcx()
+    const oobCredOfferMsg = await createOobMsg(credOfferMsg)
+    return oobCredOfferMsg
   }
 
   async function sendConnectionResponse () {
@@ -81,7 +90,7 @@ module.exports.createFaber = async function createFaber () {
     await vcxAgent.agentShutdownVcx()
   }
 
-  async function sendCredentialOffer (_revocationDetails, tailsUrl) {
+  async function createCredDef (_revocationDetails, tailsUrl) {
     await vcxAgent.agentInitVcx()
 
     logger.info('Faber writing schema on ledger')
@@ -89,18 +98,38 @@ module.exports.createFaber = async function createFaber () {
 
     logger.info('Faber writing credential definition on ledger')
     const revocationDetails = _revocationDetails || buildRevocationDetails({ supportRevocation: false })
+    credDefId = getFaberCredDefName()
+    await vcxAgent.serviceLedgerCredDef.createCredentialDefinition(
+      schemaId,
+      credDefId,
+      revocationDetails,
+      tailsUrl
+    )
+    await vcxAgent.agentShutdownVcx()
+  }
+
+  async function buildLedgerPrimitives(revocationDetails, tailsUrl) {
+    await vcxAgent.agentInitVcx()
+
+    logger.info('Faber writing schema on ledger')
+    const schemaId = await vcxAgent.serviceLedgerSchema.createSchema(getSampleSchemaData())
+
+    logger.info('Faber writing credential definition on ledger')
+    revocationDetails = revocationDetails || buildRevocationDetails({ supportRevocation: false })
     await vcxAgent.serviceLedgerCredDef.createCredentialDefinition(
       schemaId,
       getFaberCredDefName(),
       revocationDetails,
       tailsUrl
     )
-
-    logger.info('Faber sending credential to Alice')
-    const schemaAttrs = getAliceSchemaAttrs()
     credDefId = getFaberCredDefName()
-    await vcxAgent.serviceCredIssuer.sendOffer(issuerCredId, connectionId, credDefId, schemaAttrs)
+    await vcxAgent.agentShutdownVcx()
+  }
 
+  async function sendCredentialOffer () {
+    await vcxAgent.agentInitVcx()
+    const schemaAttrs = getAliceSchemaAttrs()
+    await vcxAgent.serviceCredIssuer.sendOffer(issuerCredId, connectionId, credDefId, schemaAttrs)
     await vcxAgent.agentShutdownVcx()
   }
 
@@ -237,6 +266,8 @@ module.exports.createFaber = async function createFaber () {
   }
 
   return {
+    buildLedgerPrimitives,
+    createCredDef,
     downloadReceivedMessages,
     downloadReceivedMessagesV2,
     sendMessage,
@@ -248,6 +279,7 @@ module.exports.createFaber = async function createFaber () {
     updateConnection,
     sendConnectionResponse,
     sendCredentialOffer,
+    createOobCredOffer,
     updateStateCredentialV2,
     sendCredential,
     requestProofFromAlice,

--- a/agents/node/vcxagent-core/test/utils/faber.js
+++ b/agents/node/vcxagent-core/test/utils/faber.js
@@ -72,6 +72,19 @@ module.exports.createFaber = async function createFaber () {
     return oobCredOfferMsg
   }
 
+  async function createOobProofRequest () {
+    await vcxAgent.agentInitVcx()
+
+    const issuerDid = vcxAgent.getInstitutionDid()
+    const proofData = getFaberProofData(issuerDid, proofId)
+    logger.info(`Faber is sending proof request to connection ${connectionId}`)
+    const presentationRequestMsg = await vcxAgent.serviceVerifier.buildProofReqAndMarkAsSent(proofId, proofData)
+
+    await vcxAgent.agentShutdownVcx()
+    const oobPresentationRequestMsg = await createOobMsg(presentationRequestMsg)
+    return oobPresentationRequestMsg
+  }
+
   async function sendConnectionResponse () {
     logger.info('Faber is going to generate invite')
     await vcxAgent.agentInitVcx()
@@ -275,6 +288,7 @@ module.exports.createFaber = async function createFaber () {
     createInvite,
     createPublicInvite,
     createOobMsg,
+    createOobProofRequest,
     createConnectionFromReceivedRequest,
     updateConnection,
     sendConnectionResponse,

--- a/agents/node/vcxagent-core/test/utils/utils.js
+++ b/agents/node/vcxagent-core/test/utils/utils.js
@@ -28,10 +28,25 @@ module.exports.createPairedAliceAndFaberViaOobMsg = async function createPairedA
   const alice = await createAlice()
   const faber = await createFaber()
   const msg = await faber.createOobMsg()
-  await alice.acceptOobMsg(msg)
+  await alice.createConnectionUsingOobMessage(msg)
   await alice.updateConnection(ConnectionStateType.Requested)
   await faber.createConnectionFromReceivedRequest()
   await alice.updateConnection(ConnectionStateType.Finished)
   await faber.updateConnection(ConnectionStateType.Finished)
+  return { alice, faber }
+}
+
+module.exports.connectViaOobMessage = async function connectViaOobMessage (alice, faber, msg) {
+  await alice.createConnectionUsingOobMessage(msg)
+  await alice.updateConnection(ConnectionStateType.Requested)
+  await faber.createConnectionFromReceivedRequest()
+  await alice.updateConnection(ConnectionStateType.Finished)
+  await faber.updateConnection(ConnectionStateType.Finished)
+  return { alice, faber }
+}
+
+module.exports.createAliceAndFaber = async function createAliceAndFaber () {
+  const alice = await createAlice()
+  const faber = await createFaber()
   return { alice, faber }
 }

--- a/aries_vcx/src/handlers/issuance/issuer/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/issuer.rs
@@ -107,13 +107,11 @@ impl Issuer {
         Ok(offer.to_a2a_message())
     }
 
-    // todo: include in tests
     pub fn mark_credential_offer_msg_sent(&mut self) -> VcxResult<()> {
         self.issuer_sm = self.issuer_sm.clone().mark_credential_offer_msg_sent()?;
         Ok(())
     }
 
-    // todo: Not needed, consumer should build and sent the offer himself, then call mark_credential_offer_sent
     pub fn send_credential_offer(&mut self, send_message: impl Fn(&A2AMessage) -> VcxResult<()>) -> VcxResult<()> {
         if self.issuer_sm.get_state() == IssuerState::OfferSet {
             let cred_offer_msg = self.get_credential_offer_msg()?;

--- a/aries_vcx/src/handlers/issuance/issuer/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/issuer.rs
@@ -35,7 +35,6 @@ pub enum IssuerState {
     Failed,
 }
 
-
 fn _build_credential_preview(credential_json: &str) -> VcxResult<CredentialPreviewData> {
     trace!("Issuer::_build_credential_preview >>> credential_json: {:?}", credential_json);
 

--- a/aries_vcx/src/handlers/issuance/issuer/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/issuer.rs
@@ -318,6 +318,6 @@ pub mod test {
 
         let res = issuer.send_credential_offer(_send_message_but_fail().unwrap());
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
-        assert!(res.is_ok());
+        assert!(res.is_err());
     }
 }

--- a/aries_vcx/src/handlers/issuance/issuer/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/issuer.rs
@@ -102,8 +102,9 @@ impl Issuer {
         Ok(())
     }
 
-    pub fn get_credential_offer_msg(&self) -> VcxResult<CredentialOffer> {
-        self.issuer_sm.get_credential_offer_msg()
+    pub fn get_credential_offer_msg(&self) -> VcxResult<A2AMessage> {
+        let offer = self.issuer_sm.get_credential_offer()?;
+        Ok(offer.to_a2a_message())
     }
 
     // todo: include in tests
@@ -116,7 +117,7 @@ impl Issuer {
     pub fn send_credential_offer(&mut self, send_message: impl Fn(&A2AMessage) -> VcxResult<()>) -> VcxResult<()> {
         if self.issuer_sm.get_state() == IssuerState::OfferSet {
             let cred_offer_msg = self.get_credential_offer_msg()?;
-            send_message(&cred_offer_msg.to_a2a_message())?;
+            send_message(&cred_offer_msg)?;
             self.issuer_sm = self.issuer_sm.clone().mark_credential_offer_msg_sent()?;
         }
         Ok(())

--- a/aries_vcx/src/handlers/issuance/issuer/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/issuer.rs
@@ -4,10 +4,11 @@ use crate::error::prelude::*;
 use crate::handlers::connection::connection::Connection;
 use crate::handlers::issuance::issuer::state_machine::IssuerSM;
 use crate::handlers::issuance::messages::CredentialIssuanceMessage;
-use crate::messages::issuance::credential_proposal::CredentialProposal;
-use crate::messages::issuance::credential_offer::OfferInfo;
-use crate::messages::a2a::A2AMessage;
 use crate::libindy::utils::anoncreds::libindy_issuer_create_credential_offer;
+use crate::messages::a2a::A2AMessage;
+use crate::messages::issuance::credential_offer::{CredentialOffer, OfferInfo};
+use crate::messages::issuance::credential_proposal::CredentialProposal;
+use crate::messages::mime_type::MimeType;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Issuer {
@@ -24,12 +25,49 @@ pub struct IssuerConfig {
 #[derive(Debug, PartialEq)]
 pub enum IssuerState {
     Initial,
+    OfferSet,
     ProposalReceived,
     OfferSent,
     RequestReceived,
     CredentialSent,
     Finished,
     Failed,
+}
+
+
+fn _append_credential_preview(cred_offer_msg: CredentialOffer, credential_json: &str) -> VcxResult<CredentialOffer> {
+    trace!("Issuer::_append_credential_preview >>> cred_offer_msg: {:?}, credential_json: {:?}", cred_offer_msg, credential_json);
+
+    let cred_values: serde_json::Value = serde_json::from_str(credential_json)
+        .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Can't deserialize credential preview json. credential_json: {}, error: {:?}", credential_json, err)))?;
+
+    let mut new_offer = cred_offer_msg;
+    match cred_values {
+        serde_json::Value::Array(cred_values) => {
+            for cred_value in cred_values.iter() {
+                let key = cred_value.get("name").ok_or(VcxError::from_msg(VcxErrorKind::InvalidAttributesStructure, format!("No 'name' field in cred_value: {:?}", cred_value)))?;
+                let value = cred_value.get("value").ok_or(VcxError::from_msg(VcxErrorKind::InvalidAttributesStructure, format!("No 'value' field in cred_value: {:?}", cred_value)))?;
+                new_offer = new_offer.add_credential_preview_data(
+                    &key.to_string(),
+                    &value.to_string(),
+                    MimeType::Plain,
+                )?;
+            };
+        }
+        serde_json::Value::Object(values_map) => {
+            for item in values_map.iter() {
+                let (key, value) = item;
+                new_offer = new_offer.add_credential_preview_data(
+                    key,
+                    &value.to_string(),
+                    MimeType::Plain,
+                )?;
+            }
+        }
+        _ => {}
+    };
+
+    Ok(new_offer)
 }
 
 impl Issuer {
@@ -45,9 +83,41 @@ impl Issuer {
         Ok(Issuer { issuer_sm })
     }
 
-    pub fn send_credential_offer(&mut self, offer_info: OfferInfo, comment: Option<&str>, send_message: impl Fn(&A2AMessage) -> VcxResult<()>) -> VcxResult<()> {
-        let cred_offer = libindy_issuer_create_credential_offer(&offer_info.cred_def_id)?;
-        self.step(CredentialIssuanceMessage::CredentialOfferSend(offer_info, cred_offer, comment.map(String::from)), Some(&send_message))
+    pub fn build_credential_offer_msg(&mut self, offer_info: OfferInfo, comment: Option<String>) -> VcxResult<()> {
+        let libindy_cred_offer = libindy_issuer_create_credential_offer(&offer_info.cred_def_id)?;
+        let cred_offer_msg = CredentialOffer::create()
+            .set_id(&self.issuer_sm.thread_id()?)
+            .set_offers_attach(&libindy_cred_offer)?
+            .set_comment(comment);
+        // todo: use .set_credential_preview(..), refactor _append_credential_preview
+        let cred_offer_msg = _append_credential_preview(cred_offer_msg, &offer_info.credential_json)?;
+        self.issuer_sm = self.issuer_sm.clone()
+            .set_offer(
+                cred_offer_msg,
+                &offer_info.credential_json,
+                &offer_info.cred_def_id,
+                offer_info.rev_reg_id,
+                offer_info.tails_file,
+            )?;
+        Ok(())
+    }
+
+    pub fn get_credential_offer_msg(&self) -> VcxResult<CredentialOffer> {
+        self.issuer_sm.get_credential_offer_msg()
+    }
+
+    // todo: include in tests
+    pub fn mark_credential_offer_sent(&mut self) -> VcxResult<()> {
+        self.issuer_sm = self.issuer_sm.clone().mark_credential_offer_sent()?;
+        Ok(())
+    }
+
+    // todo: Not needed, consumer should build and sent the offer himself, then call mark_credential_offer_sent
+    pub fn send_credential_offer(&mut self, send_message: impl Fn(&A2AMessage) -> VcxResult<()>) -> VcxResult<()> {
+        let cred_offer_msg = self.get_credential_offer_msg()?;
+        send_message(&cred_offer_msg.to_a2a_message())?;
+        self.issuer_sm = self.issuer_sm.clone().mark_credential_offer_sent()?;
+        Ok(())
     }
 
     pub fn send_credential(&mut self, send_message: impl Fn(&A2AMessage) -> VcxResult<()>) -> VcxResult<()> {
@@ -115,12 +185,12 @@ impl Issuer {
 
 #[cfg(test)]
 pub mod test {
+    use crate::handlers::issuance::issuer::state_machine::test::_send_message;
+    use crate::messages::issuance::credential_offer::test_utils::{_offer_info, _offer_info_unrevokable};
     use crate::messages::issuance::credential_proposal::test_utils::_credential_proposal;
     use crate::messages::issuance::credential_request::test_utils::_credential_request;
-    use crate::messages::issuance::credential_offer::test_utils::{_offer_info, _offer_info_unrevokable};
-    use crate::utils::devsetup::SetupMocks;
-    use crate::handlers::issuance::issuer::state_machine::test::_send_message;
     use crate::utils::constants::LIBINDY_CRED_OFFER;
+    use crate::utils::devsetup::SetupMocks;
 
     use super::*;
 
@@ -142,19 +212,19 @@ pub mod test {
 
     impl Issuer {
         fn to_offer_sent_state_unrevokable(mut self) -> Issuer {
-            self.step(CredentialIssuanceMessage::CredentialOfferSend(_offer_info_unrevokable(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            self.build_credential_offer_msg(_offer_info_unrevokable(), None);
+            self.mark_credential_offer_sent();
             self
         }
 
         fn to_request_received_state(mut self) -> Issuer {
-            self.step(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            self = self.to_offer_sent_state_unrevokable();
             self.step(CredentialIssuanceMessage::CredentialRequest(_credential_request()), _send_message()).unwrap();
             self
         }
 
         fn to_finished_state_unrevokable(mut self) -> Issuer {
-            self.step(CredentialIssuanceMessage::CredentialOfferSend(_offer_info_unrevokable(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
-            self.step(CredentialIssuanceMessage::CredentialRequest(_credential_request()), _send_message()).unwrap();
+            self = self.to_request_received_state();
             self.step(CredentialIssuanceMessage::CredentialSend(), _send_message()).unwrap();
             self
         }
@@ -193,7 +263,8 @@ pub mod test {
         let mut issuer = _issuer_revokable_from_proposal();
         assert_eq!(IssuerState::ProposalReceived, issuer.get_state());
 
-        issuer.send_credential_offer(_offer_info(), Some("comment"), _send_message().unwrap()).unwrap();
+        issuer.build_credential_offer_msg(_offer_info(), Some("comment".into())).unwrap();
+        issuer.send_credential_offer(_send_message().unwrap()).unwrap();
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
 
         let messages = map!(
@@ -214,7 +285,8 @@ pub mod test {
         let mut issuer = _issuer_revokable_from_proposal();
         assert_eq!(IssuerState::ProposalReceived, issuer.get_state());
 
-        issuer.send_credential_offer(_offer_info(), Some("comment"), _send_message().unwrap()).unwrap();
+        issuer.build_credential_offer_msg(_offer_info(), Some("comment".into())).unwrap();
+        issuer.send_credential_offer(_send_message().unwrap()).unwrap();
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
 
         let messages = map!(
@@ -224,7 +296,8 @@ pub mod test {
         issuer.step(msg.into(), _send_message()).unwrap();
         assert_eq!(IssuerState::ProposalReceived, issuer.get_state());
 
-        issuer.send_credential_offer(_offer_info(), Some("comment"), _send_message().unwrap()).unwrap();
+        issuer.build_credential_offer_msg(_offer_info(), Some("comment".into())).unwrap();
+        issuer.send_credential_offer(_send_message().unwrap()).unwrap();
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
 
         let messages = map!(
@@ -245,7 +318,8 @@ pub mod test {
         let mut issuer = _issuer().to_offer_sent_state_unrevokable();
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
 
-        let res = issuer.send_credential_offer(_offer_info(), Some("comment"), _send_message_but_fail().unwrap());
+        issuer.build_credential_offer_msg(_offer_info(), Some("comment".into())).unwrap();
+        let res = issuer.send_credential_offer(_send_message_but_fail().unwrap());
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
         assert!(res.is_ok());
     }

--- a/aries_vcx/src/handlers/issuance/issuer/state_machine.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/state_machine.rs
@@ -8,6 +8,7 @@ use crate::handlers::issuance::issuer::states::offer_sent::OfferSentState;
 use crate::handlers::issuance::issuer::states::requested_received::RequestReceivedState;
 use crate::handlers::issuance::issuer::states::credential_sent::CredentialSentState;
 use crate::handlers::issuance::issuer::states::finished::FinishedState;
+use crate::handlers::issuance::issuer::states::offer_set::OfferSetState;
 use crate::handlers::issuance::issuer::utils::encode_attributes;
 use crate::handlers::issuance::messages::CredentialIssuanceMessage;
 use crate::handlers::issuance::verify_thread_id;
@@ -24,6 +25,7 @@ use crate::messages::status::Status;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IssuerFullState {
     Initial(InitialIssuerState),
+    OfferSet(OfferSetState),
     ProposalReceived(ProposalReceivedState),
     OfferSent(OfferSentState),
     RequestReceived(RequestReceivedState),
@@ -107,6 +109,7 @@ impl IssuerSM {
     pub fn get_rev_reg_id(&self) -> VcxResult<String> {
         let rev_registry = match &self.state {
             IssuerFullState::Initial(_state) => { return Err(VcxError::from_msg(VcxErrorKind::InvalidState, "No revocation info available in the initial state")); },
+            IssuerFullState::OfferSet(state) => state.rev_reg_id.clone(),
             IssuerFullState::ProposalReceived(state) => match &state.offer_info {
                 Some(offer_info) => offer_info.rev_reg_id.clone(),
                 _ => None
@@ -118,7 +121,7 @@ impl IssuerSM {
                 .rev_reg_id,
             IssuerFullState::Finished(state) => state.revocation_info_v1.clone()
                 .ok_or(VcxError::from_msg(VcxErrorKind::InvalidState, "No revocation info found - is this credential revokable?"))?
-                .rev_reg_id
+                .rev_reg_id,
         };
         rev_registry.ok_or(VcxError::from_msg(VcxErrorKind::InvalidState, "No revocation registry id found on revocation info - is this credential revokable?"))
     }
@@ -127,10 +130,11 @@ impl IssuerSM {
         match &self.state {
             IssuerFullState::Initial(_state) => { return Err(VcxError::from_msg(VcxErrorKind::InvalidState, "No revocation info available in the initial state")); },
             IssuerFullState::ProposalReceived(state) => state.is_revokable(),
+            IssuerFullState::OfferSet(state) => Ok(state.rev_reg_id.is_some()),
             IssuerFullState::OfferSent(state) => Ok(state.rev_reg_id.is_some()),
             IssuerFullState::RequestReceived(state) => Ok(state.rev_reg_id.is_some()),
             IssuerFullState::CredentialSent(state) => Ok(state.revocation_info_v1.is_some()),
-            IssuerFullState::Finished(state) => Ok(state.revocation_info_v1.is_some())
+            IssuerFullState::Finished(state) => Ok(state.revocation_info_v1.is_some()),
         }
     }
 
@@ -195,6 +199,7 @@ impl IssuerSM {
         match self.state {
             IssuerFullState::Initial(_) => IssuerState::Initial,
             IssuerFullState::ProposalReceived(_) => IssuerState::ProposalReceived,
+            IssuerFullState::OfferSet(_) => IssuerState::OfferSet,
             IssuerFullState::OfferSent(_) => IssuerState::OfferSent,
             IssuerFullState::RequestReceived(_) => IssuerState::RequestReceived,
             IssuerFullState::CredentialSent(_) => IssuerState::CredentialSent,
@@ -214,6 +219,42 @@ impl IssuerSM {
         }
     }
 
+    pub fn set_offer(self, cred_offer_msg: CredentialOffer, credential_json: &str, cred_def_id: &str, rev_reg_id: Option<String>, tails_file: Option<String>) -> VcxResult<Self> {
+        let Self { state, source_id, thread_id } = self;
+        let state = match state {
+            IssuerFullState::Initial(_) | IssuerFullState::OfferSet(_) | IssuerFullState::ProposalReceived(_) => {
+                IssuerFullState::OfferSet(OfferSetState::new(
+                    cred_offer_msg,
+                    credential_json,
+                    cred_def_id,
+                    rev_reg_id,
+                    tails_file
+                ))
+            }
+            _ => {
+                warn!("Can not set credential offer in current state {:?}", state);
+                state
+            }
+        };
+        Ok(Self::step(source_id, thread_id, state))
+    }
+
+    pub fn get_credential_offer_msg(&self) -> VcxResult<CredentialOffer> {
+        match &self.state {
+            IssuerFullState::OfferSet(state) => Ok(state.cred_offer_msg.clone()),
+            _ => Err(VcxError::from_msg(VcxErrorKind::InvalidState, "Can not get cred_offer_msg in current state."))
+        }
+    }
+
+    pub fn mark_credential_offer_sent(self) -> VcxResult<Self> {
+        let Self { state, source_id, thread_id } = self;
+        let state = match state {
+            IssuerFullState::OfferSet(state) => IssuerFullState::OfferSent(state.into()),
+            _ => return Err(VcxError::from_msg(VcxErrorKind::InvalidState, "Can not mark_as_offer_sent in current state."))
+        };
+        Ok(Self::step(source_id, thread_id, state))
+    }
+
     pub fn handle_message(self, cim: CredentialIssuanceMessage, send_message: Option<&impl Fn(&A2AMessage) -> VcxResult<()>>) -> VcxResult<Self> {
         trace!("IssuerSM::handle_message >>> cim: {:?}, state: {:?}", cim, self.state);
         verify_thread_id(&self.thread_id, &cim)?;
@@ -224,35 +265,12 @@ impl IssuerSM {
                     let thread_id = proposal.id.0.to_string();
                     (IssuerFullState::ProposalReceived(ProposalReceivedState::new(proposal, None)), thread_id)
                 }
-                CredentialIssuanceMessage::CredentialOfferSend(offer_info, cred_offer, comment) => {
-                    let cred_offer_msg = CredentialOffer::create()
-                        .set_id(&thread_id)
-                        .set_offers_attach(&cred_offer)?
-                        .set_comment(comment);
-                    let cred_offer_msg = _append_credential_preview(cred_offer_msg, &offer_info.credential_json)?;
-                    send_message.ok_or(
-                        VcxError::from_msg(VcxErrorKind::InvalidState, "Attempted to call undefined send_message callback")
-                    )?(&cred_offer_msg.to_a2a_message())?;
-                    (IssuerFullState::OfferSent((offer_info, cred_offer_msg).into()), thread_id)
-                }
                 _ => {
                     warn!("Unable to process received message in this state");
                     (IssuerFullState::Initial(state_data), thread_id)
                 }
-            }
+            },
             IssuerFullState::ProposalReceived(state_data) => match cim {
-                CredentialIssuanceMessage::CredentialOfferSend(offer_info, cred_offer, comment) => {
-                    let thread_id = state_data.credential_proposal.get_thread_id();
-                    let cred_offer_msg = CredentialOffer::create()
-                        .set_thread_id(&thread_id)
-                        .set_offers_attach(&cred_offer)?
-                        .set_comment(comment);
-                    let cred_offer_msg = _append_credential_preview(cred_offer_msg, &offer_info.credential_json)?;
-                    send_message.ok_or(
-                        VcxError::from_msg(VcxErrorKind::InvalidState, "Attempted to call undefined send_message callback")
-                    )?(&cred_offer_msg.to_a2a_message())?;
-                    (IssuerFullState::OfferSent((cred_offer_msg, offer_info).into()), thread_id)
-                }
                 _ => {
                     warn!("Unable to process received message in this state");
                     (IssuerFullState::ProposalReceived(state_data), thread_id)
@@ -320,6 +338,10 @@ impl IssuerSM {
                 warn!("Unable to process received message in this state");
                 (IssuerFullState::Finished(state_data), thread_id)
             }
+            IssuerFullState::OfferSet(state_data) => {
+                warn!("Unable to process received message in this state");
+                (IssuerFullState::OfferSet(state_data), thread_id)
+            }
         };
 
         Ok(Self::step(source_id, thread_id, state))
@@ -346,45 +368,9 @@ impl IssuerSM {
     }
 }
 
-
-fn _append_credential_preview(cred_offer_msg: CredentialOffer, credential_json: &str) -> VcxResult<CredentialOffer> {
-    trace!("Issuer::_append_credential_preview >>> cred_offer_msg: {:?}, credential_json: {:?}", cred_offer_msg, credential_json);
-
-    let cred_values: serde_json::Value = serde_json::from_str(credential_json)
-        .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Can't deserialize credential preview json. credential_json: {}, error: {:?}", credential_json, err)))?;
-
-    let mut new_offer = cred_offer_msg;
-    match cred_values {
-        serde_json::Value::Array(cred_values) => {
-            for cred_value in cred_values.iter() {
-                let key = cred_value.get("name").ok_or(VcxError::from_msg(VcxErrorKind::InvalidAttributesStructure, format!("No 'name' field in cred_value: {:?}", cred_value)))?;
-                let value = cred_value.get("value").ok_or(VcxError::from_msg(VcxErrorKind::InvalidAttributesStructure, format!("No 'value' field in cred_value: {:?}", cred_value)))?;
-                new_offer = new_offer.add_credential_preview_data(
-                    &key.to_string(),
-                    &value.to_string(),
-                    MimeType::Plain,
-                )?;
-            };
-        }
-        serde_json::Value::Object(values_map) => {
-            for item in values_map.iter() {
-                let (key, value) = item;
-                new_offer = new_offer.add_credential_preview_data(
-                    key,
-                    &value.to_string(),
-                    MimeType::Plain,
-                )?;
-            }
-        }
-        _ => {}
-    };
-
-    Ok(new_offer)
-}
-
 fn _create_credential(request: &CredentialRequest, rev_reg_id: &Option<String>, tails_file: &Option<String>, offer: &CredentialOffer, cred_data: &str, thread_id: &str) -> VcxResult<(Credential, Option<String>)> {
-    trace!("Issuer::_create_credential >>> request: {:?}, rev_reg_id: {:?}, tails_file: {:?}, offer: {:?}, cred_data: {}, thread_id: {}", request, rev_reg_id, tails_file, offer, cred_data, thread_id);
     let offer = offer.offers_attach.content()?;
+    trace!("Issuer::_create_credential >>> request: {:?}, rev_reg_id: {:?}, tails_file: {:?}, offer: {}, cred_data: {}, thread_id: {}", request, rev_reg_id, tails_file, offer, cred_data, thread_id);
     if !request.from_thread(&thread_id) {
         return Err(VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot handle credential request: thread id does not match: {:?}", request.thread)));
     };
@@ -439,19 +425,21 @@ pub mod test {
         }
 
         fn to_offer_sent_state(mut self) -> IssuerSM {
-            self = self.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            let cred_offer = serde_json::from_str(LIBINDY_CRED_OFFER).unwrap();
+            let cred_info = _offer_info();
+            self = self.set_offer(cred_offer, &cred_info.credential_json, &cred_info.cred_def_id, cred_info.rev_reg_id, cred_info.tails_file).unwrap();
+            self = self.mark_credential_offer_sent().unwrap();
             self
         }
 
         fn to_request_received_state(mut self) -> IssuerSM {
-            self = self.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            self = self.to_offer_sent_state();
             self = self.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), _send_message()).unwrap();
             self
         }
 
         fn to_finished_state(mut self) -> IssuerSM {
-            self = self.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
-            self = self.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), _send_message()).unwrap();
+            self = self.to_request_received_state();
             self = self.handle_message(CredentialIssuanceMessage::CredentialSend(), _send_message()).unwrap();
             self
         }
@@ -503,7 +491,10 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            let cred_offer = serde_json::from_str(LIBINDY_CRED_OFFER).unwrap();
+            let cred_info = _offer_info();
+            issuer_sm = issuer_sm.set_offer(cred_offer, &cred_info.credential_json, &cred_info.cred_def_id, cred_info.rev_reg_id, cred_info.tails_file).unwrap();
+            issuer_sm = issuer_sm.mark_credential_offer_sent().unwrap();
 
             assert_match!(IssuerFullState::OfferSent(_), issuer_sm.state);
         }
@@ -528,7 +519,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm_from_proposal();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
 
             assert_match!(IssuerFullState::OfferSent(_), issuer_sm.state);
         }
@@ -553,7 +544,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), _send_message()).unwrap();
 
             assert_match!(IssuerFullState::RequestReceived(_), issuer_sm.state);
@@ -565,7 +556,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialProposal(_credential_proposal()), _send_message()).unwrap();
 
             assert_match!(IssuerFullState::ProposalReceived(_), issuer_sm.state);
@@ -577,7 +568,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::ProblemReport(_problem_report()), _send_message()).unwrap();
 
             assert_match!(IssuerFullState::Finished(_), issuer_sm.state);
@@ -590,7 +581,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::Credential(_credential()), _send_message()).unwrap();
 
             assert_match!(IssuerFullState::OfferSent(_), issuer_sm.state);
@@ -602,7 +593,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), _send_message()).unwrap();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), _send_message()).unwrap();
 
@@ -616,7 +607,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(CredentialRequest::create()), _send_message()).unwrap();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), _send_message()).unwrap();
 
@@ -630,7 +621,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), _send_message()).unwrap();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), _send_message()).unwrap();
 
@@ -647,7 +638,7 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request_1()), _send_message()).unwrap();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), _send_message()).unwrap();
             assert_match!(IssuerFullState::Finished(_), issuer_sm.state);
@@ -660,11 +651,11 @@ pub mod test {
             let _setup = SetupMocks::init();
 
             let mut issuer_sm = _issuer_sm();
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), _send_message()).unwrap();
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialSend(), _send_message()).unwrap();
 
-            issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialOfferSend(_offer_info(), LIBINDY_CRED_OFFER.to_string(), None), _send_message()).unwrap();
+            issuer_sm = issuer_sm.to_offer_sent_state();
             assert_match!(IssuerFullState::Finished(_), issuer_sm.state);
 
             issuer_sm = issuer_sm.handle_message(CredentialIssuanceMessage::CredentialRequest(_credential_request()), _send_message()).unwrap();

--- a/aries_vcx/src/handlers/issuance/issuer/state_machine.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/state_machine.rs
@@ -239,7 +239,7 @@ impl IssuerSM {
         Ok(Self::step(source_id, thread_id, state))
     }
 
-    pub fn get_credential_offer_msg(&self) -> VcxResult<CredentialOffer> {
+    pub fn get_credential_offer(&self) -> VcxResult<CredentialOffer> {
         match &self.state {
             IssuerFullState::OfferSet(state) => Ok(state.offer.clone()),
             IssuerFullState::OfferSent(state) => Ok(state.offer.clone()),

--- a/aries_vcx/src/handlers/issuance/issuer/states/mod.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/states/mod.rs
@@ -4,3 +4,4 @@ pub(super) mod offer_sent;
 pub(super) mod requested_received;
 pub(super) mod credential_sent;
 pub(super) mod finished;
+pub(super) mod offer_set;

--- a/aries_vcx/src/handlers/issuance/issuer/states/offer_set.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/states/offer_set.rs
@@ -24,18 +24,6 @@ impl OfferSetState {
         }
     }
 }
-//
-// impl From<OfferSetState> for FinishedState {
-//     fn from(_state: OfferSetState) -> Self {
-//         trace!("SM is now in Finished state");
-//         FinishedState {
-//             cred_id: None,
-//             thread_id: String::new(),
-//             revocation_info_v1: None,
-//             status: Status::Undefined,
-//         }
-//     }
-// }
 
 impl From<OfferSetState> for OfferSentState {
     fn from(state: OfferSetState) -> Self {

--- a/aries_vcx/src/handlers/issuance/issuer/states/offer_set.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/states/offer_set.rs
@@ -1,0 +1,50 @@
+use crate::handlers::issuance::issuer::states::finished::FinishedState;
+use crate::handlers::issuance::issuer::states::offer_sent::OfferSentState;
+use crate::messages::a2a::MessageId;
+use crate::messages::status::Status;
+use crate::messages::issuance::credential_offer::CredentialOffer;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct OfferSetState {
+    pub cred_offer_msg: CredentialOffer,
+    pub credential_json: String,
+    pub cred_def_id: String,
+    pub rev_reg_id: Option<String>,
+    pub tails_file: Option<String>
+}
+
+impl OfferSetState {
+    pub fn new(cred_offer_msg: CredentialOffer, credential_json: &str, cred_def_id: &str, rev_reg_id: Option<String>, tails_file: Option<String>) -> Self {
+        OfferSetState {
+            cred_offer_msg,
+            credential_json: credential_json.into(),
+            cred_def_id: cred_def_id.into(),
+            rev_reg_id,
+            tails_file
+        }
+    }
+}
+//
+// impl From<OfferSetState> for FinishedState {
+//     fn from(_state: OfferSetState) -> Self {
+//         trace!("SM is now in Finished state");
+//         FinishedState {
+//             cred_id: None,
+//             thread_id: String::new(),
+//             revocation_info_v1: None,
+//             status: Status::Undefined,
+//         }
+//     }
+// }
+
+impl From<OfferSetState> for OfferSentState {
+    fn from(state: OfferSetState) -> Self {
+        trace!("SM is now in OfferSent state");
+        OfferSentState {
+            offer: state.cred_offer_msg,
+            cred_data: state.credential_json,
+            rev_reg_id: state.rev_reg_id,
+            tails_file: state.tails_file,
+        }
+    }
+}

--- a/aries_vcx/src/handlers/issuance/issuer/states/offer_set.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/states/offer_set.rs
@@ -1,7 +1,4 @@
-use crate::handlers::issuance::issuer::states::finished::FinishedState;
 use crate::handlers::issuance::issuer::states::offer_sent::OfferSentState;
-use crate::messages::a2a::MessageId;
-use crate::messages::status::Status;
 use crate::messages::issuance::credential_offer::CredentialOffer;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/aries_vcx/src/handlers/issuance/issuer/states/offer_set.rs
+++ b/aries_vcx/src/handlers/issuance/issuer/states/offer_set.rs
@@ -6,7 +6,7 @@ use crate::messages::issuance::credential_offer::CredentialOffer;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct OfferSetState {
-    pub cred_offer_msg: CredentialOffer,
+    pub offer: CredentialOffer,
     pub credential_json: String,
     pub cred_def_id: String,
     pub rev_reg_id: Option<String>,
@@ -16,7 +16,7 @@ pub struct OfferSetState {
 impl OfferSetState {
     pub fn new(cred_offer_msg: CredentialOffer, credential_json: &str, cred_def_id: &str, rev_reg_id: Option<String>, tails_file: Option<String>) -> Self {
         OfferSetState {
-            cred_offer_msg,
+            offer: cred_offer_msg,
             credential_json: credential_json.into(),
             cred_def_id: cred_def_id.into(),
             rev_reg_id,
@@ -41,7 +41,7 @@ impl From<OfferSetState> for OfferSentState {
     fn from(state: OfferSetState) -> Self {
         trace!("SM is now in OfferSent state");
         OfferSentState {
-            offer: state.cred_offer_msg,
+            offer: state.offer,
             cred_data: state.credential_json,
             rev_reg_id: state.rev_reg_id,
             tails_file: state.tails_file,

--- a/aries_vcx/src/handlers/issuance/messages.rs
+++ b/aries_vcx/src/handlers/issuance/messages.rs
@@ -2,12 +2,11 @@ use crate::messages::a2a::A2AMessage;
 use crate::messages::error::ProblemReport;
 use crate::messages::issuance::credential::Credential;
 use crate::messages::issuance::credential_ack::CredentialAck;
-use crate::messages::issuance::credential_offer::{CredentialOffer, OfferInfo};
+use crate::messages::issuance::credential_offer::CredentialOffer;
 use crate::messages::issuance::credential_proposal::{CredentialProposal, CredentialProposalData};
 use crate::messages::issuance::credential_request::CredentialRequest;
 
 type OptionalComment = Option<String>;
-type CredentialOfferJson = String;
 
 #[derive(Debug, Clone)]
 pub enum CredentialIssuanceMessage {

--- a/aries_vcx/src/handlers/issuance/messages.rs
+++ b/aries_vcx/src/handlers/issuance/messages.rs
@@ -11,7 +11,6 @@ type CredentialOfferJson = String;
 
 #[derive(Debug, Clone)]
 pub enum CredentialIssuanceMessage {
-    CredentialOfferSend(OfferInfo, CredentialOfferJson, OptionalComment),
     CredentialSend(),
     CredentialProposalSend(CredentialProposalData),
     CredentialProposal(CredentialProposal),

--- a/aries_vcx/src/handlers/mod.rs
+++ b/aries_vcx/src/handlers/mod.rs
@@ -54,12 +54,12 @@ impl From<IssuerState> for u32 {
         match state {
             IssuerState::Initial => 0,
             IssuerState::ProposalReceived => 1,
-            IssuerState::OfferSet => 12,
-            IssuerState::OfferSent => 2,
-            IssuerState::RequestReceived => 3,
-            IssuerState::CredentialSent => 4,
-            IssuerState::Finished => 5,
-            IssuerState::Failed => 6,
+            IssuerState::OfferSet => 3,
+            IssuerState::OfferSent => 4,
+            IssuerState::RequestReceived => 5,
+            IssuerState::CredentialSent => 6,
+            IssuerState::Finished => 7,
+            IssuerState::Failed => 8,
         }
     }
 }

--- a/aries_vcx/src/handlers/mod.rs
+++ b/aries_vcx/src/handlers/mod.rs
@@ -54,12 +54,12 @@ impl From<IssuerState> for u32 {
         match state {
             IssuerState::Initial => 0,
             IssuerState::ProposalReceived => 1,
-            IssuerState::OfferSet => 3,
-            IssuerState::OfferSent => 4,
-            IssuerState::RequestReceived => 5,
-            IssuerState::CredentialSent => 6,
-            IssuerState::Finished => 7,
-            IssuerState::Failed => 8,
+            IssuerState::OfferSet => 2,
+            IssuerState::OfferSent => 3,
+            IssuerState::RequestReceived => 4,
+            IssuerState::CredentialSent => 5,
+            IssuerState::Finished => 6,
+            IssuerState::Failed => 7,
         }
     }
 }

--- a/aries_vcx/src/handlers/mod.rs
+++ b/aries_vcx/src/handlers/mod.rs
@@ -54,11 +54,12 @@ impl From<IssuerState> for u32 {
         match state {
             IssuerState::Initial => 0,
             IssuerState::ProposalReceived => 1,
+            IssuerState::OfferSet => 12,
             IssuerState::OfferSent => 2,
             IssuerState::RequestReceived => 3,
             IssuerState::CredentialSent => 4,
             IssuerState::Finished => 5,
-            IssuerState::Failed => 6
+            IssuerState::Failed => 6,
         }
     }
 }

--- a/aries_vcx/src/handlers/out_of_band/sender/sender.rs
+++ b/aries_vcx/src/handlers/out_of_band/sender/sender.rs
@@ -54,33 +54,18 @@ impl OutOfBandSender {
 
     pub fn append_a2a_message(mut self, msg: A2AMessage) -> VcxResult<Self> {
         let (attach_id, attach) = match msg {
-            A2AMessage::CredentialRequest(request) => {
-                (AttachmentId::CredentialRequest,
-                serde_json::to_string(&request)
-                    .map_err(|_| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to serialize request: {:?}", request)))?)
-            }
             A2AMessage::PresentationRequest(request) => {
-                (AttachmentId::PresentationRequest,
-                serde_json::to_string(&request)
-                    .map_err(|_| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to serialize request: {:?}", request)))?)
+                (AttachmentId::PresentationRequest, json!(&request).to_string())
             }
             A2AMessage::CredentialOffer(offer) => {
-                (AttachmentId::CredentialOffer,
-                serde_json::to_string(&offer)
-                    .map_err(|_| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to serialize offer: {:?}", offer)))?)
-            }
-            A2AMessage::Credential(credential) => {
-                (AttachmentId::Credential,
-                serde_json::to_string(&credential)
-                    .map_err(|_| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to serialize credential: {:?}", credential)))?)
-            }
-            A2AMessage::Presentation(presentation) => {
-                (AttachmentId::Presentation,
-                serde_json::to_string(&presentation)
-                    .map_err(|_| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to serialize presentation: {:?}", presentation)))?)
+                 (AttachmentId::CredentialOffer, json!(&offer).to_string())
             }
             _ => {
-                return Err(VcxError::from(VcxErrorKind::InvalidMessageFormat))
+                error!("Appended message type {:?} is not allowed.", msg);
+                return Err(VcxError::from_msg(
+                    VcxErrorKind::InvalidMessageFormat,
+                    format!("Appended message type {:?} is not allowed.", msg))
+                )
             }
         };
         self.oob.requests_attach.add_base64_encoded_json_attachment(attach_id, ::serde_json::Value::String(attach))?;

--- a/aries_vcx/src/handlers/proof_presentation/verifier/messages.rs
+++ b/aries_vcx/src/handlers/proof_presentation/verifier/messages.rs
@@ -2,17 +2,16 @@ use crate::messages::a2a::A2AMessage;
 use crate::messages::error::ProblemReport;
 use crate::messages::proof_presentation::presentation::Presentation;
 use crate::messages::proof_presentation::presentation_proposal::PresentationProposal;
-use crate::messages::proof_presentation::presentation_request::PresentationRequestData;
+use crate::messages::proof_presentation::presentation_request::PresentationRequest;
 
 type Comment = Option<String>;
 type Reason = String;
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub enum VerifierMessages {
-    SendPresentationRequest(Comment),
     VerifyPresentation(Presentation),
     RejectPresentationProposal(Reason),
-    SetPresentationRequest(PresentationRequestData),
+    SetPresentationRequest(PresentationRequest),
     PresentationProposalReceived(PresentationProposal),
     PresentationRejectReceived(ProblemReport),
     SendPresentationAck(),

--- a/aries_vcx/src/handlers/proof_presentation/verifier/messages.rs
+++ b/aries_vcx/src/handlers/proof_presentation/verifier/messages.rs
@@ -4,7 +4,6 @@ use crate::messages::proof_presentation::presentation::Presentation;
 use crate::messages::proof_presentation::presentation_proposal::PresentationProposal;
 use crate::messages::proof_presentation::presentation_request::PresentationRequest;
 
-type Comment = Option<String>;
 type Reason = String;
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]

--- a/aries_vcx/src/handlers/proof_presentation/verifier/states/presentation_proposal_received.rs
+++ b/aries_vcx/src/handlers/proof_presentation/verifier/states/presentation_proposal_received.rs
@@ -1,10 +1,10 @@
 use crate::messages::proof_presentation::presentation_proposal::PresentationProposal;
-use crate::messages::proof_presentation::presentation_request::PresentationRequestData;
+use crate::messages::proof_presentation::presentation_request::PresentationRequest;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct PresentationProposalReceivedState {
     pub presentation_proposal: PresentationProposal,
-    pub presentation_request_data: Option<PresentationRequestData>,
+    pub presentation_request: Option<PresentationRequest>,
 }
 
 impl PresentationProposalReceivedState {

--- a/aries_vcx/src/handlers/proof_presentation/verifier/states/presentation_request_set.rs
+++ b/aries_vcx/src/handlers/proof_presentation/verifier/states/presentation_request_set.rs
@@ -1,12 +1,22 @@
-use crate::messages::proof_presentation::presentation_request::PresentationRequestData;
+use crate::handlers::proof_presentation::verifier::states::presentation_request_sent::PresentationRequestSentState;
+use crate::messages::proof_presentation::presentation_request::PresentationRequest;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct PresentationRequestSet {
-    pub presentation_request_data: PresentationRequestData,
+pub struct PresentationRequestSetState {
+    pub presentation_request: PresentationRequest,
 }
 
-impl PresentationRequestSet {
-    pub fn new(presentation_request_data: PresentationRequestData) -> Self {
-        Self { presentation_request_data }
+impl PresentationRequestSetState {
+    pub fn new(presentation_request: PresentationRequest) -> Self {
+        Self { presentation_request }
+    }
+}
+
+impl From<PresentationRequestSetState> for PresentationRequestSentState {
+    fn from(state: PresentationRequestSetState) -> Self {
+        trace!("transit state from PresentationRequestSetState to PresentationRequestSentState");
+        PresentationRequestSentState {
+            presentation_request: state.presentation_request
+        }
     }
 }

--- a/aries_vcx/src/messages/connection/invite.rs
+++ b/aries_vcx/src/messages/connection/invite.rs
@@ -4,7 +4,6 @@ use crate::error::prelude::*;
 use crate::messages::a2a::{A2AMessage, MessageId};
 use crate::messages::connection::did_doc::Did;
 use crate::messages::connection::service::ServiceResolvable;
-use crate::utils::uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
@@ -113,7 +112,7 @@ a2a_message!(PublicInvitation, ConnectionInvitationPublic);
 #[cfg(feature = "test_utils")]
 pub mod test_utils {
     use crate::messages::connection::did_doc::test_utils::*;
-
+    use crate::utils::uuid;
     use super::*;
 
     pub fn _pairwise_invitation() -> PairwiseInvitation {
@@ -161,7 +160,6 @@ pub mod test_utils {
 pub mod tests {
     use crate::messages::connection::did_doc::test_utils::*;
     use crate::messages::connection::invite::test_utils::{_pairwise_invitation, _public_invitation};
-
     use super::*;
 
     #[test]

--- a/aries_vcx/src/messages/issuance/credential_offer.rs
+++ b/aries_vcx/src/messages/issuance/credential_offer.rs
@@ -39,14 +39,14 @@ impl CredentialOffer {
         Ok(self)
     }
 
-    pub fn set_credential_preview_data(mut self, credential_preview: CredentialPreviewData) -> VcxResult<CredentialOffer> {
+    pub fn set_credential_preview_data(mut self, credential_preview: CredentialPreviewData) -> CredentialOffer {
         self.credential_preview = credential_preview;
-        Ok(self)
+        self
     }
 
-    pub fn add_credential_preview_data(mut self, name: &str, value: &str, mime_type: MimeType) -> VcxResult<CredentialOffer> {
-        self.credential_preview = self.credential_preview.add_value(name, value, mime_type)?;
-        Ok(self)
+    pub fn add_credential_preview_data(mut self, name: &str, value: &str, mime_type: MimeType) -> CredentialOffer {
+        self.credential_preview = self.credential_preview.add_value(name, value, mime_type);
+        self
     }
 }
 
@@ -96,7 +96,7 @@ pub mod test_utils {
     pub fn _preview_data() -> CredentialPreviewData {
         let (name, value) = _value();
         CredentialPreviewData::new()
-            .add_value(name, value, MimeType::Plain).unwrap()
+            .add_value(name, value, MimeType::Plain)
     }
 
     pub fn thread() -> Thread {

--- a/aries_vcx/src/messages/issuance/credential_offer.rs
+++ b/aries_vcx/src/messages/issuance/credential_offer.rs
@@ -166,7 +166,7 @@ pub mod tests {
         let credential_offer: CredentialOffer = CredentialOffer::create()
             .set_comment(_comment())
             .set_thread_id(&_thread_id())
-            .set_credential_preview_data(_preview_data()).unwrap()
+            .set_credential_preview_data(_preview_data())
             .set_offers_attach(&_attachment().to_string()).unwrap();
 
         assert_eq!(_credential_offer(), credential_offer);

--- a/aries_vcx/src/messages/issuance/credential_proposal.rs
+++ b/aries_vcx/src/messages/issuance/credential_proposal.rs
@@ -1,4 +1,3 @@
-use crate::error::VcxResult;
 use crate::messages::a2a::{A2AMessage, MessageId};
 use crate::messages::issuance::CredentialPreviewData;
 use crate::messages::mime_type::MimeType;
@@ -38,9 +37,9 @@ impl CredentialProposal {
         self
     }
 
-    pub fn add_credential_preview_data(mut self, name: &str, value: &str, mime_type: MimeType) -> VcxResult<Self> {
-        self.credential_proposal = self.credential_proposal.add_value(name, value, mime_type)?;
-        Ok(self)
+    pub fn add_credential_preview_data(mut self, name: &str, value: &str, mime_type: MimeType) -> Self {
+        self.credential_proposal = self.credential_proposal.add_value(name, value, mime_type);
+        self
     }
 
     pub fn set_id(mut self, id: &str) -> Self {
@@ -81,9 +80,9 @@ impl CredentialProposalData {
         self
     }
 
-    pub fn add_credential_preview_data(mut self, name: &str, value: &str, mime_type: MimeType) -> VcxResult<Self> {
-        self.credential_proposal = self.credential_proposal.add_value(name, value, mime_type)?;
-        Ok(self)
+    pub fn add_credential_preview_data(mut self, name: &str, value: &str, mime_type: MimeType) -> Self {
+        self.credential_proposal = self.credential_proposal.add_value(name, value, mime_type);
+        self
     }
 }
 
@@ -121,7 +120,7 @@ pub mod test_utils {
         let (name, value) = _value();
 
         CredentialPreviewData::new()
-            .add_value(name, value, MimeType::Plain).unwrap()
+            .add_value(name, value, MimeType::Plain)
     }
 
     pub fn _credential_proposal() -> CredentialProposal {
@@ -162,7 +161,7 @@ pub mod tests {
             .set_thread_id(&thread_id())
             .set_cred_def_id(_cred_def_id())
             .set_schema_id(_schema_id())
-            .add_credential_preview_data(name, value, MimeType::Plain).unwrap();
+            .add_credential_preview_data(name, value, MimeType::Plain);
 
         assert_eq!(_credential_proposal(), credential_proposal);
     }

--- a/aries_vcx/src/messages/issuance/mod.rs
+++ b/aries_vcx/src/messages/issuance/mod.rs
@@ -21,7 +21,7 @@ impl CredentialPreviewData {
         CredentialPreviewData::default()
     }
 
-    pub fn add_value(mut self, name: &str, value: &str, mime_type: MimeType) -> VcxResult<CredentialPreviewData> {
+    pub fn add_value(mut self, name: &str, value: &str, mime_type: MimeType) -> CredentialPreviewData {
         let data_value = match mime_type {
             MimeType::Plain => {
                 CredentialValue {
@@ -32,7 +32,7 @@ impl CredentialPreviewData {
             }
         };
         self.attributes.push(data_value);
-        Ok(self)
+        self
     }
 
     pub fn to_string(&self) -> VcxResult<String> {

--- a/aries_vcx/src/messages/proof_presentation/presentation.rs
+++ b/aries_vcx/src/messages/proof_presentation/presentation.rs
@@ -41,7 +41,7 @@ a2a_message!(Presentation);
 
 #[cfg(feature = "test_utils")]
 pub mod test_utils {
-    use crate::messages::proof_presentation::presentation_request::test_utils::_thread;
+    use crate::messages::proof_presentation::presentation_request::test_utils::thread;
     use crate::messages::connection::response::test_utils::_thread_1;
 
     use super::*;
@@ -62,7 +62,7 @@ pub mod test_utils {
             id: MessageId::id(),
             comment: _comment(),
             presentations_attach: attachment,
-            thread: _thread(),
+            thread: thread(),
             please_ack: Some(PleaseAck {}),
         }
     }

--- a/aries_vcx/src/messages/proof_presentation/presentation_proposal.rs
+++ b/aries_vcx/src/messages/proof_presentation/presentation_proposal.rs
@@ -164,8 +164,7 @@ impl From<PresentationProposalData> for PresentationProposal {
 
 #[cfg(feature = "test_utils")]
 pub mod test_utils {
-    use crate::messages::proof_presentation::presentation_request::test_utils::_thread;
-
+    use crate::messages::connection::response::test_utils::_thread;
     use super::*;
 
     fn _attachment() -> ::serde_json::Value {

--- a/aries_vcx/src/messages/proof_presentation/presentation_request.rs
+++ b/aries_vcx/src/messages/proof_presentation/presentation_request.rs
@@ -79,7 +79,7 @@ pub mod test_utils {
         _presentation_request().id.0
     }
 
-    pub fn _thread() -> Thread {
+    pub fn thread() -> Thread {
         Thread::new().set_thid(_presentation_request().id.0)
     }
 

--- a/aries_vcx/src/utils/author_agreement.rs
+++ b/aries_vcx/src/utils/author_agreement.rs
@@ -51,7 +51,7 @@ pub fn get_txn_author_agreement() -> VcxResult<Option<TxnAuthorAgreementAcceptan
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::devsetup::SetupDefaults;
+    use crate::utils::lcreddevsetup::SetupDefaults;
 
     use super::*;
 

--- a/aries_vcx/src/utils/author_agreement.rs
+++ b/aries_vcx/src/utils/author_agreement.rs
@@ -51,7 +51,7 @@ pub fn get_txn_author_agreement() -> VcxResult<Option<TxnAuthorAgreementAcceptan
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::lcreddevsetup::SetupDefaults;
+    use crate::utils::devsetup::SetupDefaults;
 
     use super::*;
 

--- a/aries_vcx/tests/test_integration.rs
+++ b/aries_vcx/tests/test_integration.rs
@@ -293,11 +293,11 @@ mod tests {
             .set_schema_id(schema_id.to_string())
             .set_cred_def_id(cred_def_id.to_string())
             .set_comment(comment.to_string())
-            .add_credential_preview_data(&address1, "123 Main St", MimeType::Plain).unwrap()
-            .add_credential_preview_data(&address2, "Suite 3", MimeType::Plain).unwrap()
-            .add_credential_preview_data(&city, "Draper", MimeType::Plain).unwrap()
-            .add_credential_preview_data(&state, "UT", MimeType::Plain).unwrap()
-            .add_credential_preview_data(&zip, "84000", MimeType::Plain).unwrap();
+            .add_credential_preview_data(&address1, "123 Main St", MimeType::Plain)
+            .add_credential_preview_data(&address2, "Suite 3", MimeType::Plain)
+            .add_credential_preview_data(&city, "Draper", MimeType::Plain)
+            .add_credential_preview_data(&state, "UT", MimeType::Plain)
+            .add_credential_preview_data(&zip, "84000", MimeType::Plain);
         let mut holder = Holder::create("TEST_CREDENTIAL").unwrap();
         assert_eq!(HolderState::Initial, holder.get_state());
         holder.send_proposal(proposal, connection.send_message_closure().unwrap()).unwrap();
@@ -316,11 +316,11 @@ mod tests {
             .set_schema_id(schema_id.to_string())
             .set_cred_def_id(cred_def_id.to_string())
             .set_comment(comment.to_string())
-            .add_credential_preview_data(&address1, "456 Side St", MimeType::Plain).unwrap()
-            .add_credential_preview_data(&address2, "Suite 666", MimeType::Plain).unwrap()
-            .add_credential_preview_data(&city, "Austin", MimeType::Plain).unwrap()
-            .add_credential_preview_data(&state, "TX", MimeType::Plain).unwrap()
-            .add_credential_preview_data(&zip, "42000", MimeType::Plain).unwrap();
+            .add_credential_preview_data(&address1, "456 Side St", MimeType::Plain)
+            .add_credential_preview_data(&address2, "Suite 666", MimeType::Plain)
+            .add_credential_preview_data(&city, "Austin", MimeType::Plain)
+            .add_credential_preview_data(&state, "TX", MimeType::Plain)
+            .add_credential_preview_data(&zip, "42000", MimeType::Plain);
         holder.send_proposal(proposal, connection.send_message_closure().unwrap()).unwrap();
         assert_eq!(HolderState::ProposalSent, holder.get_state());
         thread::sleep(Duration::from_millis(1000));
@@ -1095,7 +1095,7 @@ mod tests {
         let credential_data = credential_data.to_string();
         info!("test_real_proof :: generated credential data: {}", credential_data);
         let mut issuer_credential = create_and_send_cred_offer(&mut institution, &cred_def, &issuer_to_consumer, &credential_data, None);
-        let issuance_thread_id = issuer_credential.get_thread_id().unwrap();
+        let issuance_thread_id = issuer_credential.get_thread_id();
 
         info!("test_real_proof :: AS CONSUMER SEND CREDENTIAL REQUEST");
         let mut holder_credential = send_cred_req(&mut consumer, &consumer_to_issuer, None);

--- a/aries_vcx/tests/test_integration.rs
+++ b/aries_vcx/tests/test_integration.rs
@@ -455,8 +455,8 @@ mod tests {
         let presentation_request_data =
             PresentationRequestData::create("request-1").unwrap()
             .set_requested_attributes_as_vec(attrs).unwrap();
-        verifier.set_request(presentation_request_data).unwrap();
-        verifier.send_presentation_request(&connection.send_message_closure().unwrap(), None).unwrap();
+        verifier.set_request(presentation_request_data, None).unwrap();
+        verifier.send_presentation_request(&connection.send_message_closure().unwrap()).unwrap();
     }
 
     fn reject_proof_proposal(faber: &mut Faber, connection: &Connection) -> Verifier {
@@ -478,13 +478,13 @@ mod tests {
 
     fn send_proof_request(faber: &mut Faber, connection: &Connection, requested_attrs: &str, requested_preds: &str, revocation_interval: &str, request_name: Option<&str>) -> Verifier {
         faber.activate().unwrap();
-        let presentation_request =
+        let presentation_request_data =
             PresentationRequestData::create(request_name.unwrap_or("name")).unwrap()
                 .set_requested_attributes_as_string(requested_attrs.to_string()).unwrap()
                 .set_requested_predicates_as_string(requested_preds.to_string()).unwrap()
                 .set_not_revoked_interval(revocation_interval.to_string()).unwrap();
-        let mut verifier = Verifier::create_from_request("1".to_string(), &presentation_request).unwrap();
-        verifier.send_presentation_request(connection.send_message_closure().unwrap(), None).unwrap();
+        let mut verifier = Verifier::create_from_request("1".to_string(), &presentation_request_data).unwrap();
+        verifier.send_presentation_request(connection.send_message_closure().unwrap()).unwrap();
         thread::sleep(Duration::from_millis(2000));
         verifier
     }
@@ -497,7 +497,7 @@ mod tests {
                 .set_requested_predicates_as_string(requested_preds.to_string()).unwrap()
                 .set_not_revoked_interval(revocation_interval.to_string()).unwrap();
         let verifier = Verifier::create_from_request("1".to_string(), &presentation_request).unwrap();
-        verifier.generate_presentation_request().unwrap()
+        verifier.get_presentation_request().unwrap()
     }
 
     fn create_proof(alice: &mut Alice, connection: &Connection, request_name: Option<&str>) -> Prover {
@@ -542,7 +542,7 @@ mod tests {
         institution.activate().unwrap();
         verifier.update_state(&connection).unwrap();
         assert_eq!(verifier.get_state(), VerifierState::Finished);
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     fn revoke_credential(faber: &mut Faber, issuer_credential: &Issuer, rev_reg_id: Option<String>) {
@@ -696,7 +696,7 @@ mod tests {
         info!("test_proof_should_be_validated :: verifier :: going to verify proof");
         institution.activate().unwrap();
         verifier.update_state(&institution_to_consumer).unwrap();
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     #[cfg(feature = "agency_pool_tests")]
@@ -724,7 +724,7 @@ mod tests {
         info!("test_basic_revocation :: verifier :: going to verify proof");
         institution.activate().unwrap();
         verifier.update_state(&institution_to_consumer).unwrap();
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
         info!("verifier received presentation!: {}", verifier.get_presentation_attachment().unwrap());
     }
 
@@ -780,7 +780,7 @@ mod tests {
         info!("test_basic_revocation :: verifier :: going to verify proof");
         institution.activate().unwrap();
         verifier.update_state(&institution_to_consumer).unwrap();
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofInvalid as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofInvalid as u32);
     }
 
     #[cfg(feature = "agency_pool_tests")]
@@ -800,7 +800,7 @@ mod tests {
 
         institution.activate().unwrap();
         verifier.update_state(&institution_to_consumer).unwrap();
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
 
         publish_revocation(&mut institution, rev_reg_id.clone().unwrap());
         let request_name2 = Some("request2");
@@ -809,7 +809,7 @@ mod tests {
 
         institution.activate().unwrap();
         verifier.update_state(&institution_to_consumer).unwrap();
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofInvalid as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofInvalid as u32);
     }
 
     #[cfg(feature = "agency_pool_tests")]
@@ -837,14 +837,14 @@ mod tests {
         prover_select_credentials_and_send_proof(&mut consumer1, &consumer1_to_verifier, None, None);
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer1).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
 
         let request_name2 = Some("request2");
         let mut proof_verifier = verifier_create_proof_and_send_request(&mut verifier, &verifier_to_consumer2, &schema_id, &cred_def_id, request_name2);
         prover_select_credentials_and_send_proof(&mut consumer2, &consumer2_to_verifier, None, None);
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer2).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     #[cfg(feature = "agency_pool_tests")]
@@ -865,14 +865,14 @@ mod tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, request_name1, None);
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
 
         let request_name2 = Some("request2");
         let mut proof_verifier = verifier_create_proof_and_send_request(&mut verifier, &verifier_to_consumer, &schema_id, &cred_def_id, request_name2);
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, request_name2, None);
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     #[cfg(feature = "agency_pool_tests")]
@@ -893,14 +893,14 @@ mod tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_institution, request_name1, None);
         institution.activate().unwrap();
         verifier.update_state(&institution_to_consumer).unwrap();
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
 
         let request_name2 = Some("request2");
         let mut verifier = verifier_create_proof_and_send_request(&mut institution, &institution_to_consumer, &schema_id, &cred_def_id, request_name2);
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_institution, request_name2, None);
         institution.activate().unwrap();
         verifier.update_state(&institution_to_consumer).unwrap();
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     #[cfg(feature = "agency_pool_tests")]
@@ -947,9 +947,9 @@ mod tests {
         verifier1.update_state(&institution_to_consumer1).unwrap();
         verifier2.update_state(&institution_to_consumer2).unwrap();
         verifier3.update_state(&institution_to_consumer3).unwrap();
-        assert_eq!(verifier1.presentation_status(), ProofStateType::ProofValidated as u32);
-        assert_eq!(verifier2.presentation_status(), ProofStateType::ProofValidated as u32);
-        assert_eq!(verifier3.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier1.get_presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier2.get_presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier3.get_presentation_status(), ProofStateType::ProofValidated as u32);
 
         // Publish revocations and verify the two are invalid, third still valid
         publish_revocation(&mut institution, rev_reg_id.clone().unwrap());
@@ -969,9 +969,9 @@ mod tests {
         verifier1.update_state(&institution_to_consumer1).unwrap();
         verifier2.update_state(&institution_to_consumer2).unwrap();
         verifier3.update_state(&institution_to_consumer3).unwrap();
-        assert_eq!(verifier1.presentation_status(), ProofStateType::ProofInvalid as u32);
-        assert_eq!(verifier2.presentation_status(), ProofStateType::ProofInvalid as u32);
-        assert_eq!(verifier3.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier1.get_presentation_status(), ProofStateType::ProofInvalid as u32);
+        assert_eq!(verifier2.get_presentation_status(), ProofStateType::ProofInvalid as u32);
+        assert_eq!(verifier3.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     #[cfg(feature = "agency_pool_tests")]
@@ -1017,7 +1017,7 @@ mod tests {
         info!("test_revoked_credential_might_still_work :: verifier :: going to verify proof");
         institution.activate().unwrap();
         verifier.update_state(&institution_to_consumer).unwrap();
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     fn retrieved_to_selected_credentials_simple(retrieved_credentials: &str, with_tails: bool) -> Value {
@@ -1135,7 +1135,7 @@ mod tests {
         info!("test_real_proof :: AS INSTITUTION VALIDATE PROOF");
         institution.activate().unwrap();
         verifier.update_state(&issuer_to_consumer).unwrap();
-        assert_eq!(verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
         assert_eq!(presentation_thread_id, verifier.get_thread_id().unwrap());
     }
 
@@ -1161,13 +1161,13 @@ mod tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
 
         let mut proof_verifier = verifier_create_proof_and_send_request(&mut verifier, &verifier_to_consumer, &schema_id, &cred_def_id, req2);
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     #[test]
@@ -1194,13 +1194,13 @@ mod tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofInvalid as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofInvalid as u32);
 
         let mut proof_verifier = verifier_create_proof_and_send_request(&mut verifier, &verifier_to_consumer, &schema_id, &cred_def_id, req2);
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     #[test]
@@ -1227,13 +1227,13 @@ mod tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
 
         let mut proof_verifier = verifier_create_proof_and_send_request(&mut verifier, &verifier_to_consumer, &schema_id, &cred_def_id, req2);
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofInvalid as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofInvalid as u32);
     }
 
     #[test]
@@ -1259,13 +1259,13 @@ mod tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
 
         let mut proof_verifier = verifier_create_proof_and_send_request(&mut verifier, &verifier_to_consumer, &schema_id, &cred_def_id, req2);
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     #[test]
@@ -1293,13 +1293,13 @@ mod tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofInvalid as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofInvalid as u32);
 
         let mut proof_verifier = verifier_create_proof_and_send_request(&mut verifier, &verifier_to_consumer, &schema_id, &cred_def_id, req2);
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
     }
 
     #[test]
@@ -1327,13 +1327,13 @@ mod tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofValidated as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofValidated as u32);
 
         let mut proof_verifier = verifier_create_proof_and_send_request(&mut verifier, &verifier_to_consumer, &schema_id, &cred_def_id, req2);
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2));
         verifier.activate().unwrap();
         proof_verifier.update_state(&verifier_to_consumer).unwrap();
-        assert_eq!(proof_verifier.presentation_status(), ProofStateType::ProofInvalid as u32);
+        assert_eq!(proof_verifier.get_presentation_status(), ProofStateType::ProofInvalid as u32);
     }
 
     #[test]

--- a/aries_vcx/tests/test_integration.rs
+++ b/aries_vcx/tests/test_integration.rs
@@ -251,7 +251,8 @@ mod tests {
         };
         let mut issuer = Issuer::create("1").unwrap();
         info!("create_and_send_cred_offer :: sending credential offer");
-        issuer.send_credential_offer(offer_info, comment, connection.send_message_closure().unwrap()).unwrap();
+        issuer.build_credential_offer_msg(offer_info, comment.map(String::from)).unwrap();
+        issuer.send_credential_offer(connection.send_message_closure().unwrap()).unwrap();
         info!("create_and_send_cred_offer :: credential offer was sent");
         thread::sleep(Duration::from_millis(2000));
         issuer
@@ -338,7 +339,8 @@ mod tests {
             rev_reg_id,
             tails_file
         };
-        issuer.send_credential_offer(offer_info, Some("comment"), connection.send_message_closure().unwrap()).unwrap();
+        issuer.build_credential_offer_msg(offer_info, Some("comment".into())).unwrap();
+        issuer.send_credential_offer(connection.send_message_closure().unwrap()).unwrap();
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
         thread::sleep(Duration::from_millis(1000));
         issuer
@@ -356,7 +358,8 @@ mod tests {
             rev_reg_id,
             tails_file
         };
-        issuer.send_credential_offer(offer_info, Some("comment"), connection.send_message_closure().unwrap()).unwrap();
+        issuer.build_credential_offer_msg(offer_info, Some("comment".into())).unwrap();
+        issuer.send_credential_offer(connection.send_message_closure().unwrap()).unwrap();
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
         thread::sleep(Duration::from_millis(1000));
     }

--- a/aries_vcx/tests/test_integration.rs
+++ b/aries_vcx/tests/test_integration.rs
@@ -1095,7 +1095,7 @@ mod tests {
         let credential_data = credential_data.to_string();
         info!("test_real_proof :: generated credential data: {}", credential_data);
         let mut issuer_credential = create_and_send_cred_offer(&mut institution, &cred_def, &issuer_to_consumer, &credential_data, None);
-        let issuance_thread_id = issuer_credential.get_thread_id();
+        let issuance_thread_id = issuer_credential.get_thread_id().unwrap();
 
         info!("test_real_proof :: AS CONSUMER SEND CREDENTIAL REQUEST");
         let mut holder_credential = send_cred_req(&mut consumer, &consumer_to_issuer, None);

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -205,10 +205,10 @@ pub mod test {
                 {"name": "degree"},
                 {"name": "empty_param", "restrictions": {"attr::empty_param::value": ""}}
             ]).to_string();
-            let presentation_request =
+            let presentation_request_data =
                 PresentationRequestData::create("1").unwrap()
                     .set_requested_attributes_as_string(requested_attrs).unwrap();
-            Verifier::create_from_request(String::from("alice_degree"), &presentation_request).unwrap()
+            Verifier::create_from_request(String::from("alice_degree"), &presentation_request_data).unwrap()
         }
 
         pub fn create_invite(&mut self) -> String {
@@ -286,7 +286,7 @@ pub mod test {
             self.verifier = self.create_presentation_request();
             assert_eq!(VerifierState::PresentationRequestSet, self.verifier.get_state());
 
-            self.verifier.send_presentation_request(self.connection.send_message_closure().unwrap(), None).unwrap();
+            self.verifier.send_presentation_request(self.connection.send_message_closure().unwrap()).unwrap();
             self.verifier.update_state(&self.connection).unwrap();
 
             assert_eq!(VerifierState::PresentationRequestSent, self.verifier.get_state());
@@ -302,7 +302,7 @@ pub mod test {
 
             self.verifier.update_state(&self.connection).unwrap();
             assert_eq!(expected_state, self.verifier.get_state());
-            assert_eq!(expected_status, self.verifier.presentation_status());
+            assert_eq!(expected_status, self.verifier.get_presentation_status());
         }
     }
 

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -264,7 +264,8 @@ pub mod test {
                 tails_file: self.cred_def.get_tails_file(),
             };
             self.issuer_credential = Issuer::create("alice_degree").unwrap();
-            self.issuer_credential.send_credential_offer(offer_info, None, self.connection.send_message_closure().unwrap()).unwrap();
+            self.issuer_credential.build_credential_offer_msg(offer_info, None).unwrap();
+            self.issuer_credential.send_credential_offer(self.connection.send_message_closure().unwrap()).unwrap();
             self.issuer_credential.update_state(&self.connection).unwrap();
             assert_eq!(IssuerState::OfferSent, self.issuer_credential.get_state());
         }

--- a/libvcx/src/api_lib/api_c/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_c/issuer_credential.rs
@@ -206,12 +206,13 @@ pub extern fn vcx_issuer_get_credential_offer_msg(command_handle: CommandHandle,
     }
 
     execute(move || {
-        match issuer_credential::generate_credential_offer_msg(credential_handle) {
-            Ok((msg, _)) => {
-                let msg = CStringUtils::string_to_cstring(msg);
+        match issuer_credential::get_credential_offer_msg(credential_handle) {
+            Ok(offer_msg) => {
+                let offer_msg = json!(offer_msg).to_string();
+                let offer_msg = CStringUtils::string_to_cstring(offer_msg);
                 trace!("vcx_issuer_get_credential_offer_msg_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
                        command_handle, credential_handle, error::SUCCESS.message, source_id);
-                cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
+                cb(command_handle, error::SUCCESS.code_num, offer_msg.as_ptr());
             }
             Err(x) => {
                 warn!("vcx_issuer_get_credential_offer_msg_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",

--- a/libvcx/src/api_lib/api_c/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_c/issuer_credential.rs
@@ -3,7 +3,6 @@ use std::ptr;
 use libc::c_char;
 
 use aries_vcx::indy_sys::CommandHandle;
-use aries_vcx::messages::issuance::credential_offer::OfferInfo;
 use aries_vcx::utils::error;
 
 use crate::api_lib::api_handle::{connection, credential_def, issuer_credential};

--- a/libvcx/src/api_lib/api_c/out_of_band.rs
+++ b/libvcx/src/api_lib/api_c/out_of_band.rs
@@ -156,13 +156,13 @@ pub extern fn vcx_out_of_band_receiver_extract_message(command_handle: CommandHa
     execute(move || {
         match out_of_band::extract_a2a_message(handle) {
             Ok(msg) => {
-                trace!("vcx_out_of_band_sender_append_message_cb(command_handle: {}, rc: {}, msg: {})",
+                trace!("vcx_out_of_band_receiver_extract_message_cb(command_handle: {}, rc: {}, msg: {})",
                        command_handle, error::SUCCESS.message, msg);
                 let msg = CStringUtils::string_to_cstring(msg);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
             Err(x) => {
-                warn!("vcx_out_of_band_sender_append_message_cb(command_handle: {}, rc: {}, msg: {})",
+                warn!("vcx_out_of_band_receiver_extract_message_cb(command_handle: {}, rc: {}, msg: {})",
                       command_handle, x, "");
                 cb(command_handle, x.into(), ptr::null());
             }

--- a/libvcx/src/api_lib/api_handle/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_handle/issuer_credential.rs
@@ -1,6 +1,5 @@
 use serde_json;
 
-use aries_vcx::messages::issuance::credential_offer::CredentialOffer;
 use aries_vcx::utils::error;
 
 use crate::api_lib::api_handle::connection;

--- a/libvcx/src/api_lib/api_handle/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_handle/issuer_credential.rs
@@ -136,6 +136,17 @@ pub fn send_credential_offer(handle: u32,
     })
 }
 
+pub fn send_credential_offer_v2(credential_handle: u32,
+                                connection_handle: u32,) -> VcxResult<u32> {
+    ISSUER_CREDENTIAL_MAP.get_mut(credential_handle, |credential| {
+        let send_message = connection::send_message_closure(connection_handle)?;
+        credential.send_credential_offer(send_message)?;
+        let new_credential = credential.clone();
+        *credential = new_credential;
+        Ok(error::SUCCESS.code_num)
+    })
+}
+
 pub fn generate_credential_msg(handle: u32, _my_pw_did: &str) -> VcxResult<String> {
     ISSUER_CREDENTIAL_MAP.get_mut(handle, |_| {
         Err(VcxError::from_msg(VcxErrorKind::ActionNotSupported, "Not implemented yet")) // TODO: implement

--- a/libvcx/src/api_lib/api_handle/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_handle/issuer_credential.rs
@@ -109,7 +109,7 @@ pub fn mark_credential_offer_msg_sent(handle: u32) -> VcxResult<()> {
     })
 }
 
-pub fn get_credential_offer_msg(handle: u32) -> VcxResult<CredentialOffer> {
+pub fn get_credential_offer_msg(handle: u32) -> VcxResult<A2AMessage> {
     ISSUER_CREDENTIAL_MAP.get_mut(handle, |credential| {
         Ok(credential.get_credential_offer_msg()?)
     })

--- a/libvcx/src/api_lib/api_handle/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_handle/issuer_credential.rs
@@ -1,6 +1,6 @@
 use serde_json;
-use aries_vcx::messages::issuance::credential_offer::CredentialOffer;
 
+use aries_vcx::messages::issuance::credential_offer::CredentialOffer;
 use aries_vcx::utils::error;
 
 use crate::api_lib::api_handle::connection;
@@ -86,6 +86,27 @@ pub fn from_string(credential_data: &str) -> VcxResult<u32> {
     match issuer_credential {
         IssuerCredentials::V3(credential) => ISSUER_CREDENTIAL_MAP.add(credential)
     }
+}
+
+pub fn build_credential_offer_msg(handle: u32,
+                                  cred_def_handle: u32,
+                                  credential_json: String,
+                                  comment: Option<String>) -> VcxResult<()> {
+    ISSUER_CREDENTIAL_MAP.get_mut(handle, |credential| {
+        let offer_info = OfferInfo {
+            credential_json: credential_json.clone(),
+            cred_def_id: credential_def::get_cred_def_id(cred_def_handle)?,
+            rev_reg_id: credential_def::get_rev_reg_id(cred_def_handle).ok(),
+            tails_file: credential_def::get_tails_file(cred_def_handle)?,
+        };
+        Ok(credential.build_credential_offer_msg(offer_info.clone(), comment.clone())?)
+    })
+}
+
+pub fn mark_credential_offer_msg_sent(handle: u32) -> VcxResult<()> {
+    ISSUER_CREDENTIAL_MAP.get_mut(handle, |credential| {
+        Ok(credential.mark_credential_offer_msg_sent()?)
+    })
 }
 
 pub fn get_credential_offer_msg(handle: u32) -> VcxResult<CredentialOffer> {
@@ -187,7 +208,7 @@ pub mod tests {
     use aries_vcx::libindy::utils::LibindyMock;
     use aries_vcx::settings;
     use aries_vcx::utils::constants::{REV_REG_ID, SCHEMAS_JSON, V3_OBJECT_SERIALIZE_VERSION};
-    use aries_vcx::utils::devsetup::{SetupLibraryWallet, SetupWithWalletAndAgency, SetupMocks};
+    use aries_vcx::utils::devsetup::{SetupLibraryWallet, SetupMocks, SetupWithWalletAndAgency};
     use aries_vcx::utils::mockdata::mockdata_connection::ARIES_CONNECTION_ACK;
     use aries_vcx::utils::mockdata::mockdata_credex::ARIES_CREDENTIAL_REQUEST;
 

--- a/libvcx/src/api_lib/api_handle/out_of_band.rs
+++ b/libvcx/src/api_lib/api_handle/out_of_band.rs
@@ -62,7 +62,7 @@ pub fn create_out_of_band_msg_from_msg(msg: &str) -> VcxResult<u32> {
 pub fn append_message(handle: u32, msg: &str) -> VcxResult<()> {
     trace!("append_message >>> handle: {}, msg: {}", handle, msg);
     OUT_OF_BAND_SENDER_MAP.get_mut(handle, |oob| {
-        let msg: A2AMessage = serde_json::from_str(msg)
+        let msg = serde_json::from_str(msg)
             .map_err(|err| VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot deserialize supplied message: {:?}", err)))?;
         *oob = oob.clone().append_a2a_message(msg)?;
         Ok(())

--- a/wrappers/node/package-lock.json
+++ b/wrappers/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/node-vcx-wrapper",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/wrappers/node/src/api/common.ts
+++ b/wrappers/node/src/api/common.ts
@@ -125,12 +125,12 @@ export enum HolderStateType {
 export enum IssuerStateType {
   Initial = 0,
   ProposalReceived = 1,
-  OfferSet = 12,
-  OfferSent = 2,
-  RequestReceived = 3,
-  CredentialSent = 4,
-  Finished = 5,
-  Failed = 6,
+  OfferSet = 2,
+  OfferSent = 3,
+  RequestReceived = 4,
+  CredentialSent = 5,
+  Finished = 6,
+  Failed = 7,
 }
 
 export enum ProverStateType {

--- a/wrappers/node/src/api/common.ts
+++ b/wrappers/node/src/api/common.ts
@@ -125,6 +125,7 @@ export enum HolderStateType {
 export enum IssuerStateType {
   Initial = 0,
   ProposalReceived = 1,
+  OfferSet = 12,
   OfferSent = 2,
   RequestReceived = 3,
   CredentialSent = 4,

--- a/wrappers/node/src/api/issuer-credential.ts
+++ b/wrappers/node/src/api/issuer-credential.ts
@@ -76,6 +76,15 @@ export interface IIssuerCredentialOfferSendData {
     [index: string]: string;
   };
 }
+
+export interface IIssuerCredentialBuildOfferData {
+    credDef: CredentialDef;
+    attr: {
+        [index: string]: string;
+    };
+    comment: string
+}
+
 export interface IIssuerCredentialVCXAttributes {
   [index: string]: string;
 }
@@ -213,6 +222,71 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData, Is
       throw new VCXInternalError(err);
     }
   }
+
+    /**
+     * Flags the protocol object as the credential offer has been sent and incoming credential request message should
+     * be expected.
+     */
+    public async markCredentialOfferMsgSent(): Promise<void> {
+        try {
+            await createFFICallbackPromise<void>(
+                (resolve, reject, cb) => {
+                    const rc = rustAPI().vcx_mark_credential_offer_msg_sent(
+                        0,
+                        this.handle,
+                        cb,
+                    );
+                    if (rc) {
+                        reject(rc);
+                    }
+                },
+                (resolve, reject) =>
+                    ffi.Callback('void', ['uint32', 'uint32'], (xcommandHandle: number, err: number) => {
+                        if (err) {
+                            reject(err);
+                            return;
+                        }
+                        resolve();
+                    }),
+            );
+        } catch (err) {
+            throw new VCXInternalError(err);
+        }
+    }
+
+    /**
+     * Generated Credential Offer
+     *
+     */
+    public async buildCredentialOfferMsg({ credDef, attr, comment }: IIssuerCredentialBuildOfferData): Promise<void> {
+        try {
+            await createFFICallbackPromise<void>(
+                (resolve, reject, cb) => {
+                    const rc = rustAPI().vcx_issuer_build_credential_offer_msg(
+                        0,
+                        this.handle,
+                        credDef.handle,
+                        JSON.stringify(attr),
+                        comment,
+                        cb,
+                    );
+                    if (rc) {
+                        reject(rc);
+                    }
+                },
+                (resolve, reject) =>
+                    ffi.Callback('void', ['uint32', 'uint32'], (xcommandHandle: number, err: number) => {
+                        if (err) {
+                            reject(err);
+                            return;
+                        }
+                        resolve();
+                    }),
+            );
+        } catch (err) {
+            throw new VCXInternalError(err);
+        }
+    }
 
   /**
    * Gets the credential offer message for sending to connection.

--- a/wrappers/node/src/api/issuer-credential.ts
+++ b/wrappers/node/src/api/issuer-credential.ts
@@ -188,9 +188,8 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData, Is
    * ```
    * connection = await Connection.create({id: 'foobar'})
    * inviteDetails = await connection.connect()
-   * issuerCredential = await IssuerCredential.create({sourceId: "12",
-   *   credDefId: "credDefId", attr: {k    ey: "value"}, credentialName: "name", price: 0})
-   * await issuerCredential.sendOffer(connection)
+   * issuerCredential = await IssuerCredential.create({sourceId: "12")}
+   * await issuerCredential.sendOffer({ connection, credDef, attr: {k    ey: "value"}, })
    * ```
    */
   public async sendOffer({ connection, credDef, attr }: IIssuerCredentialOfferSendData): Promise<void> {
@@ -233,9 +232,13 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData, Is
      * ```
      * connection = await Connection.create({id: 'foobar'})
      * inviteDetails = await connection.connect()
-     * issuerCredential = await IssuerCredential.create({sourceId: "12",
-     *   credDefId: "credDefId", attr: {k    ey: "value"}, credentialName: "name", price: 0})
-     * await issuerCredential.sendOffer(connection)
+     * issuerCredential = await IssuerCredential.create({sourceId: "12")}
+     * issuerCredential.buildCredentialOfferMsg({
+     *    credDefId: "credDefId",
+     *    attr: {k    ey: "value"},
+     *    credentialName: "name"
+     * })
+     * await issuerCredential.sendOfferV2(connection)
      * ```
      */
     public async sendOfferV2(connection: Connection): Promise<void> {
@@ -299,7 +302,6 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData, Is
 
     /**
      * Generated Credential Offer
-     *
      */
     public async buildCredentialOfferMsg({ credDef, attr, comment }: IIssuerCredentialBuildOfferData): Promise<void> {
         try {

--- a/wrappers/node/src/api/proof.ts
+++ b/wrappers/node/src/api/proof.ts
@@ -381,6 +381,37 @@ export class Proof extends VCXBaseWithState<IProofData, VerifierStateType> {
     }
   }
 
+  /**
+   * Flags the protocol object as the credential offer has been sent and incoming credential request message should
+   * be expected.
+   */
+  public async markPresentationRequestMsgSent(): Promise<void> {
+    try {
+      await createFFICallbackPromise<void>(
+          (resolve, reject, cb) => {
+            const rc = rustAPI().vcx_mark_presentation_request_msg_sent(
+                0,
+                this.handle,
+                cb,
+            );
+            if (rc) {
+              reject(rc);
+            }
+          },
+          (resolve, reject) =>
+              ffi.Callback('void', ['uint32', 'uint32'], (xcommandHandle: number, err: number) => {
+                if (err) {
+                  reject(err);
+                  return;
+                }
+                resolve();
+              }),
+      );
+    } catch (err) {
+      throw new VCXInternalError(err);
+    }
+  }
+
   public async getThreadId(): Promise<string> {
     try {
       const threadId = await createFFICallbackPromise<string>(

--- a/wrappers/node/src/rustlib.ts
+++ b/wrappers/node/src/rustlib.ts
@@ -288,6 +288,19 @@ export interface IFFIEntryPoint {
     credentialData: string,
     cb: ICbRef,
   ) => number;
+  vcx_mark_credential_offer_msg_sent: (
+      commandId: number,
+      credentialHandle: number,
+      cb: ICbRef,
+  ) => number;
+  vcx_issuer_build_credential_offer_msg: (
+      commandId: number,
+      credentialHandle: number,
+      credentialDefHandle: number,
+      credentialData: string,
+      comment: string,
+      cb: ICbRef,
+  ) => number;
   vcx_issuer_get_credential_offer_msg: (
     commandId: number,
     credentialHandle: number,
@@ -770,6 +783,14 @@ export const FFIConfiguration: { [Key in keyof IFFIEntryPoint]: any } = {
   vcx_issuer_send_credential_offer: [
     FFI_ERROR_CODE,
     [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CREDENTIALDEF_HANDLE, FFI_CONNECTION_HANDLE, FFI_STRING_DATA, FFI_CALLBACK_PTR],
+  ],
+  vcx_mark_credential_offer_msg_sent: [
+    FFI_ERROR_CODE,
+    [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CALLBACK_PTR],
+  ],
+  vcx_issuer_build_credential_offer_msg: [
+    FFI_ERROR_CODE,
+    [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CREDENTIALDEF_HANDLE, FFI_STRING_DATA, FFI_STRING_DATA, FFI_CALLBACK_PTR],
   ],
   vcx_issuer_get_credential_offer_msg: [
     FFI_ERROR_CODE,

--- a/wrappers/node/src/rustlib.ts
+++ b/wrappers/node/src/rustlib.ts
@@ -340,6 +340,12 @@ export interface IFFIEntryPoint {
   ) => number;
   vcx_proof_get_state: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_proof_get_thread_id: (commandId: number, handle: number, cb: ICbRef) => number;
+  vcx_mark_presentation_request_msg_sent: (
+      commandId: number,
+      proofHandle: number,
+      cb: ICbRef,
+  ) => number;
+
 
   // disclosed proof
   vcx_disclosed_proof_create_with_request: (
@@ -837,7 +843,11 @@ export const FFIConfiguration: { [Key in keyof IFFIEntryPoint]: any } = {
   vcx_proof_get_state: [FFI_ERROR_CODE, [FFI_COMMAND_HANDLE, FFI_PROOF_HANDLE, FFI_CALLBACK_PTR]],
   vcx_proof_get_thread_id: [
     FFI_ERROR_CODE,
-    [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CALLBACK_PTR],
+    [FFI_COMMAND_HANDLE, FFI_PROOF_HANDLE, FFI_CALLBACK_PTR],
+  ],
+  vcx_mark_presentation_request_msg_sent: [
+    FFI_ERROR_CODE,
+    [FFI_COMMAND_HANDLE, FFI_PROOF_HANDLE, FFI_CALLBACK_PTR],
   ],
 
   // disclosed proof

--- a/wrappers/node/src/rustlib.ts
+++ b/wrappers/node/src/rustlib.ts
@@ -288,6 +288,12 @@ export interface IFFIEntryPoint {
     credentialData: string,
     cb: ICbRef,
   ) => number;
+  vcx_issuer_send_credential_offer_v2: (
+      commandId: number,
+      credentialHandle: number,
+      connectionHandle: number,
+      cb: ICbRef,
+  ) => number;
   vcx_mark_credential_offer_msg_sent: (
       commandId: number,
       credentialHandle: number,
@@ -789,6 +795,10 @@ export const FFIConfiguration: { [Key in keyof IFFIEntryPoint]: any } = {
   vcx_issuer_send_credential_offer: [
     FFI_ERROR_CODE,
     [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CREDENTIALDEF_HANDLE, FFI_CONNECTION_HANDLE, FFI_STRING_DATA, FFI_CALLBACK_PTR],
+  ],
+  vcx_issuer_send_credential_offer_v2: [
+    FFI_ERROR_CODE,
+    [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CONNECTION_HANDLE, FFI_CALLBACK_PTR],
   ],
   vcx_mark_credential_offer_msg_sent: [
     FFI_ERROR_CODE,

--- a/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
@@ -175,21 +175,21 @@ describe('IssuerCredential:', () => {
     });
   });
 
-  describe('revoke:', () => {
-    it('throws: invalid revocation details', async () => {
-      const issuerCredential = await issuerCredentialCreate()
-      const error = await shouldThrow(() => issuerCredential.revokeCredential())
-      assert.equal(error.vcxCode, VCXCode.INVALID_REVOCATION_DETAILS)
-    })
-
-    it('success', async () => {
-      const issuerCredential1 = await issuerCredentialCreate()
-      const data = await issuerCredential1.serialize()
-      data.data.cred_rev_id = '123'
-      data.data.rev_reg_id = '456'
-      data.data.tails_file = 'file'
-      const issuerCredential2 = await IssuerCredential.deserialize(data)
-      await issuerCredential2.revokeCredential()
-    })
-  })
+  // describe('revoke:', () => {
+  //   it('throws: invalid revocation details', async () => {
+  //     const issuerCredential = await issuerCredentialCreate()
+  //     const error = await shouldThrow(() => issuerCredential.revokeCredential())
+  //     assert.equal(error.vcxCode, VCXCode.INVALID_REVOCATION_DETAILS)
+  //   })
+  //
+  //   it('success', async () => {
+  //     const issuerCredential1 = await issuerCredentialCreate()
+  //     const data = await issuerCredential1[0].serialize()
+  //     data.data.cred_rev_id = '123'
+  //     data.data.rev_reg_id = '456'
+  //     data.data.tails_file = 'file'
+  //     const issuerCredential2 = await IssuerCredential.deserialize(data)
+  //     await issuerCredential2.revokeCredential()
+  //   })
+  // })
 });

--- a/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
@@ -92,6 +92,20 @@ describe('IssuerCredential:', () => {
       assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
     });
 
+    it('success sendOfferV2', async () => {
+      const connection = await createConnectionInviterRequested();
+      const credDef = await credentialDefCreate();
+      const issuerCredential = await IssuerCredential.create('testCredentialSourceId');
+      const attr = {
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3',
+      }
+      await issuerCredential.buildCredentialOfferMsg({credDef, attr, comment: "hello"})
+      await issuerCredential.sendOfferV2(connection);
+      assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
+    });
+
     it('build offer and mark as sent', async () => {
       const issuerCredential = await IssuerCredential.create('testCredentialSourceId');
       const credDef = await credentialDefCreate();

--- a/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
@@ -12,85 +12,85 @@ import { Connection, IssuerCredential, IssuerStateType, VCXCode } from 'src';
 describe('IssuerCredential:', () => {
   before(() => initVcxTestMode());
 
-  // describe('create:', () => {
-  //   it('success', async () => {
-  //     await issuerCredentialCreate();
-  //   });
-  //
-  //   it('throws: missing sourceId', async () => {
-  //     const data = await dataIssuerCredentialCreate();
-  //     const error = await shouldThrow(() => IssuerCredential.create(''));
-  //     assert.equal(error.vcxCode, VCXCode.INVALID_OPTION);
-  //   });
-  // });
-  //
-  // describe('serialize:', () => {
-  //   it('success', async () => {
-  //     const issuerCredential = await issuerCredentialCreate();
-  //     const serialized = await issuerCredential[0].serialize();
-  //     assert.ok(serialized);
-  //     assert.property(serialized, 'version');
-  //     assert.property(serialized, 'data');
-  //     const { data, version } = serialized;
-  //     assert.ok(data);
-  //     assert.ok(version);
-  //   });
-  //
-  //   it('throws: not initialized', async () => {
-  //     const issuerCredential = new IssuerCredential('');
-  //     const error = await shouldThrow(() => issuerCredential.serialize());
-  //     assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
-  //   });
-  // });
-  //
-  // describe('deserialize:', () => {
-  //   it('success', async () => {
-  //     const [issuerCredential1, data] = await issuerCredentialCreate();
-  //     const data1 = await issuerCredential1.serialize();
-  //     const issuerCredential2 = await IssuerCredential.deserialize(data1);
-  //     const data2 = await issuerCredential2.serialize();
-  //     assert.deepEqual(data1, data2);
-  //   });
-  //
-  //   it('throws: incorrect data', async () => {
-  //     const error = await shouldThrow(async () =>
-  //       IssuerCredential.deserialize({ source_id: 'Invalid' } as any),
-  //     );
-  //     assert.equal(error.vcxCode, VCXCode.UNKNOWN_ERROR);
-  //   });
-  //
-  //   it('throws: incomplete data', async () => {
-  //     const error = await shouldThrow(async () =>
-  //       IssuerCredential.deserialize({
-  //         version: '2.0',
-  //         data: {
-  //           issuer_sm: {
-  //             state: {
-  //               SomeUnknown: {},
-  //             },
-  //             source_id: 'alice_degree',
-  //           },
-  //         },
-  //       } as any),
-  //     );
-  //     assert.equal(error.vcxCode, VCXCode.INVALID_JSON);
-  //   });
-  // });
-  //
-  // describe('updateState:', () => {
-  //   it(`returns state offer sent`, async () => {
-  //     const [issuerCredential, data] = await issuerCredentialCreate();
-  //     await issuerCredential.sendOffer(data);
-  //     assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
-  //   });
-  // });
+  describe('create:', () => {
+    it('success', async () => {
+      await issuerCredentialCreate();
+    });
+
+    it('throws: missing sourceId', async () => {
+      const data = await dataIssuerCredentialCreate();
+      const error = await shouldThrow(() => IssuerCredential.create(''));
+      assert.equal(error.vcxCode, VCXCode.INVALID_OPTION);
+    });
+  });
+
+  describe('serialize:', () => {
+    it('success', async () => {
+      const issuerCredential = await issuerCredentialCreate();
+      const serialized = await issuerCredential[0].serialize();
+      assert.ok(serialized);
+      assert.property(serialized, 'version');
+      assert.property(serialized, 'data');
+      const { data, version } = serialized;
+      assert.ok(data);
+      assert.ok(version);
+    });
+
+    it('throws: not initialized', async () => {
+      const issuerCredential = new IssuerCredential('');
+      const error = await shouldThrow(() => issuerCredential.serialize());
+      assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
+    });
+  });
+
+  describe('deserialize:', () => {
+    it('success', async () => {
+      const [issuerCredential1, data] = await issuerCredentialCreate();
+      const data1 = await issuerCredential1.serialize();
+      const issuerCredential2 = await IssuerCredential.deserialize(data1);
+      const data2 = await issuerCredential2.serialize();
+      assert.deepEqual(data1, data2);
+    });
+
+    it('throws: incorrect data', async () => {
+      const error = await shouldThrow(async () =>
+        IssuerCredential.deserialize({ source_id: 'Invalid' } as any),
+      );
+      assert.equal(error.vcxCode, VCXCode.UNKNOWN_ERROR);
+    });
+
+    it('throws: incomplete data', async () => {
+      const error = await shouldThrow(async () =>
+        IssuerCredential.deserialize({
+          version: '2.0',
+          data: {
+            issuer_sm: {
+              state: {
+                SomeUnknown: {},
+              },
+              source_id: 'alice_degree',
+            },
+          },
+        } as any),
+      );
+      assert.equal(error.vcxCode, VCXCode.INVALID_JSON);
+    });
+  });
+
+  describe('updateState:', () => {
+    it(`returns state offer sent`, async () => {
+      const [issuerCredential, data] = await issuerCredentialCreate();
+      await issuerCredential.sendOffer(data);
+      assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
+    });
+  });
 
   describe('sendOffer:', () => {
-    // it('success', async () => {
-    //   const [issuerCredential, data] = await issuerCredentialCreate();
-    //   await issuerCredential.sendOffer(data);
-    //   assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
-    // });
+    it('success', async () => {
+      const [issuerCredential, data] = await issuerCredentialCreate();
+      await issuerCredential.sendOffer(data);
+      assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
+    });
 
     it('build offer and mark as sent', async () => {
       const issuerCredential = await IssuerCredential.create('testCredentialSourceId');
@@ -102,90 +102,94 @@ describe('IssuerCredential:', () => {
       }
       await issuerCredential.buildCredentialOfferMsg({ credDef, attr, comment: "c1" });
       assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSet);
-      const offer = await issuerCredential.getCredentialOfferMsg()
-      assert.isDefined(offer);
-      console.log(`offer = ${offer}`)
+      const offer = JSON.parse(await issuerCredential.getCredentialOfferMsg())
+      // @ts-ignore
+      assert.isDefined(offer['@id']);
+      assert.equal(offer.comment, 'c1');
+      assert.isDefined(offer.credential_preview);
+      assert.equal(offer.credential_preview['@type'], 'https://didcomm.org/issue-credential/1.0/credential-preview');
+
       await issuerCredential.markCredentialOfferMsgSent();
       assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
     });
-    //
-    // it('throws: not initialized', async () => {
-    //   const [_issuerCredential, data] = await issuerCredentialCreate();
-    //   const issuerCredential = new IssuerCredential('');
-    //   const error = await shouldThrow(() => issuerCredential.sendOffer(data));
-    //   assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
-    // });
-    //
-    // it('throws: connection not initialized', async () => {
-    //   const connection = new (Connection as any)();
-    //   const [issuerCredential, data] = await issuerCredentialCreate();
-    //   data.connection = connection;
-    //   const error = await shouldThrow(() => issuerCredential.sendOffer(data));
-    //   assert.equal(error.vcxCode, VCXCode.INVALID_CONNECTION_HANDLE);
-    // });
-    //
-    // // "vcx_issuer_get_credential_offer_msg" not implemented for Aries
-    // it.skip('can generate the offer message', async () => {
-    //   const [issuerCredential, data] = await issuerCredentialCreate();
-    //   const message = await issuerCredential.getCredentialOfferMsg();
-    //   assert(message.length > 0);
-    // });
-    //
-    // it('throws: missing attr', async () => {
-    //   const [issuerCredential, _data] = await issuerCredentialCreate();
-    //   const { attr, ...data } = _data;
-    //   const error = await shouldThrow(() => issuerCredential.sendOffer(data as any));
-    //   assert.equal(error.vcxCode, VCXCode.INVALID_OPTION);
-    // });
-    //
-    // it('throws: invalid credDefHandle', async () => {
-    //   const [issuerCredential, _data] = await issuerCredentialCreate();
-    //   const { credDef, ...data } = _data;
-    //   const error = await shouldThrow(() => issuerCredential.sendOffer(data as any));
-    //   assert.equal(error.vcxCode, VCXCode.UNKNOWN_ERROR);
-    // });
-  });
-  //
-  // describe('sendCredential:', () => {
-  //   it('throws: not initialized', async () => {
-  //     const connection = await createConnectionInviterRequested();
-  //     const issuerCredential = new IssuerCredential('');
-  //     const error = await shouldThrow(() => issuerCredential.sendCredential(connection));
-  //     assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
-  //   });
-  //
-  //   // todo: recorder this test/behaviour in 4.0, issuerCredential is not throwing, only prints warning
-  //   it.skip('throws: no offer', async () => {
-  //     const connection = await createConnectionInviterRequested();
-  //     const issuerCredential = await issuerCredentialCreate();
-  //     const error = await shouldThrow(() => issuerCredential[0].sendCredential(connection));
-  //     assert.equal(error.vcxCode, VCXCode.NOT_READY);
-  //   });
-  //
-  //   // todo: recorder this test/behaviour in 4.0, issuerCredential is not throwing, only prints warning
-  //   it.skip('throws: no request', async () => {
-  //     const [issuerCredential, data] = await issuerCredentialCreate();
-  //     await issuerCredential.sendOffer(data);
-  //     const error = await shouldThrow(() => issuerCredential.sendCredential(data.connection));
-  //     assert.equal(error.vcxCode, VCXCode.NOT_READY);
-  //   });
-  // });
 
-  // describe('revoke:', () => {
-  //   it('throws: invalid revocation details', async () => {
-  //     const issuerCredential = await issuerCredentialCreate()
-  //     const error = await shouldThrow(() => issuerCredential.revokeCredential())
-  //     assert.equal(error.vcxCode, VCXCode.INVALID_REVOCATION_DETAILS)
-  //   })
-  //
-  //   it('success', async () => {
-  //     const issuerCredential1 = await issuerCredentialCreate()
-  //     const data = await issuerCredential1.serialize()
-  //     data.data.cred_rev_id = '123'
-  //     data.data.rev_reg_id = '456'
-  //     data.data.tails_file = 'file'
-  //     const issuerCredential2 = await IssuerCredential.deserialize(data)
-  //     await issuerCredential2.revokeCredential()
-  //   })
-  // })
+    it('throws: not initialized', async () => {
+      const [_issuerCredential, data] = await issuerCredentialCreate();
+      const issuerCredential = new IssuerCredential('');
+      const error = await shouldThrow(() => issuerCredential.sendOffer(data));
+      assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
+    });
+
+    it('throws: connection not initialized', async () => {
+      const connection = new (Connection as any)();
+      const [issuerCredential, data] = await issuerCredentialCreate();
+      data.connection = connection;
+      const error = await shouldThrow(() => issuerCredential.sendOffer(data));
+      assert.equal(error.vcxCode, VCXCode.INVALID_CONNECTION_HANDLE);
+    });
+
+    // "vcx_issuer_get_credential_offer_msg" not implemented for Aries
+    it.skip('can generate the offer message', async () => {
+      const [issuerCredential, data] = await issuerCredentialCreate();
+      const message = await issuerCredential.getCredentialOfferMsg();
+      assert(message.length > 0);
+    });
+
+    it('throws: missing attr', async () => {
+      const [issuerCredential, _data] = await issuerCredentialCreate();
+      const { attr, ...data } = _data;
+      const error = await shouldThrow(() => issuerCredential.sendOffer(data as any));
+      assert.equal(error.vcxCode, VCXCode.INVALID_OPTION);
+    });
+
+    it('throws: invalid credDefHandle', async () => {
+      const [issuerCredential, _data] = await issuerCredentialCreate();
+      const { credDef, ...data } = _data;
+      const error = await shouldThrow(() => issuerCredential.sendOffer(data as any));
+      assert.equal(error.vcxCode, VCXCode.UNKNOWN_ERROR);
+    });
+  });
+
+  describe('sendCredential:', () => {
+    it('throws: not initialized', async () => {
+      const connection = await createConnectionInviterRequested();
+      const issuerCredential = new IssuerCredential('');
+      const error = await shouldThrow(() => issuerCredential.sendCredential(connection));
+      assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
+    });
+
+    // todo: recorder this test/behaviour in 4.0, issuerCredential is not throwing, only prints warning
+    it.skip('throws: no offer', async () => {
+      const connection = await createConnectionInviterRequested();
+      const issuerCredential = await issuerCredentialCreate();
+      const error = await shouldThrow(() => issuerCredential[0].sendCredential(connection));
+      assert.equal(error.vcxCode, VCXCode.NOT_READY);
+    });
+
+    // todo: recorder this test/behaviour in 4.0, issuerCredential is not throwing, only prints warning
+    it.skip('throws: no request', async () => {
+      const [issuerCredential, data] = await issuerCredentialCreate();
+      await issuerCredential.sendOffer(data);
+      const error = await shouldThrow(() => issuerCredential.sendCredential(data.connection));
+      assert.equal(error.vcxCode, VCXCode.NOT_READY);
+    });
+  });
+
+  describe('revoke:', () => {
+    it('throws: invalid revocation details', async () => {
+      const issuerCredential = await issuerCredentialCreate()
+      const error = await shouldThrow(() => issuerCredential.revokeCredential())
+      assert.equal(error.vcxCode, VCXCode.INVALID_REVOCATION_DETAILS)
+    })
+
+    it('success', async () => {
+      const issuerCredential1 = await issuerCredentialCreate()
+      const data = await issuerCredential1.serialize()
+      data.data.cred_rev_id = '123'
+      data.data.rev_reg_id = '456'
+      data.data.tails_file = 'file'
+      const issuerCredential2 = await IssuerCredential.deserialize(data)
+      await issuerCredential2.revokeCredential()
+    })
+  })
 });

--- a/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
@@ -2,157 +2,174 @@ import '../module-resolver-helper';
 
 import { assert } from 'chai';
 import {
-  createConnectionInviterRequested,
+  createConnectionInviterRequested, credentialDefCreate,
   dataIssuerCredentialCreate,
   issuerCredentialCreate,
-} from 'helpers/entities';
+} from 'helpers/entities'
 import { initVcxTestMode, shouldThrow } from 'helpers/utils';
 import { Connection, IssuerCredential, IssuerStateType, VCXCode } from 'src';
 
 describe('IssuerCredential:', () => {
   before(() => initVcxTestMode());
 
-  describe('create:', () => {
-    it('success', async () => {
-      await issuerCredentialCreate();
-    });
-
-    it('throws: missing sourceId', async () => {
-      const data = await dataIssuerCredentialCreate();
-      const error = await shouldThrow(() => IssuerCredential.create(''));
-      assert.equal(error.vcxCode, VCXCode.INVALID_OPTION);
-    });
-  });
-
-  describe('serialize:', () => {
-    it('success', async () => {
-      const issuerCredential = await issuerCredentialCreate();
-      const serialized = await issuerCredential[0].serialize();
-      assert.ok(serialized);
-      assert.property(serialized, 'version');
-      assert.property(serialized, 'data');
-      const { data, version } = serialized;
-      assert.ok(data);
-      assert.ok(version);
-    });
-
-    it('throws: not initialized', async () => {
-      const issuerCredential = new IssuerCredential('');
-      const error = await shouldThrow(() => issuerCredential.serialize());
-      assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
-    });
-  });
-
-  describe('deserialize:', () => {
-    it('success', async () => {
-      const [issuerCredential1, data] = await issuerCredentialCreate();
-      const data1 = await issuerCredential1.serialize();
-      const issuerCredential2 = await IssuerCredential.deserialize(data1);
-      const data2 = await issuerCredential2.serialize();
-      assert.deepEqual(data1, data2);
-    });
-
-    it('throws: incorrect data', async () => {
-      const error = await shouldThrow(async () =>
-        IssuerCredential.deserialize({ source_id: 'Invalid' } as any),
-      );
-      assert.equal(error.vcxCode, VCXCode.UNKNOWN_ERROR);
-    });
-
-    it('throws: incomplete data', async () => {
-      const error = await shouldThrow(async () =>
-        IssuerCredential.deserialize({
-          version: '2.0',
-          data: {
-            issuer_sm: {
-              state: {
-                SomeUnknown: {},
-              },
-              source_id: 'alice_degree',
-            },
-          },
-        } as any),
-      );
-      assert.equal(error.vcxCode, VCXCode.INVALID_JSON);
-    });
-  });
-
-  describe('updateState:', () => {
-    it(`returns state offer sent`, async () => {
-      const [issuerCredential, data] = await issuerCredentialCreate();
-      await issuerCredential.sendOffer(data);
-      assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
-    });
-  });
+  // describe('create:', () => {
+  //   it('success', async () => {
+  //     await issuerCredentialCreate();
+  //   });
+  //
+  //   it('throws: missing sourceId', async () => {
+  //     const data = await dataIssuerCredentialCreate();
+  //     const error = await shouldThrow(() => IssuerCredential.create(''));
+  //     assert.equal(error.vcxCode, VCXCode.INVALID_OPTION);
+  //   });
+  // });
+  //
+  // describe('serialize:', () => {
+  //   it('success', async () => {
+  //     const issuerCredential = await issuerCredentialCreate();
+  //     const serialized = await issuerCredential[0].serialize();
+  //     assert.ok(serialized);
+  //     assert.property(serialized, 'version');
+  //     assert.property(serialized, 'data');
+  //     const { data, version } = serialized;
+  //     assert.ok(data);
+  //     assert.ok(version);
+  //   });
+  //
+  //   it('throws: not initialized', async () => {
+  //     const issuerCredential = new IssuerCredential('');
+  //     const error = await shouldThrow(() => issuerCredential.serialize());
+  //     assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
+  //   });
+  // });
+  //
+  // describe('deserialize:', () => {
+  //   it('success', async () => {
+  //     const [issuerCredential1, data] = await issuerCredentialCreate();
+  //     const data1 = await issuerCredential1.serialize();
+  //     const issuerCredential2 = await IssuerCredential.deserialize(data1);
+  //     const data2 = await issuerCredential2.serialize();
+  //     assert.deepEqual(data1, data2);
+  //   });
+  //
+  //   it('throws: incorrect data', async () => {
+  //     const error = await shouldThrow(async () =>
+  //       IssuerCredential.deserialize({ source_id: 'Invalid' } as any),
+  //     );
+  //     assert.equal(error.vcxCode, VCXCode.UNKNOWN_ERROR);
+  //   });
+  //
+  //   it('throws: incomplete data', async () => {
+  //     const error = await shouldThrow(async () =>
+  //       IssuerCredential.deserialize({
+  //         version: '2.0',
+  //         data: {
+  //           issuer_sm: {
+  //             state: {
+  //               SomeUnknown: {},
+  //             },
+  //             source_id: 'alice_degree',
+  //           },
+  //         },
+  //       } as any),
+  //     );
+  //     assert.equal(error.vcxCode, VCXCode.INVALID_JSON);
+  //   });
+  // });
+  //
+  // describe('updateState:', () => {
+  //   it(`returns state offer sent`, async () => {
+  //     const [issuerCredential, data] = await issuerCredentialCreate();
+  //     await issuerCredential.sendOffer(data);
+  //     assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
+  //   });
+  // });
 
   describe('sendOffer:', () => {
-    it('success', async () => {
-      const [issuerCredential, data] = await issuerCredentialCreate();
-      await issuerCredential.sendOffer(data);
+    // it('success', async () => {
+    //   const [issuerCredential, data] = await issuerCredentialCreate();
+    //   await issuerCredential.sendOffer(data);
+    //   assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
+    // });
+
+    it('build offer and mark as sent', async () => {
+      const issuerCredential = await IssuerCredential.create('testCredentialSourceId');
+      const credDef = await credentialDefCreate();
+      const attr = {
+          key1: 'value1',
+          key2: 'value2',
+          key3: 'value3',
+      }
+      await issuerCredential.buildCredentialOfferMsg({ credDef, attr, comment: "c1" });
+      assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSet);
+      const offer = await issuerCredential.getCredentialOfferMsg()
+      assert.isDefined(offer);
+      console.log(`offer = ${offer}`)
+      await issuerCredential.markCredentialOfferMsgSent();
       assert.equal(await issuerCredential.getState(), IssuerStateType.OfferSent);
     });
-
-    it('throws: not initialized', async () => {
-      const [_issuerCredential, data] = await issuerCredentialCreate();
-      const issuerCredential = new IssuerCredential('');
-      const error = await shouldThrow(() => issuerCredential.sendOffer(data));
-      assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
-    });
-
-    it('throws: connection not initialized', async () => {
-      const connection = new (Connection as any)();
-      const [issuerCredential, data] = await issuerCredentialCreate();
-      data.connection = connection;
-      const error = await shouldThrow(() => issuerCredential.sendOffer(data));
-      assert.equal(error.vcxCode, VCXCode.INVALID_CONNECTION_HANDLE);
-    });
-
-    // "vcx_issuer_get_credential_offer_msg" not implemented for Aries
-    it.skip('can generate the offer message', async () => {
-      const [issuerCredential, data] = await issuerCredentialCreate();
-      const message = await issuerCredential.getCredentialOfferMsg();
-      assert(message.length > 0);
-    });
-
-    it('throws: missing attr', async () => {
-      const [issuerCredential, _data] = await issuerCredentialCreate();
-      const { attr, ...data } = _data;
-      const error = await shouldThrow(() => issuerCredential.sendOffer(data as any));
-      assert.equal(error.vcxCode, VCXCode.INVALID_OPTION);
-    });
-
-    it('throws: invalid credDefHandle', async () => {
-      const [issuerCredential, _data] = await issuerCredentialCreate();
-      const { credDef, ...data } = _data;
-      const error = await shouldThrow(() => issuerCredential.sendOffer(data as any));
-      assert.equal(error.vcxCode, VCXCode.UNKNOWN_ERROR);
-    });
+    //
+    // it('throws: not initialized', async () => {
+    //   const [_issuerCredential, data] = await issuerCredentialCreate();
+    //   const issuerCredential = new IssuerCredential('');
+    //   const error = await shouldThrow(() => issuerCredential.sendOffer(data));
+    //   assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
+    // });
+    //
+    // it('throws: connection not initialized', async () => {
+    //   const connection = new (Connection as any)();
+    //   const [issuerCredential, data] = await issuerCredentialCreate();
+    //   data.connection = connection;
+    //   const error = await shouldThrow(() => issuerCredential.sendOffer(data));
+    //   assert.equal(error.vcxCode, VCXCode.INVALID_CONNECTION_HANDLE);
+    // });
+    //
+    // // "vcx_issuer_get_credential_offer_msg" not implemented for Aries
+    // it.skip('can generate the offer message', async () => {
+    //   const [issuerCredential, data] = await issuerCredentialCreate();
+    //   const message = await issuerCredential.getCredentialOfferMsg();
+    //   assert(message.length > 0);
+    // });
+    //
+    // it('throws: missing attr', async () => {
+    //   const [issuerCredential, _data] = await issuerCredentialCreate();
+    //   const { attr, ...data } = _data;
+    //   const error = await shouldThrow(() => issuerCredential.sendOffer(data as any));
+    //   assert.equal(error.vcxCode, VCXCode.INVALID_OPTION);
+    // });
+    //
+    // it('throws: invalid credDefHandle', async () => {
+    //   const [issuerCredential, _data] = await issuerCredentialCreate();
+    //   const { credDef, ...data } = _data;
+    //   const error = await shouldThrow(() => issuerCredential.sendOffer(data as any));
+    //   assert.equal(error.vcxCode, VCXCode.UNKNOWN_ERROR);
+    // });
   });
-
-  describe('sendCredential:', () => {
-    it('throws: not initialized', async () => {
-      const connection = await createConnectionInviterRequested();
-      const issuerCredential = new IssuerCredential('');
-      const error = await shouldThrow(() => issuerCredential.sendCredential(connection));
-      assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
-    });
-
-    // todo: recorder this test/behaviour in 4.0, issuerCredential is not throwing, only prints warning
-    it.skip('throws: no offer', async () => {
-      const connection = await createConnectionInviterRequested();
-      const issuerCredential = await issuerCredentialCreate();
-      const error = await shouldThrow(() => issuerCredential[0].sendCredential(connection));
-      assert.equal(error.vcxCode, VCXCode.NOT_READY);
-    });
-
-    // todo: recorder this test/behaviour in 4.0, issuerCredential is not throwing, only prints warning
-    it.skip('throws: no request', async () => {
-      const [issuerCredential, data] = await issuerCredentialCreate();
-      await issuerCredential.sendOffer(data);
-      const error = await shouldThrow(() => issuerCredential.sendCredential(data.connection));
-      assert.equal(error.vcxCode, VCXCode.NOT_READY);
-    });
-  });
+  //
+  // describe('sendCredential:', () => {
+  //   it('throws: not initialized', async () => {
+  //     const connection = await createConnectionInviterRequested();
+  //     const issuerCredential = new IssuerCredential('');
+  //     const error = await shouldThrow(() => issuerCredential.sendCredential(connection));
+  //     assert.equal(error.vcxCode, VCXCode.INVALID_ISSUER_CREDENTIAL_HANDLE);
+  //   });
+  //
+  //   // todo: recorder this test/behaviour in 4.0, issuerCredential is not throwing, only prints warning
+  //   it.skip('throws: no offer', async () => {
+  //     const connection = await createConnectionInviterRequested();
+  //     const issuerCredential = await issuerCredentialCreate();
+  //     const error = await shouldThrow(() => issuerCredential[0].sendCredential(connection));
+  //     assert.equal(error.vcxCode, VCXCode.NOT_READY);
+  //   });
+  //
+  //   // todo: recorder this test/behaviour in 4.0, issuerCredential is not throwing, only prints warning
+  //   it.skip('throws: no request', async () => {
+  //     const [issuerCredential, data] = await issuerCredentialCreate();
+  //     await issuerCredential.sendOffer(data);
+  //     const error = await shouldThrow(() => issuerCredential.sendCredential(data.connection));
+  //     assert.equal(error.vcxCode, VCXCode.NOT_READY);
+  //   });
+  // });
 
   // describe('revoke:', () => {
   //   it('throws: invalid revocation details', async () => {

--- a/wrappers/node/test/suite1/ariesvcx-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-proof.test.ts
@@ -1,7 +1,7 @@
 import '../module-resolver-helper';
 
 import { assert } from 'chai';
-import { createConnectionInviterRequested, dataProofCreate, proofCreate } from 'helpers/entities';
+import {createConnectionInviterRequested, credentialDefCreate, dataProofCreate, proofCreate} from 'helpers/entities'
 import { initVcxTestMode, shouldThrow } from 'helpers/utils';
 import {
   Connection,
@@ -11,8 +11,8 @@ import {
   VerifierStateType,
   VCXCode,
   VCXMock,
-  VCXMockMessage,
-} from 'src';
+  VCXMockMessage, IssuerCredential, IssuerStateType,
+} from 'src'
 
 describe('Proof:', () => {
   before(() => initVcxTestMode());
@@ -119,6 +119,13 @@ describe('Proof:', () => {
         caught_error = err;
       }
       assert.isNotNull(caught_error);
+    });
+
+    it('build presentation request and mark as sent', async () => {
+      const proof = await proofCreate();
+      assert.equal(await proof.getState(), VerifierStateType.PresentationRequestSet);
+      await proof.markPresentationRequestMsgSent()
+      assert.equal(await proof.getState(), VerifierStateType.PresentationRequestSent);
     });
   });
 


### PR DESCRIPTION
Built on top of https://github.com/hyperledger/aries-vcx/pull/419

This PR 
- decouples generation of `credential offer` and `presentation request` from its sending
- unifying approach for `issuer credential` and `proof` in sense they both have states `OfferSet` and `PresentationRequestSet` respectively.

# Issuer Credentials
This is somewhat revert, as we are adding `OfferSet` state which we have previously removed. Consequently `send_offer` transition was quite "fat" as it was conveniently performing 2 steps:
- generating libindy credential offer
- sending aries credential offer message to counterparty

However this is not always desirable, and in particular doesn't work for OOB workflows. To issue OOB credential, we need to strictly build credential offer and message delivery can happen via arbitrary communication channel. 

This RP replaces 
```
pub fn send_credential_offer(&mut self, offer_info: OfferInfo, comment: Option<&str>, send_message: impl Fn(&A2AMessage) -> VcxResult<()>) -> VcxResult<()>
```
with primarily
```
pub fn build_credential_offer_msg(&mut self, offer_info: OfferInfo, comment: Option<String>) -> VcxResult<()> 
pub fn mark_credential_offer_sent(&mut self) -> VcxResult<()> 
pub fn get_credential_offer_msg(&self) -> VcxResult<CredentialOffer>
```
and temporarily I also kept `send_credential_offer` but became rather a "convenience function" and probably can be removed soon.
```
pub fn send_credential_offer(&mut self, send_message: impl Fn(&A2AMessage) -> VcxResult<()>) -> VcxResult<()>
```

New version of `send_credential_offer` is backward compatible and preserves functionality.
For new OOB flows, it's expected to:
- call `build_credential_offer_msg`
- call `get_credential_offer_msg` to get aries credential offer message
- wrap the credential offer in OOB message
- deliver the OOB message the receiver 
- call `mark_credential_offer_sent`
- wait for credential request with matching thread_id and progress the issuance protocol

# Proof Verifier
In case of `proof`, although we already had state `PresentationRequestSet`, it was containing data *needed* to generate presentation request. However the generation of Presentation Request was happening upon processing of `VerifierMessages::SendPresentationRequest` action inside its `step` function implementation. This was again making it impossible to send out-of-band presentation requests (as in order to generate presentation request, it would be immediately sent as well).

This PR moves the presentation request generation logic into 
```
pub fn set_request(&mut self, presentation_request_data: PresentationRequestData, comment: Option<String>) -> VcxResult<()> 
```
and adds method
```
pub fn mark_presentation_request_msg_sent(&mut self) -> VcxResult<()> 
```
which signals that the presentation request has been sent to a counterparty through some channel.

The functionality of original method
```
pub fn send_presentation_request(&mut self, send_message: impl Fn(&A2AMessage) -> VcxResult<()>) -> VcxResult<()>
```
is still preserved, however it's now rather just a "convenience function" rather than being necessary to progress state.



