### PR TITLE
Change/public invitations api

### DIFF
--- a/agents/node/vcxagent-core/src/agent.js
+++ b/agents/node/vcxagent-core/src/agent.js
@@ -6,7 +6,7 @@ const { createServiceProver } = require('./services/service-prover')
 const { createServiceCredHolder } = require('./services/service-cred-holder')
 const { createServiceCredIssuer } = require('./services/service-cred-issuer')
 const { createServiceConnections } = require('./services/service-connections')
-const { createServiceAgents } = require('./services/service-agents')
+const { createServicePublicAgents } = require('./services/service-public-agents')
 const { createServiceOutOfBand } = require('./services/service-out-of-band')
 const { provisionAgentInAgency } = require('./utils/vcx-workflows')
 const {
@@ -121,7 +121,7 @@ async function createVcxAgent ({ agentName, genesisPath, agencyUrl, seed, usePos
     loadProof: storageService.loadProof,
     listProofIds: storageService.listProofKeys
   })
-  const serviceAgent = createServiceAgents({
+  const servicePublicAgents = createServicePublicAgents({
     logger,
     saveAgent: storageService.saveAgent,
     loadAgent: storageService.loadAgent
@@ -156,7 +156,7 @@ async function createVcxAgent ({ agentName, genesisPath, agencyUrl, seed, usePos
     serviceVerifier,
 
     // agents
-    serviceAgent,
+    servicePublicAgents,
 
     // out of band
     serviceOutOfBand

--- a/agents/node/vcxagent-core/src/services/service-public-agents.js
+++ b/agents/node/vcxagent-core/src/services/service-public-agents.js
@@ -1,20 +1,14 @@
 const {
-  Agent
+  PublicAgent
 } = require('@hyperledger/node-vcx-wrapper')
 
-module.exports.createServiceAgents = function createServiceAgents ({ logger, saveAgent, loadAgent }) {
+module.exports.createServicePublicAgents = function createServicePublicAgents ({ logger, saveAgent, loadAgent }) {
   async function publicAgentCreate (agentId, institutionDid) {
     logger.info(`Creating public agent with id ${agentId} for institution did ${institutionDid}`)
-    const agent = await Agent.create(agentId, institutionDid)
+    const agent = await PublicAgent.create(agentId, institutionDid)
     await saveAgent(agentId, agent)
     logger.info(`Created public agent with id ${agentId} for institution did ${institutionDid}`)
     return agent
-  }
-
-  async function getPublicInvite (agentId, label) {
-    logger.info(`Public agent with id ${agentId} is creating public invite with label ${label}`)
-    const agent = await loadAgent(agentId)
-    return agent.generatePublicInvite(label)
   }
 
   async function downloadConnectionRequests (agentId) {
@@ -25,7 +19,6 @@ module.exports.createServiceAgents = function createServiceAgents ({ logger, sav
 
   return {
     publicAgentCreate,
-    getPublicInvite,
     downloadConnectionRequests
   }
 }

--- a/agents/node/vcxagent-core/src/storage/storage-service.js
+++ b/agents/node/vcxagent-core/src/storage/storage-service.js
@@ -8,7 +8,7 @@ const {
   Schema,
   DisclosedProof,
   Proof,
-  Agent
+  PublicAgent
 } = require('@hyperledger/node-vcx-wrapper')
 
 async function createStorageService (agentName) {
@@ -138,9 +138,9 @@ async function createStorageService (agentName) {
   async function loadAgent (name) {
     const serialized = await storageAgents.get(name)
     if (!serialized) {
-      throw Error(`Agent ${name} was not found.`)
+      throw Error(`PublicAgent ${name} was not found.`)
     }
-    return Agent.deserialize(serialized)
+    return PublicAgent.deserialize(serialized)
   }
 
   async function listConnectionKeys () {

--- a/aries_vcx/src/handlers/connection/public_agent.rs
+++ b/aries_vcx/src/handlers/connection/public_agent.rs
@@ -3,7 +3,6 @@ use std::convert::TryFrom;
 use crate::error::prelude::*;
 use crate::handlers::connection::cloud_agent::CloudAgentInfo;
 use crate::handlers::connection::pairwise_info::PairwiseInfo;
-use crate::messages::connection::invite::PublicInvitation;
 use crate::messages::connection::service::FullService;
 use crate::libindy::utils::ledger::add_service;
 use crate::messages::connection::request::Request;
@@ -43,13 +42,6 @@ impl PublicAgent {
 
     pub fn service(&self) -> VcxResult<FullService> {
         FullService::try_from(self)
-    }
-
-    pub fn generate_public_invite(&self, label: &str) -> VcxResult<PublicInvitation> {
-        let invite: PublicInvitation = PublicInvitation::create()
-            .set_label(label.to_string())
-            .set_public_did(self.institution_did.to_string());
-        Ok(invite)
     }
 
     pub fn download_connection_requests(&self, uids: Option<Vec<String>>) -> VcxResult<Vec<Request>> {
@@ -115,19 +107,5 @@ pub mod tests {
             },
             institution_did: INSTITUTION_DID.to_string()
         }
-    }
-
-    #[test]
-    #[cfg(feature = "general_test")]
-    fn test_generate_public_invite() {
-        let _setup = SetupMocks::init();
-        let expected_invite = PublicInvitation {
-            id: MessageId("testid".to_string()),
-            label: "hello".to_string(),
-            did: "2hoqvcwupRTUNkXn6ArYzs".to_string()
-        };
-        let agent = PublicAgent::create("testid", INSTITUTION_DID).unwrap();
-        let invite = agent.generate_public_invite(LABEL).unwrap();
-        assert_eq!(expected_invite, invite);
     }
 }

--- a/aries_vcx/src/messages/connection/invite.rs
+++ b/aries_vcx/src/messages/connection/invite.rs
@@ -79,18 +79,18 @@ impl PublicInvitation {
         Self::default()
     }
 
-    pub fn set_label(mut self, label: String) -> Self {
-        self.label = label;
+    pub fn set_label(mut self, label: &str) -> Self {
+        self.label = label.into();
         self
     }
 
-    pub fn set_id(mut self, id: String) -> Self {
-        self.id = MessageId(id);
+    pub fn set_id(mut self, id: &str) -> Self {
+        self.id = MessageId(id.into());
         self
     }
 
-    pub fn set_public_did(mut self, public_did: String) -> Self {
-        self.did = public_did;
+    pub fn set_public_did(mut self, public_did: &str) -> Self {
+        self.did = public_did.into();
         self
     }
 }
@@ -178,8 +178,8 @@ pub mod tests {
     #[cfg(feature = "general_test")]
     fn test_public_invite_build_works() {
         let invitation: PublicInvitation = PublicInvitation::default()
-            .set_label(_label())
-            .set_public_did(_did());
+            .set_label(&_label())
+            .set_public_did(&_did());
 
         assert_eq!(_public_invitation(), invitation);
     }

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -26,6 +26,7 @@ pub mod test {
     use aries_vcx::handlers::proof_presentation::verifier::verifier::{Verifier, VerifierState};
     use aries_vcx::handlers::proof_presentation::prover::prover::{Prover, ProverState};
     use aries_vcx::handlers::proof_presentation::prover::get_proof_request_messages;
+    use aries_vcx::messages::connection::invite::PublicInvitation;
     use aries_vcx::messages::proof_presentation::presentation_request::{PresentationRequest, PresentationRequestData};
 
     #[derive(Debug)]
@@ -221,8 +222,10 @@ pub mod test {
         }
 
         pub fn create_public_invite(&mut self) -> String {
-            self.activate().unwrap();
-            json!(self.agent.generate_public_invite("faber").unwrap()).to_string()
+            let public_invitation = PublicInvitation::create()
+                .set_label("faber")
+                .set_public_did(&self.config_issuer.institution_did);
+            json!(public_invitation).to_string()
         }
 
         pub fn update_state(&mut self, expected_state: u32) {

--- a/libvcx/src/api_lib/api_c/agent.rs
+++ b/libvcx/src/api_lib/api_c/agent.rs
@@ -42,42 +42,6 @@ pub extern fn vcx_public_agent_create(command_handle: CommandHandle,
 }
 
 #[no_mangle]
-pub extern fn vcx_public_agent_generate_public_invite(command_handle: CommandHandle,
-                                                      agent_handle: u32,
-                                                      label: *const c_char,
-                                                      cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, public_invite: *const c_char)>) -> u32 {
-    info!("vcx_public_agent_generate_public_invite >>>");
-
-    check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
-    check_useful_c_str!(label, VcxErrorKind::InvalidOption);
-
-    if !agent::is_valid_handle(agent_handle) {
-        return VcxError::from(VcxErrorKind::InvalidHandle).into();
-    }
-
-    trace!("vcx_public_agent_generate_public_invite(command_handle: {}, label: {})", command_handle, label);
-
-    execute(move || {
-        match agent::generate_public_invite(agent_handle, &label) {
-            Ok(public_invite) => {
-                trace!("generate_public_invite_cb(command_handle: {}, rc: {}, public_invite: {})",
-                       command_handle, error::SUCCESS.message, public_invite);
-                let public_invite = CStringUtils::string_to_cstring(public_invite);
-                cb(command_handle, error::SUCCESS.code_num, public_invite.as_ptr());
-            }
-            Err(x) => {
-                warn!("generate_public_invite_cb(command_handle: {}, rc: {}, public_invite: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
-            }
-        }
-        Ok(())
-    });
-
-    error::SUCCESS.code_num
-}
-
-#[no_mangle]
 pub extern fn vcx_public_agent_download_connection_requests(command_handle: CommandHandle,
                                                             agent_handle: u32,
                                                             uids: *const c_char,

--- a/libvcx/src/api_lib/api_c/connection.rs
+++ b/libvcx/src/api_lib/api_c/connection.rs
@@ -105,7 +105,7 @@ pub extern fn vcx_generate_public_invite(command_handle: CommandHandle,
                                          public_did: *const c_char,
                                          label: *const c_char,
                                          cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32, public_invite: *const c_char)>) -> u32 {
-    info!("vcx_generate_public_invite >>>");
+    info!("vcx_generate_public_invite >>> ");
 
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
     check_useful_c_str!(public_did, VcxErrorKind::InvalidOption);

--- a/libvcx/src/api_lib/api_handle/agent.rs
+++ b/libvcx/src/api_lib/api_handle/agent.rs
@@ -21,16 +21,6 @@ pub fn create_public_agent(source_id: &str, institution_did: &str) -> VcxResult<
     return store_public_agent(agent);
 }
 
-pub fn generate_public_invite(agent_handle: u32, label: &str) -> VcxResult<String> {
-    trace!("generate_public_invite >>> agent_handle: {}, label: {}", agent_handle, label);
-    PUBLIC_AGENT_MAP.get(agent_handle, |agent| {
-        let invite = agent.generate_public_invite(label)?;
-        let invite = serde_json::to_string(&invite)
-            .map_err(|err| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to serialize public invite {:?}, err: {:?}", invite, err)))?;
-        Ok(invite)
-    })
-}
-
 pub fn download_connection_requests(agent_handle: u32, uids: Option<Vec<String>>) -> VcxResult<String> {
     trace!("download_connection_requests >>> agent_handle: {}, uids: {:?}", agent_handle, uids);
     PUBLIC_AGENT_MAP.get(agent_handle, |agent| {

--- a/libvcx/src/api_lib/api_handle/connection.rs
+++ b/libvcx/src/api_lib/api_handle/connection.rs
@@ -285,6 +285,7 @@ pub fn download_messages(conn_handles: Vec<u32>, status_codes: Option<Vec<Messag
 
 #[cfg(test)]
 pub mod tests {
+    use serde_json::Value;
     use aries_vcx;
     use aries_vcx::agency_client::mocking::AgencyMockDecrypted;
     use aries_vcx::messages::connection::invite::test_utils::{_pairwise_invitation_json, _public_invitation_json};
@@ -566,9 +567,9 @@ pub mod tests {
         let _setup = SetupMocks::init();
 
         let invitation = generate_public_invitation("sob:mainnet:abcde123", "faber-enterprise").unwrap();
-        let parsed = json!(invitation);
+        let parsed: Value = serde_json::from_str(&invitation).unwrap();
         assert!(parsed["@id"].is_string());
-        assert_eq!(parsed["@type"], json!(expected).to_string());
+        assert_eq!(parsed["@type"], "https://didcomm.org/connections/1.0/invitation");
         assert_eq!(parsed["did"], "sob:mainnet:abcde123");
         assert_eq!(parsed["label"], "faber-enterprise");
     }

--- a/wrappers/node/src/api/public-agent.ts
+++ b/wrappers/node/src/api/public-agent.ts
@@ -16,59 +16,21 @@ export interface IPairwiseInfo {
 }
 
 export interface IAgentSerializedData {
-  source_id: string; 
+  source_id: string;
   agent_info: IAgentInfo,
   pairwise_info: IPairwiseInfo,
   institution_did: string
 }
 
-export class Agent extends VCXBase<IAgentSerializedData> {
-  public static async create(sourceId: string, institution_did: string): Promise<Agent> {
-    const agent = new Agent(sourceId);
+export class PublicAgent extends VCXBase<IAgentSerializedData> {
+  public static async create(sourceId: string, institution_did: string): Promise<PublicAgent> {
+    const agent = new PublicAgent(sourceId);
     const commandHandle = 0;
     try {
       await agent._create((cb) =>
         rustAPI().vcx_public_agent_create(commandHandle, sourceId, institution_did, cb),
       );
       return agent;
-    } catch (err) {
-      throw new VCXInternalError(err);
-    }
-  }
-
-  public async generatePublicInvite(label: string): Promise<string> {
-    try {
-      const data = await createFFICallbackPromise<string>(
-        (resolve, reject, cb) => {
-          const commandHandle = 0;
-          const rc = rustAPI().vcx_public_agent_generate_public_invite(
-            commandHandle,
-            this.handle,
-            label,
-            cb,
-          );
-          if (rc) {
-            reject(rc);
-          }
-        },
-        (resolve, reject) =>
-          ffi.Callback(
-            'void',
-            ['uint32', 'uint32', 'string'],
-            (handle: number, err: number, invite: string) => {
-              if (err) {
-                reject(err);
-                return;
-              }
-              if (!invite) {
-                reject('no public invite returned');
-                return;
-              }
-              resolve(invite);
-            },
-          ),
-      );
-      return data;
     } catch (err) {
       throw new VCXInternalError(err);
     }
@@ -151,8 +113,8 @@ export class Agent extends VCXBase<IAgentSerializedData> {
 
   public static async deserialize(
     agentData: ISerializedData<IAgentSerializedData>,
-  ): Promise<Agent> {
-    const agent = await super._deserialize<Agent>(Agent, agentData);
+  ): Promise<PublicAgent> {
+    const agent = await super._deserialize<PublicAgent>(PublicAgent, agentData);
     return agent;
   }
 

--- a/wrappers/node/src/index.ts
+++ b/wrappers/node/src/index.ts
@@ -10,7 +10,7 @@ export * from './api/credential';
 export * from './api/disclosed-proof';
 export * from './api/utils';
 export * from './api/wallet';
-export * from './api/agent';
+export * from './api/public-agent';
 export * from './api/out-of-band-sender';
 export * from './api/out-of-band-receiver';
 export * from './vcx';

--- a/wrappers/node/src/rustlib.ts
+++ b/wrappers/node/src/rustlib.ts
@@ -537,7 +537,7 @@ export interface IFFIEntryPoint {
   vcx_schema_update_state: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_schema_get_state: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_public_agent_create: (commandId: number, sourceId: string, institutionDid: string, cb: ICbRef) => number;
-  vcx_public_agent_generate_public_invite: (commandId: number, handle: number, label: string, cb: ICbRef) => number;
+  vcx_generate_public_invite: (commandId: number, public_did: string, label: string, cb: ICbRef) => number;
   vcx_public_agent_download_connection_requests: (commandId: number, handle: number, uids: string, cb: ICbRef) => number;
   vcx_public_agent_get_service: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_public_agent_serialize: (commandId: number, handle: number, cb: ICbRef) => number;
@@ -1128,9 +1128,9 @@ export const FFIConfiguration: { [Key in keyof IFFIEntryPoint]: any } = {
     FFI_ERROR_CODE,
     [FFI_COMMAND_HANDLE, FFI_STRING_DATA, FFI_STRING_DATA, FFI_CALLBACK_PTR],
   ],
-  vcx_public_agent_generate_public_invite: [
+  vcx_generate_public_invite: [
     FFI_ERROR_CODE,
-    [FFI_COMMAND_HANDLE, FFI_AGENT_HANDLE, FFI_STRING_DATA, FFI_CALLBACK_PTR],
+    [FFI_COMMAND_HANDLE, FFI_STRING_DATA, FFI_STRING_DATA, FFI_CALLBACK_PTR],
   ],
   vcx_public_agent_download_connection_requests: [
     FFI_ERROR_CODE,


### PR DESCRIPTION
# 1. 
Our API `vcx_public_agent_generate_public_invite` creates public did invitations which looks as follows:
```
{
    "@type": "https://didcomm.org/didexchange/1.0/invitation",
    "@id": "12345678900987654321",
    "label": "Alice",
    "did": "did:sov:QmWbsNYhMrjHiqZDTUTEJs"
}
```

The previously implementation required `agent_handle` though it did not use the agent for anything but getting `institution_did`. 

This PR changes the api from 
```
 vcx_public_agent_generate_public_invite(command_handle: CommandHandle,
                                                      agent_handle: u32,
                                                      label: *const c_char,
```
to 
```
pub extern fn vcx_generate_public_invite(command_handle: CommandHandle,
                                         public_did: *const c_char,
                                         label: *const c_char,
```

So that no public_agent is not required to create public invitation, and the public DID to be used is supplied by the user.

# 2.
Rename NodeJS wrapper structure `Agent` to `PublicAgent`