### PR TITLE
Change issuer's implementation of is_revokable

### DIFF
--- a/aries_vcx/src/handlers/issuance/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer.rs
@@ -143,12 +143,12 @@ impl Issuer {
         self.issuer_sm.get_proposal()
     }
 
-    pub fn is_revokable(&self) -> VcxResult<bool> {
-        self.issuer_sm.is_revokable()
-    }
-
     pub fn get_credential_status(&self) -> VcxResult<u32> {
         Ok(self.issuer_sm.credential_status())
+    }
+
+    pub fn is_revokable(&self) -> bool {
+        self.issuer_sm.is_revokable()
     }
 
     pub async fn step(&mut self, message: CredentialIssuanceAction, send_message: Option<SendClosure>) -> VcxResult<()> {

--- a/aries_vcx/src/protocols/issuance/issuer/states/proposal_received.rs
+++ b/aries_vcx/src/protocols/issuance/issuer/states/proposal_received.rs
@@ -1,7 +1,5 @@
-use crate::error::prelude::*;
 use crate::messages::issuance::credential_offer::{CredentialOffer, OfferInfo};
 use crate::messages::issuance::credential_proposal::CredentialProposal;
-use crate::protocols::issuance::is_cred_def_revokable;
 use crate::protocols::issuance::issuer::states::offer_sent::OfferSentState;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -16,10 +14,6 @@ impl ProposalReceivedState {
             credential_proposal,
             offer_info,
         }
-    }
-
-    pub fn is_revokable(&self) -> VcxResult<bool> {
-        is_cred_def_revokable(&self.credential_proposal.cred_def_id)
     }
 }
 

--- a/aries_vcx/tests/test_integration.rs
+++ b/aries_vcx/tests/test_integration.rs
@@ -396,10 +396,10 @@ mod tests {
         info!("send_credential >>> getting offers");
         let thread_id = issuer_credential.get_thread_id().unwrap();
         assert_eq!(IssuerState::OfferSent, issuer_credential.get_state());
-        assert_eq!(issuer_credential.is_revokable().unwrap(), revokable);
+        assert_eq!(issuer_credential.is_revokable(), revokable);
         issuer_credential.update_state(issuer_to_consumer).await.unwrap();
         assert_eq!(IssuerState::RequestReceived, issuer_credential.get_state());
-        assert_eq!(issuer_credential.is_revokable().unwrap(), revokable);
+        assert_eq!(issuer_credential.is_revokable(), revokable);
         assert_eq!(thread_id, issuer_credential.get_thread_id().unwrap());
 
         info!("send_credential >>> sending credential");

--- a/aries_vcx/tests/test_integration.rs
+++ b/aries_vcx/tests/test_integration.rs
@@ -396,10 +396,10 @@ mod tests {
         info!("send_credential >>> getting offers");
         let thread_id = issuer_credential.get_thread_id().unwrap();
         assert_eq!(IssuerState::OfferSent, issuer_credential.get_state());
-        assert_eq!(issuer_credential.is_revokable(), revokable);
+        assert_eq!(issuer_credential.is_revokable(), false);
         issuer_credential.update_state(issuer_to_consumer).await.unwrap();
         assert_eq!(IssuerState::RequestReceived, issuer_credential.get_state());
-        assert_eq!(issuer_credential.is_revokable(), revokable);
+        assert_eq!(issuer_credential.is_revokable(), false);
         assert_eq!(thread_id, issuer_credential.get_thread_id().unwrap());
 
         info!("send_credential >>> sending credential");

--- a/libvcx/src/api_lib/api_handle/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_handle/issuer_credential.rs
@@ -189,7 +189,7 @@ pub fn get_rev_reg_id(handle: u32) -> VcxResult<String> {
 
 pub fn is_revokable(handle: u32) -> VcxResult<bool> {
     ISSUER_CREDENTIAL_MAP.get(handle, |credential| {
-        credential.is_revokable().map_err(|err| err.into())
+        Ok(credential.is_revokable())
     })
 }
 

--- a/wrappers/node/src/api/issuer-credential.ts
+++ b/wrappers/node/src/api/issuer-credential.ts
@@ -518,6 +518,33 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData, Is
     }
   }
 
+  public async isRevokable(): Promise<boolean> {
+    try {
+      return await createFFICallbackPromise<boolean>(
+        (resolve, reject, cb) => {
+          const rc = rustAPI().vcx_issuer_credential_is_revokable(0, this.handle, cb);
+          if (rc) {
+            reject(rc);
+          }
+        },
+        (resolve, reject) =>
+          ffi.Callback(
+            'void',
+            ['uint32', 'uint32', 'bool'],
+            (xcommandHandle: number, err: number, revokable: boolean) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+              resolve(revokable);
+            },
+          ),
+      );
+    } catch (err) {
+      throw new VCXInternalError(err);
+    }
+  }
+
   public async getRevRegId(): Promise<string> {
     try {
       const revRegId = await createFFICallbackPromise<string>(

--- a/wrappers/node/src/rustlib.ts
+++ b/wrappers/node/src/rustlib.ts
@@ -274,6 +274,7 @@ export interface IFFIEntryPoint {
   ) => number;
   vcx_issuer_revoke_credential: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_issuer_revoke_credential_local: (commandId: number, handle: number, cb: ICbRef) => number;
+  vcx_issuer_credential_is_revokable: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_issuer_send_credential: (
     commandId: number,
     credentialHandle: number,
@@ -794,6 +795,10 @@ export const FFIConfiguration: { [Key in keyof IFFIEntryPoint]: any } = {
     [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CALLBACK_PTR],
   ],
   vcx_issuer_revoke_credential_local: [
+    FFI_ERROR_CODE,
+    [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CALLBACK_PTR],
+  ],
+  vcx_issuer_credential_is_revokable: [
     FFI_ERROR_CODE,
     [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CALLBACK_PTR],
   ],


### PR DESCRIPTION
Changes issuer's implementation of `is_revokable` from returning `true` iff the credential was issued under revokable credential definition to returning `true` iff attempt to revoke is expected to succeed, i.e. the credential was issued under revokable credential definition and it was created and saved to the wallet (and potentially sent).

Holder's implementation still returns `true` iff the credential was issued under revokable credential definition.

Signed-off-by: Miroslav Kovar <miroslav.kovar@absa.africa>