### PR TITLE
Unify err handling code in libvcx, use error level instead of warn

### DIFF
--- a/libvcx/src/api_lib/api_c/agent.rs
+++ b/libvcx/src/api_lib/api_c/agent.rs
@@ -32,11 +32,11 @@ pub extern fn vcx_public_agent_create(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, handle);
                 cb(command_handle, error::SUCCESS.code_num, handle);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_public_agent_create_cb(command_handle: {}, rc: {}, handle: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_public_agent_create_cb(command_handle: {}, rc: {}, handle: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), 0);
             }
         }
         Ok(())
@@ -73,11 +73,11 @@ pub extern fn vcx_public_agent_download_connection_requests(command_handle: Comm
                 let requests = CStringUtils::string_to_cstring(requests);
                 cb(command_handle, error::SUCCESS.code_num, requests.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_public_agent_download_connection_requests_cb(command_handle: {}, rc: {}, requests: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_public_agent_download_connection_requests_cb(command_handle: {}, rc: {}, requests: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -106,10 +106,11 @@ pub extern fn vcx_public_agent_download_message(command_handle: CommandHandle,
                 let msg = CStringUtils::string_to_cstring(msg);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                warn!("vcx_public_agent_download_message_cb(command_handle: {}, rc: {}, msg: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_public_agent_download_message_cb(command_handle: {}, rc: {}, msg: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -136,11 +137,11 @@ pub extern fn vcx_public_agent_get_service(command_handle: CommandHandle,
                 let service = CStringUtils::string_to_cstring(service);
                 cb(command_handle, error::SUCCESS.code_num, service.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_public_agent_get_service_cb(command_handle: {}, rc: {}, service: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_public_agent_get_service_cb(command_handle: {}, rc: {}, service: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -167,11 +168,11 @@ pub extern fn vcx_public_agent_serialize(command_handle: CommandHandle,
                 let agent_json = CStringUtils::string_to_cstring(agent_json);
                 cb(command_handle, error::SUCCESS.code_num, agent_json.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_public_agent_serialize_cb(command_handle: {}, rc: {}, agent_json: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_public_agent_serialize_cb(command_handle: {}, rc: {}, agent_json: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -198,11 +199,11 @@ pub extern fn vcx_public_agent_deserialize(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, agent_handle);
                 cb(command_handle, error::SUCCESS.code_num, agent_handle);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_public_agent_deserialize_cb(command_handle: {}, rc: {}, agent_handle: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_public_agent_deserialize_cb(command_handle: {}, rc: {}, agent_handle: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), 0);
             }
         }
         Ok(())
@@ -221,10 +222,11 @@ pub extern fn vcx_public_agent_release(agent_handle: u32) -> u32 {
                    agent_handle, error::SUCCESS.message);
             error::SUCCESS.code_num
         }
-        Err(e) => {
-            warn!("vcx_public_agent_release(agent_handle: {}), rc: {})",
-                  agent_handle, e);
-            e.into()
+        Err(err) => {
+            set_current_error_vcx(&err);
+            error!("vcx_public_agent_release(agent_handle: {}), rc: {})",
+                  agent_handle, err);
+            err.into()
         }
     }
 }

--- a/libvcx/src/api_lib/api_c/connection.rs
+++ b/libvcx/src/api_lib/api_c/connection.rs
@@ -123,11 +123,11 @@ pub extern fn vcx_generate_public_invite(command_handle: CommandHandle,
                 let public_invite = CStringUtils::string_to_cstring(public_invite);
                 cb(command_handle, error::SUCCESS.code_num, public_invite.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_generate_public_invite_cb(command_handle: {}, rc: {}, public_invite: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_generate_public_invite_cb(command_handle: {}, rc: {}, public_invite: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -167,9 +167,10 @@ pub extern fn vcx_connection_delete_connection(command_handle: CommandHandle,
                 trace!("vcx_connection_delete_connection_cb(command_handle: {}, rc: {})", command_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(e) => {
-                trace!("vcx_connection_delete_connection_cb(command_handle: {}, rc: {})", command_handle, e);
-                cb(command_handle, e.into());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                trace!("vcx_connection_delete_connection_cb(command_handle: {}, rc: {})", command_handle, err);
+                cb(command_handle, err.into());
             }
         }
 
@@ -209,11 +210,11 @@ pub extern fn vcx_connection_create(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, handle, source_id);
                 cb(command_handle, error::SUCCESS.code_num, handle);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_create_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                      command_handle, x, 0, source_id);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_create_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
+                      command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -265,11 +266,11 @@ pub extern fn vcx_connection_create_with_invite(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, handle, source_id);
                 cb(command_handle, error::SUCCESS.code_num, handle);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_create_with_invite_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                      command_handle, x, 0, source_id);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_create_with_invite_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
+                      command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -300,11 +301,11 @@ pub extern fn vcx_connection_create_with_connection_request(command_handle: Comm
                        command_handle, error::SUCCESS.message, handle, source_id);
                 cb(command_handle, error::SUCCESS.code_num, handle);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_create_with_connection_request_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                      command_handle, x, 0, source_id);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_create_with_connection_request_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
+                      command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -363,7 +364,7 @@ pub extern fn vcx_connection_connect(command_handle: CommandHandle,
             }
             Err(err) => {
                 set_current_error_vcx(&err);
-                warn!("vcx_connection_connect_cb(command_handle: {}, connection_handle: {}, rc: {}, details: {}, source_id: {})",
+                error!("vcx_connection_connect_cb(command_handle: {}, connection_handle: {}, rc: {}, details: {}, source_id: {})",
                       command_handle, connection_handle, err, "null", source_id);
                 cb(command_handle, err.into(), ptr::null_mut());
             }
@@ -395,11 +396,11 @@ pub extern fn vcx_connection_get_thread_id(command_handle: CommandHandle,
                 let tid = CStringUtils::string_to_cstring(tid);
                 cb(command_handle, error::SUCCESS.code_num, tid.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_get_thread_id_cb(command_handle: {}, connection_handle: {}, rc: {}, thread_id: {}), source_id: {:?}",
-                      command_handle, connection_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_get_thread_id_cb(command_handle: {}, connection_handle: {}, rc: {}, thread_id: {}), source_id: {:?}",
+                      command_handle, connection_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -440,11 +441,11 @@ pub extern fn vcx_connection_serialize(command_handle: CommandHandle,
                 let msg = CStringUtils::string_to_cstring(json);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_serialize_cb(command_handle: {}, connection_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                      command_handle, connection_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_serialize_cb(command_handle: {}, connection_handle: {}, rc: {}, state: {}), source_id: {:?}",
+                      command_handle, connection_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -478,17 +479,17 @@ pub extern fn vcx_connection_deserialize(command_handle: CommandHandle,
 
     execute(move || {
         let (rc, handle) = match from_string(&connection_data) {
-            Ok(x) => {
-                let source_id = get_source_id(x).unwrap_or_default();
+            Ok(err) => {
+                let source_id = get_source_id(err).unwrap_or_default();
                 trace!("vcx_connection_deserialize_cb(command_handle: {}, rc: {}, handle: {}), source_id: {:?}",
-                       command_handle, error::SUCCESS.message, x, source_id);
-                (error::SUCCESS.code_num, x)
+                       command_handle, error::SUCCESS.message, err, source_id);
+                (error::SUCCESS.code_num, err)
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_deserialize_cb(command_handle: {}, rc: {}, handle: {} )",
-                      command_handle, x, 0);
-                (x.into(), 0)
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_deserialize_cb(command_handle: {}, rc: {}, handle: {} )",
+                      command_handle, err, 0);
+                (err.into(), 0)
             }
         };
 
@@ -531,16 +532,16 @@ pub extern fn vcx_connection_update_state(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         let rc = match update_state(connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_connection_update_state_cb(command_handle: {}, rc: {}, connection_handle: {}, state: {}), source_id: {:?}",
                        command_handle, error::SUCCESS.message, connection_handle, get_state(connection_handle), source_id);
-                x
+                err
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_update_state_cb(command_handle: {}, rc: {}, connection_handle: {}, state: {}), source_id: {:?}",
-                      command_handle, x, connection_handle, get_state(connection_handle), source_id);
-                x.into()
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_update_state_cb(command_handle: {}, rc: {}, connection_handle: {}, state: {}), source_id: {:?}",
+                      command_handle, err, connection_handle, get_state(connection_handle), source_id);
+                err.into()
             }
         };
         let state = get_state(connection_handle);
@@ -581,16 +582,16 @@ pub extern fn vcx_connection_update_state_with_message(command_handle: CommandHa
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         let rc = match update_state_with_message(connection_handle, &message).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_connection_update_state_with_message_cb(command_handle: {}, rc: {}, connection_handle: {}, state: {}), source_id: {:?}",
                        command_handle, error::SUCCESS.message, connection_handle, get_state(connection_handle), source_id);
-                x
+                err
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_update_state_with_message_cb(command_handle: {}, rc: {}, connection_handle: {}, state: {}), source_id: {:?}",
-                      command_handle, x, connection_handle, get_state(connection_handle), source_id);
-                x.into()
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_update_state_with_message_cb(command_handle: {}, rc: {}, connection_handle: {}, state: {}), source_id: {:?}",
+                      command_handle, err, connection_handle, get_state(connection_handle), source_id);
+                err.into()
             }
         };
 
@@ -689,11 +690,11 @@ pub extern fn vcx_connection_invite_details(command_handle: CommandHandle,
                 let msg = CStringUtils::string_to_cstring(str);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_invite_details_cb(command_handle: {}, connection_handle: {}, rc: {}, details: {}, source_id: {:?})",
-                      command_handle, connection_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_invite_details_cb(command_handle: {}, connection_handle: {}, rc: {}, details: {}, source_id: {:?})",
+                      command_handle, connection_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -737,18 +738,18 @@ pub extern fn vcx_connection_send_message(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match send_generic_message(connection_handle, &msg).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_connection_send_message_cb(command_handle: {}, rc: {}, msg_id: {})",
-                       command_handle, error::SUCCESS.message, x);
+                       command_handle, error::SUCCESS.message, err);
 
-                let msg_id = CStringUtils::string_to_cstring(x);
+                let msg_id = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg_id.as_ptr());
             }
-            Err(e) => {
-                warn!("vcx_connection_send_message_cb(command_handle: {}, rc: {})",
-                      command_handle, e);
+            Err(err) => {
+                error!("vcx_connection_send_message_cb(command_handle: {}, rc: {})",
+                      command_handle, err);
 
-                cb(command_handle, e.into(), ptr::null_mut());
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -797,11 +798,11 @@ pub extern fn vcx_connection_send_ping(command_handle: u32,
                        command_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(e) => {
-                warn!("vcx_connection_send_ping(command_handle: {}, rc: {})",
-                      command_handle, e);
+            Err(err) => {
+                error!("vcx_connection_send_ping(command_handle: {}, rc: {})",
+                      command_handle, err);
 
-                cb(command_handle, e.into());
+                cb(command_handle, err.into());
             }
         };
 
@@ -831,11 +832,11 @@ pub extern fn vcx_connection_send_handshake_reuse(command_handle: u32,
                        command_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(e) => {
-                warn!("vcx_connection_send_handshake_reuse_cb(command_handle: {}, rc: {})",
-                      command_handle, e);
+            Err(err) => {
+                error!("vcx_connection_send_handshake_reuse_cb(command_handle: {}, rc: {})",
+                      command_handle, err);
 
-                cb(command_handle, e.into());
+                cb(command_handle, err.into());
             }
         };
 
@@ -886,28 +887,28 @@ pub extern fn vcx_connection_sign_data(command_handle: CommandHandle,
 
     execute(move || {
         let vk = match connection::get_pw_verkey(connection_handle) {
-            Ok(x) => x,
-            Err(e) => {
-                warn!("vcx_messages_sign_data_cb(command_handle: {}, rc: {}, signature: null)",
-                      command_handle, e);
-                cb(command_handle, e.into(), ptr::null_mut(), 0);
+            Ok(err) => err,
+            Err(err) => {
+                error!("vcx_messages_sign_data_cb(command_handle: {}, rc: {}, signature: null)",
+                      command_handle, err);
+                cb(command_handle, err.into(), ptr::null_mut(), 0);
                 return Ok(());
             }
         };
 
         match libindy::utils::crypto::sign(&vk, &data_raw) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_connection_sign_data_cb(command_handle: {}, connection_handle: {}, rc: {}, signature: {:?})",
-                       command_handle, connection_handle, error::SUCCESS.message, x);
+                       command_handle, connection_handle, error::SUCCESS.message, err);
 
-                let (signature_raw, signature_len) = utils::cstring::vec_to_pointer(&x);
+                let (signature_raw, signature_len) = utils::cstring::vec_to_pointer(&err);
                 cb(command_handle, error::SUCCESS.code_num, signature_raw, signature_len);
             }
-            Err(e) => {
-                warn!("vcx_messages_sign_data_cb(command_handle: {}, rc: {}, signature: null)",
-                      command_handle, e);
+            Err(err) => {
+                error!("vcx_messages_sign_data_cb(command_handle: {}, rc: {}, signature: null)",
+                      command_handle, err);
 
-                cb(command_handle, e.into(), ptr::null_mut(), 0);
+                cb(command_handle, err.into(), ptr::null_mut(), 0);
             }
         };
 
@@ -966,27 +967,27 @@ pub extern fn vcx_connection_verify_signature(command_handle: CommandHandle,
 
     execute(move || {
         let vk = match connection::get_their_pw_verkey(connection_handle) {
-            Ok(x) => x,
-            Err(e) => {
-                warn!("vcx_connection_verify_signature_cb(command_handle: {}, rc: {}, valid: {})",
-                      command_handle, e, false);
-                cb(command_handle, e.into(), false);
+            Ok(err) => err,
+            Err(err) => {
+                error!("vcx_connection_verify_signature_cb(command_handle: {}, rc: {}, valid: {})",
+                      command_handle, err, false);
+                cb(command_handle, err.into(), false);
                 return Ok(());
             }
         };
 
         match libindy::utils::crypto::verify(&vk, &data_raw, &signature_raw) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_connection_verify_signature_cb(command_handle: {}, rc: {}, valid: {})",
-                       command_handle, error::SUCCESS.message, x);
+                       command_handle, error::SUCCESS.message, err);
 
-                cb(command_handle, error::SUCCESS.code_num, x);
+                cb(command_handle, error::SUCCESS.code_num, err);
             }
-            Err(e) => {
-                warn!("vcx_connection_verify_signature_cb(command_handle: {}, rc: {}, valid: {})",
-                      command_handle, e, false);
+            Err(err) => {
+                error!("vcx_connection_verify_signature_cb(command_handle: {}, rc: {}, valid: {})",
+                      command_handle, err, false);
 
-                cb(command_handle, e.into(), false);
+                cb(command_handle, err.into(), false);
             }
         };
 
@@ -1014,10 +1015,10 @@ pub extern fn vcx_connection_release(connection_handle: u32) -> u32 {
                    connection_handle, error::SUCCESS.message, source_id);
             error::SUCCESS.code_num
         }
-        Err(e) => {
-            warn!("vcx_connection_release(connection_handle: {}), rc: {}), source_id: {:?}",
-                  connection_handle, e, source_id);
-            e.into()
+        Err(err) => {
+            error!("vcx_connection_release(connection_handle: {}), rc: {}), source_id: {:?}",
+                  connection_handle, err, source_id);
+            err.into()
         }
     }
 }
@@ -1070,11 +1071,11 @@ pub extern fn vcx_connection_send_discovery_features(command_handle: u32,
                        command_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(e) => {
-                warn!("vcx_connection_send_discovery_features(command_handle: {}, rc: {})",
-                      command_handle, e);
+            Err(err) => {
+                error!("vcx_connection_send_discovery_features(command_handle: {}, rc: {})",
+                      command_handle, err);
 
-                cb(command_handle, e.into());
+                cb(command_handle, err.into());
             }
         };
 
@@ -1137,11 +1138,11 @@ pub extern fn vcx_connection_info(command_handle: CommandHandle,
                 let info = CStringUtils::string_to_cstring(info);
                 cb(command_handle, error::SUCCESS.code_num, info.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_info(command_handle: {}, connection_handle: {}, rc: {}, info: {}, source_id: {:?})",
-                      command_handle, connection_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_info(command_handle: {}, connection_handle: {}, rc: {}, info: {}, source_id: {:?})",
+                      command_handle, connection_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -1182,11 +1183,11 @@ pub extern fn vcx_connection_get_pw_did(command_handle: u32,
                 let msg = CStringUtils::string_to_cstring(json);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_get_pw_did_cb(command_handle: {}, connection_handle: {}, rc: {}, pw_did: {}), source_id: {:?}",
-                      command_handle, connection_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_get_pw_did_cb(command_handle: {}, connection_handle: {}, rc: {}, pw_did: {}), source_id: {:?}",
+                      command_handle, connection_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -1227,11 +1228,11 @@ pub extern fn vcx_connection_get_their_pw_did(command_handle: u32,
                 let msg = CStringUtils::string_to_cstring(json);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_connection_get_their_pw_did_cb(command_handle: {}, connection_handle: {}, rc: {}, their_pw_did: {}), source_id: {:?}",
-                      command_handle, connection_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_connection_get_their_pw_did_cb(command_handle: {}, connection_handle: {}, rc: {}, their_pw_did: {}), source_id: {:?}",
+                      command_handle, connection_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -1281,29 +1282,29 @@ pub extern fn vcx_connection_messages_download(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match connection::download_messages(connection_handles, message_statuses, uids).await {
-            Ok(x) => {
-                match serde_json::to_string(&x) {
-                    Ok(x) => {
+            Ok(err) => {
+                match serde_json::to_string(&err) {
+                    Ok(err) => {
                         trace!("vcx_connection_messages_download_cb(command_handle: {}, rc: {}, messages: {})",
-                               command_handle, error::SUCCESS.message, x);
+                               command_handle, error::SUCCESS.message, err);
 
-                        let msg = CStringUtils::string_to_cstring(x);
+                        let msg = CStringUtils::string_to_cstring(err);
                         cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
                     }
-                    Err(e) => {
-                        let err = VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot serialize messages: {}", e));
-                        warn!("vcx_connection_messages_download_cb(command_handle: {}, rc: {}, messages: {})",
+                    Err(err) => {
+                        let err = VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Cannot serialize messages: {}", err));
+                        error!("vcx_connection_messages_download_cb(command_handle: {}, rc: {}, messages: {})",
                               command_handle, err, "null");
 
                         cb(command_handle, err.into(), ptr::null_mut());
                     }
                 };
             }
-            Err(e) => {
-                warn!("vcx_messages_download_cb(command_handle: {}, rc: {}, messages: {})",
-                      command_handle, e, "null");
+            Err(err) => {
+                error!("vcx_messages_download_cb(command_handle: {}, rc: {}, messages: {})",
+                      command_handle, err, "null");
 
-                cb(command_handle, e.into(), ptr::null_mut());
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 

--- a/libvcx/src/api_lib/api_c/credential.rs
+++ b/libvcx/src/api_lib/api_c/credential.rs
@@ -82,16 +82,16 @@ pub extern fn vcx_credential_create_with_offer(command_handle: CommandHandle,
 
     execute(move || {
         match credential::credential_create_with_offer(&source_id, &offer) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credential_create_with_offer_cb(command_handle: {}, source_id: {}, rc: {}, handle: {})",
-                       command_handle, source_id, error::SUCCESS.message, x);
-                cb(command_handle, error::SUCCESS.code_num, x)
+                       command_handle, source_id, error::SUCCESS.message, err);
+                cb(command_handle, error::SUCCESS.code_num, err)
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_credential_create_with_offer_cb(command_handle: {}, source_id: {}, rc: {}, handle: {})",
-                      command_handle, source_id, x, 0);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_credential_create_with_offer_cb(command_handle: {}, source_id: {}, rc: {}, handle: {})",
+                      command_handle, source_id, err, 0);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -138,10 +138,11 @@ pub extern fn vcx_get_credential(command_handle: CommandHandle,
                 let msg = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_get_credential_cb(commmand_handle: {}, rc: {}, msg: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -181,9 +182,10 @@ pub extern fn vcx_delete_credential(command_handle: CommandHandle,
                 trace!("vcx_delete_credential_cb(command_handle: {}, rc: {}), credential_handle: {}, source_id: {})", command_handle, error::SUCCESS.message, credential_handle, source_id);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(e) => {
-                trace!("vcx_delete_credential_cb(command_handle: {}, rc: {}), credential_handle: {}, source_id: {})", command_handle, e, credential_handle, source_id);
-                cb(command_handle, e.into());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                trace!("vcx_delete_credential_cb(command_handle: {}, rc: {}), credential_handle: {}, source_id: {})", command_handle, err, credential_handle, source_id);
+                cb(command_handle, err.into());
             }
         }
 
@@ -212,10 +214,11 @@ pub extern fn vcx_credential_get_attributes(command_handle: CommandHandle,
                 let attrs = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, attrs.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credential_get_attributes_cb(commmand_handle: {}, rc: {}, attributes: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -244,10 +247,11 @@ pub extern fn vcx_credential_get_attachment(command_handle: CommandHandle,
                 let attach = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, attach.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credential_get_attachment_cb(commmand_handle: {}, rc: {}, attachment: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -276,10 +280,11 @@ pub extern fn vcx_credential_get_tails_location(command_handle: CommandHandle,
                 let location = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, location.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credential_get_tails_location_cb(commmand_handle: {}, rc: {}, location: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -308,10 +313,11 @@ pub extern fn vcx_credential_get_tails_hash(command_handle: CommandHandle,
                 let hash = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, hash.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credential_get_tails_hash_cb(commmand_handle: {}, rc: {}, hash: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -340,10 +346,11 @@ pub extern fn vcx_credential_get_rev_reg_id(command_handle: CommandHandle,
                 let rev_reg_id = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, rev_reg_id.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credential_get_rev_reg_id_cb(commmand_handle: {}, rc: {}, rev_reg_id: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -372,10 +379,10 @@ pub extern fn vcx_credential_get_thread_id(command_handle: CommandHandle,
                 let thread_id = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, thread_id.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_credential_get_thread_id_cb(commmand_handle: {}, rc: {}, thread_id: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -403,10 +410,10 @@ pub extern fn vcx_credential_is_revokable(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.code_num, revokable, source_id);
                 cb(command_handle, error::SUCCESS.code_num, revokable);
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_credential_is_revokable_cb(commmand_handle: {}, rc: {}) source_id: {}",
-                       command_handle, e, source_id);
-                cb(command_handle, e.into(), false);
+                       command_handle, err, source_id);
+                cb(command_handle, err.into(), false);
             }
         };
 
@@ -455,10 +462,10 @@ pub extern fn vcx_credential_create_with_msgid(command_handle: CommandHandle,
                        command_handle, source_id, error::SUCCESS.message, handle, source_id);
                 cb(command_handle, error::SUCCESS.code_num, handle, c_offer.as_ptr())
             }
-            Err(e) => {
-                warn!("vcx_credential_create_with_offer_cb(command_handle: {}, source_id: {}, rc: {}, handle: {}) source_id: {}",
-                      command_handle, source_id, e, 0, source_id);
-                cb(command_handle, e.into(), 0, ptr::null_mut());
+            Err(err) => {
+                error!("vcx_credential_create_with_offer_cb(command_handle: {}, source_id: {}, rc: {}, handle: {}) source_id: {}",
+                      command_handle, source_id, err, 0, source_id);
+                cb(command_handle, err.into(), 0, ptr::null_mut());
             }
         };
 
@@ -497,15 +504,15 @@ pub extern fn vcx_credential_send_request(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match credential::send_credential_request(credential_handle, connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credential_send_request_cb(command_handle: {}, rc: {}) source_id: {}",
-                       command_handle, x.to_string(), source_id);
-                cb(command_handle, x);
+                       command_handle, err.to_string(), source_id);
+                cb(command_handle, err);
             }
-            Err(e) => {
-                warn!("vcx_credential_send_request_cb(command_handle: {}, rc: {}) source_id: {}",
-                      command_handle, e, source_id);
-                cb(command_handle, e.into());
+            Err(err) => {
+                error!("vcx_credential_send_request_cb(command_handle: {}, rc: {}) source_id: {}",
+                      command_handle, err, source_id);
+                cb(command_handle, err.into());
             }
         };
 
@@ -555,10 +562,10 @@ pub extern fn vcx_credential_get_request_msg(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(e) => {
-                warn!("vcx_credential_get_request_msg_cb(command_handle: {}, rc: {}) source_id: {}",
-                      command_handle, e, source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+            Err(err) => {
+                error!("vcx_credential_get_request_msg_cb(command_handle: {}, rc: {}) source_id: {}",
+                      command_handle, err, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -594,17 +601,17 @@ pub extern fn vcx_credential_get_offers(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match credential::get_credential_offer_messages_with_conn_handle(connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credential_get_offers_cb(command_handle: {}, rc: {}, msg: {})",
-                       command_handle, x.to_string(), x);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, err.to_string(), err);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credential_get_offers_cb(command_handle: {}, rc: {}, msg: null)",
-                       command_handle, x);
-                cb(command_handle, x.into(), ptr::null_mut());
+                       command_handle, err);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -631,15 +638,15 @@ pub extern fn vcx_credential_decline_offer(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match credential::decline_offer(credential_handle, connection_handle, comment.as_deref()).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credential_decline_offer_cb(command_handle: {}, rc: {}) source_id: {}",
-                       command_handle, x.to_string(), source_id);
-                cb(command_handle, x);
+                       command_handle, err.to_string(), source_id);
+                cb(command_handle, err);
             }
-            Err(e) => {
-                warn!("vcx_credential_decline_offer_cb(command_handle: {}, rc: {}) source_id: {}",
-                      command_handle, e, source_id);
-                cb(command_handle, e.into());
+            Err(err) => {
+                error!("vcx_credential_decline_offer_cb(command_handle: {}, rc: {}) source_id: {}",
+                      command_handle, err, source_id);
+                cb(command_handle, err.into());
             }
         };
 
@@ -680,10 +687,10 @@ pub extern fn vcx_v2_credential_update_state(command_handle: CommandHandle,
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match credential::update_state(credential_handle, None, connection_handle).await {
             Ok(_) => (),
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_v2_credential_update_state_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0)
             }
         }
 
@@ -693,10 +700,10 @@ pub extern fn vcx_v2_credential_update_state(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, s, source_id);
                 cb(command_handle, error::SUCCESS.code_num, s)
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_v2_credential_update_state_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0)
             }
         };
 
@@ -739,10 +746,10 @@ pub extern fn vcx_v2_credential_update_state_with_message(command_handle: Comman
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match credential::update_state(credential_handle, Some(&message), connection_handle).await {
             Ok(_) => (),
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_v2_credential_update_state_with_message_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0)
             }
         }
 
@@ -752,10 +759,10 @@ pub extern fn vcx_v2_credential_update_state_with_message(command_handle: Comman
                        command_handle, error::SUCCESS.message, s, source_id);
                 cb(command_handle, error::SUCCESS.code_num, s)
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_v2_credential_update_state_with_message_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0)
             }
         };
 
@@ -798,10 +805,10 @@ pub extern fn vcx_credential_get_state(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, s, source_id);
                 cb(command_handle, error::SUCCESS.code_num, s)
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_credential_get_state_cb(command_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0)
             }
         };
 
@@ -837,17 +844,17 @@ pub extern fn vcx_credential_serialize(command_handle: CommandHandle,
 
     execute(move || {
         match credential::to_string(handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credential_serialize_cb(command_handle: {}, rc: {}, data: {}), source_id: {:?}",
-                       command_handle, error::SUCCESS.message, x, source_id);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, error::SUCCESS.message, err, source_id);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credential_serialize_cb(command_handle: {}, rc: {}, data: {}), source_id: {:?}",
-                       command_handle, x, 0, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -883,17 +890,17 @@ pub extern fn vcx_credential_deserialize(command_handle: CommandHandle,
 
     execute(move || {
         match credential::from_string(&credential_data) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credential_deserialize_cb(command_handle: {}, rc: {}, credential_handle: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, x, credential::get_source_id(x).unwrap_or_default());
+                       command_handle, error::SUCCESS.message, err, credential::get_source_id(err).unwrap_or_default());
 
-                cb(command_handle, error::SUCCESS.code_num, x);
+                cb(command_handle, error::SUCCESS.code_num, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credential_deserialize_cb(command_handle: {}, rc: {}, credential_handle: {}) source_id: {}",
-                       command_handle, x, 0, "");
-                cb(command_handle, x.into(), 0);
+                       command_handle, err, 0, "");
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -922,10 +929,10 @@ pub extern fn vcx_credential_release(handle: u32) -> u32 {
             error::SUCCESS.code_num
         }
 
-        Err(e) => {
+        Err(err) => {
             error!("vcx_credential_release(handle: {}, rc: {}), source_id: {:?}",
-                   handle, e, source_id);
-            e.into()
+                   handle, err, source_id);
+            err.into()
         }
     }
 }

--- a/libvcx/src/api_lib/api_c/credential_def.rs
+++ b/libvcx/src/api_lib/api_c/credential_def.rs
@@ -33,8 +33,8 @@ pub extern fn vcx_credentialdef_create_and_store(command_handle: CommandHandle,
         issuer_did.to_owned()
     } else {
         match settings::get_config_value(settings::CONFIG_INSTITUTION_DID) {
-            Ok(x) => x,
-            Err(x) => return x.into(),
+            Ok(err) => err,
+            Err(err) => return err.into(),
         }
     };
 
@@ -52,16 +52,16 @@ pub extern fn vcx_credentialdef_create_and_store(command_handle: CommandHandle,
                                                                   issuer_did,
                                                                   tag,
                                                                   revocation_details) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credentialdef_create_and_store_cb(command_handle: {}, rc: {}, credentialdef_handle: {}), source_id: {:?}",
-                       command_handle, error::SUCCESS.message, x, credential_def::get_source_id(x).unwrap_or_default());
-                (error::SUCCESS.code_num, x)
+                       command_handle, error::SUCCESS.message, err, credential_def::get_source_id(err).unwrap_or_default());
+                (error::SUCCESS.code_num, err)
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_credentialdef_create_and_store_cb(command_handle: {}, rc: {}, credentialdef_handle: {}), source_id: {:?}",
-                      command_handle, x, 0, "");
-                (x.into(), 0)
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_credentialdef_create_and_store_cb(command_handle: {}, rc: {}, credentialdef_handle: {}), source_id: {:?}",
+                      command_handle, err, 0, "");
+                (err.into(), 0)
             }
         };
         cb(command_handle, rc, handle);
@@ -99,7 +99,7 @@ pub extern fn vcx_credentialdef_publish(command_handle: CommandHandle,
             }
             Err(err) => {
                 set_current_error_vcx(&err);
-                warn!("vcx_credentialdef_publish_cb(command_handle: {}, rc: {}, credentialdef_handle: {}), source_id: {:?}",
+                error!("vcx_credentialdef_publish_cb(command_handle: {}, rc: {}, credentialdef_handle: {}), source_id: {:?}",
                       command_handle, err, credentialdef_handle, source_id);
                 cb(command_handle, err.into());
             }
@@ -139,17 +139,17 @@ pub extern fn vcx_credentialdef_serialize(command_handle: CommandHandle,
 
     execute(move || {
         match credential_def::to_string(credentialdef_handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credentialdef_serialize_cb(command_handle: {}, credentialdef_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                       command_handle, credentialdef_handle, error::SUCCESS.message, x, source_id);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, credentialdef_handle, error::SUCCESS.message, err, source_id);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_credentialdef_serialize_cb(command_handle: {}, credentialdef_handle: {}, rc: {}, state: {}), source_id: {:?}",
-                      command_handle, credentialdef_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_credentialdef_serialize_cb(command_handle: {}, credentialdef_handle: {}, rc: {}, state: {}), source_id: {:?}",
+                      command_handle, credentialdef_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -183,15 +183,16 @@ pub extern fn vcx_credentialdef_deserialize(command_handle: CommandHandle,
 
     execute(move || {
         let (rc, handle) = match credential_def::from_string(&credentialdef_data) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credentialdef_deserialize_cb(command_handle: {}, rc: {}, handle: {}), source_id: {}",
-                       command_handle, error::SUCCESS.message, x, credential_def::get_source_id(x).unwrap_or_default());
-                (error::SUCCESS.code_num, x)
+                       command_handle, error::SUCCESS.message, err, credential_def::get_source_id(err).unwrap_or_default());
+                (error::SUCCESS.code_num, err)
             }
-            Err(e) => {
-                warn!("vcx_credentialdef_deserialize_cb(command_handle: {}, rc: {}, handle: {}), source_id: {}",
-                      command_handle, e, 0, "");
-                (e.into(), 0)
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_credentialdef_deserialize_cb(command_handle: {}, rc: {}, handle: {}), source_id: {}",
+                      command_handle, err, 0, "");
+                (err.into(), 0)
             }
         };
         cb(command_handle, rc, handle);
@@ -227,17 +228,17 @@ pub extern fn vcx_credentialdef_get_cred_def_id(command_handle: CommandHandle,
 
     execute(move || {
         match credential_def::get_cred_def_id(cred_def_handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credentialdef_get_cred_def_id(command_handle: {}, cred_def_handle: {}, rc: {}, cred_def_id: {}) source_id: {}",
-                       command_handle, cred_def_handle, error::SUCCESS.message, x, source_id);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, cred_def_handle, error::SUCCESS.message, err, source_id);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_credentialdef_get_cred_def_id(command_handle: {}, cred_def_handle: {}, rc: {}, cred_def_id: {}) source_id: {}",
-                      command_handle, cred_def_handle, x, "", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_credentialdef_get_cred_def_id(command_handle: {}, cred_def_handle: {}, rc: {}, cred_def_id: {}) source_id: {}",
+                      command_handle, cred_def_handle, err, "", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -266,11 +267,11 @@ pub extern fn vcx_credentialdef_release(credentialdef_handle: u32) -> u32 {
             error::SUCCESS.code_num
         }
 
-        Err(x) => {
-            set_current_error_vcx(&x);
-            warn!("vcx_credentialdef_release(credentialdef_handle: {}, rc: {}), source_id: {}",
-                  credentialdef_handle, x, source_id);
-            x.into()
+        Err(err) => {
+            set_current_error_vcx(&err);
+            error!("vcx_credentialdef_release(credentialdef_handle: {}, rc: {}), source_id: {}",
+                  credentialdef_handle, err, source_id);
+            err.into()
         }
     }
 }
@@ -312,11 +313,11 @@ pub extern fn vcx_credentialdef_update_state(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, state);
                 cb(command_handle, error::SUCCESS.code_num, state);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_credentialdef_update_state(command_handle: {}, rc: {}, state: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_credentialdef_update_state(command_handle: {}, rc: {}, state: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -363,11 +364,11 @@ pub extern fn vcx_credentialdef_get_state(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, state);
                 cb(command_handle, error::SUCCESS.code_num, state);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_credentialdef_get_state(command_handle: {}, rc: {}, state: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_credentialdef_get_state(command_handle: {}, rc: {}, state: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -397,17 +398,17 @@ pub extern fn vcx_credentialdef_rotate_rev_reg_def(command_handle: CommandHandle
 
     execute(move || {
         match credential_def::rotate_rev_reg_def(credentialdef_handle, &revocation_details) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credentialdef_rotate_rev_reg_def(command_handle: {}, credentialdef_handle: {}, rc: {}, rev_reg_def: {}), source_id: {:?}",
-                       command_handle, credentialdef_handle, error::SUCCESS.message, x, source_id);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, credentialdef_handle, error::SUCCESS.message, err, source_id);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_credentialdef_rotate_rev_reg_def(command_handle: {}, credentialdef_handle: {}, rc: {}, rev_reg_def: {}), source_id: {:?}",
-                      command_handle, credentialdef_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_credentialdef_rotate_rev_reg_def(command_handle: {}, credentialdef_handle: {}, rc: {}, rev_reg_def: {}), source_id: {:?}",
+                      command_handle, credentialdef_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -441,11 +442,11 @@ pub extern fn vcx_credentialdef_publish_revocations(command_handle: CommandHandl
                        command_handle, credentialdef_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_credentialdef_publish_revocations(command_handle: {}, credentialdef_handle: {}, rc: {})",
-                      command_handle, credentialdef_handle, x);
-                cb(command_handle, x.into());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_credentialdef_publish_revocations(command_handle: {}, credentialdef_handle: {}, rc: {})",
+                      command_handle, credentialdef_handle, err);
+                cb(command_handle, err.into());
             }
         };
 
@@ -468,18 +469,18 @@ pub extern fn vcx_credentialdef_get_tails_hash(command_handle: CommandHandle,
 
     execute(move || {
         match credential_def::get_tails_hash(handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credentialdef_get_tails_hash_cb(command_handle: {}, rc: {}, hash: {}), source_id: {}",
-                       command_handle, error::SUCCESS.message, x, credential_def::get_source_id(handle).unwrap_or_default());
+                       command_handle, error::SUCCESS.message, err, credential_def::get_source_id(handle).unwrap_or_default());
 
-                let hash = CStringUtils::string_to_cstring(x);
+                let hash = CStringUtils::string_to_cstring(err);
                 cb(command_handle, 0, hash.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credentialdef_get_tails_hash_cb(command_handle: {}, rc: {}, hash: {}), source_id: {}",
-                       command_handle, x, "null", credential_def::get_source_id(handle).unwrap_or_default());
-                cb(command_handle, x.into(), ptr::null());
+                       command_handle, err, "null", credential_def::get_source_id(handle).unwrap_or_default());
+                cb(command_handle, err.into(), ptr::null());
             }
         };
 
@@ -502,18 +503,18 @@ pub extern fn vcx_credentialdef_get_rev_reg_id(command_handle: CommandHandle,
 
     execute(move || {
         match credential_def::get_rev_reg_id(handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_credentialdef_get_rev_reg_id_cb(command_handle: {}, rc: {}, rev_reg_id: {}), source_id: {}",
-                       command_handle, error::SUCCESS.message, x, credential_def::get_source_id(handle).unwrap_or_default());
+                       command_handle, error::SUCCESS.message, err, credential_def::get_source_id(handle).unwrap_or_default());
 
-                let rev_reg_id = CStringUtils::string_to_cstring(x);
+                let rev_reg_id = CStringUtils::string_to_cstring(err);
                 cb(command_handle, 0, rev_reg_id.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_credentialdef_get_rev_reg_id(command_handle: {}, rc: {}, rev_reg_id: {}), source_id: {}",
-                       command_handle, x, "null", credential_def::get_source_id(handle).unwrap_or_default());
-                cb(command_handle, x.into(), ptr::null());
+                       command_handle, err, "null", credential_def::get_source_id(handle).unwrap_or_default());
+                cb(command_handle, err.into(), ptr::null());
             }
         };
 

--- a/libvcx/src/api_lib/api_c/disclosed_proof.rs
+++ b/libvcx/src/api_lib/api_c/disclosed_proof.rs
@@ -86,16 +86,16 @@ pub extern fn vcx_disclosed_proof_create_with_request(command_handle: CommandHan
 
     execute(move || {
         match disclosed_proof::create_proof(&source_id, &proof_req) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_disclosed_proof_create_with_request_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, x, source_id);
-                cb(command_handle, 0, x);
+                       command_handle, error::SUCCESS.message, err, source_id);
+                cb(command_handle, 0, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_create_with_request_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                       command_handle, x, 0, source_id);
-                cb(command_handle, x.into(), 0);
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -145,8 +145,9 @@ pub extern fn vcx_disclosed_proof_create_with_msgid(command_handle: CommandHandl
                 let msg = CStringUtils::string_to_cstring(request);
                 cb(command_handle, error::SUCCESS.code_num, handle, msg.as_ptr())
             }
-            Err(e) => {
-                cb(command_handle, e.into(), 0, ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                cb(command_handle, err.into(), 0, ptr::null());
             }
         };
 
@@ -189,11 +190,11 @@ pub extern fn vcx_disclosed_proof_send_proof(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_send_proof_cb(command_handle: {}, rc: {}) source_id: {}",
-                       command_handle, x, source_id);
-                cb(command_handle, x.into());
+                       command_handle, err, source_id);
+                cb(command_handle, err.into());
             }
         };
 
@@ -236,11 +237,11 @@ pub extern fn vcx_disclosed_proof_reject_proof(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_reject_proof_cb(command_handle: {}, rc: {}) source_id: {}",
-                       command_handle, x, source_id);
-                cb(command_handle, x.into());
+                       command_handle, err, source_id);
+                cb(command_handle, err.into());
             }
         };
 
@@ -281,11 +282,11 @@ pub extern fn vcx_disclosed_proof_get_proof_msg(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_get_proof_msg_cb(command_handle: {}, rc: {}) source_id: {}",
-                       command_handle, x, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+                       command_handle, err, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -326,11 +327,11 @@ pub extern fn vcx_disclosed_proof_get_reject_msg(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_get_reject_msg_cb(command_handle: {}, rc: {}) source_id: {}",
-                       command_handle, x, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+                       command_handle, err, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -365,17 +366,17 @@ pub extern fn vcx_disclosed_proof_get_requests(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match disclosed_proof::get_proof_request_messages(connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_disclosed_proof_get_requests_cb(command_handle: {}, rc: {}, msg: {})",
-                       command_handle, error::SUCCESS.message, x);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, error::SUCCESS.message, err);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_get_requests_cb(command_handle: {}, rc: {}, msg: {})",
-                       command_handle, error::SUCCESS.message, x);
-                cb(command_handle, x.into(), ptr::null_mut());
+                       command_handle, error::SUCCESS.message, err);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -418,10 +419,11 @@ pub extern fn vcx_disclosed_proof_get_state(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, s, source_id);
                 cb(command_handle, error::SUCCESS.code_num, s)
             }
-            Err(e) => {
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_get_state_cb(command_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0)
             }
         };
 
@@ -445,10 +447,10 @@ pub extern fn vcx_disclosed_proof_get_proof_request_attachment(command_handle: C
 
     execute(move || {
         match disclosed_proof::get_proof_request_attachment(proof_handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_disclosed_proof_get_attachment_cb(command_handle: {}, rc: {}, attachment: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, x, source_id);
-                let attrs = CStringUtils::string_to_cstring(x);
+                       command_handle, error::SUCCESS.message, err, source_id);
+                let attrs = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, attrs.as_ptr());
             }
             Err(err) => {
@@ -485,10 +487,10 @@ pub extern fn vcx_v2_disclosed_proof_update_state(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, s, source_id);
                 cb(command_handle, error::SUCCESS.code_num, s)
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_v2_disclosed_proof_update_state_cb(command_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0)
             }
         };
 
@@ -535,10 +537,10 @@ pub extern fn vcx_v2_disclosed_proof_update_state_with_message(command_handle: C
                        command_handle, error::SUCCESS.message, state, source_id);
                 cb(command_handle, error::SUCCESS.code_num, state)
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_v2_disclosed_proof_update_state_with_message_cb(command_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, e, 0, source_id);
-                cb(command_handle, e.into(), 0)
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0)
             }
         };
 
@@ -573,17 +575,17 @@ pub extern fn vcx_disclosed_proof_serialize(command_handle: CommandHandle,
 
     execute(move || {
         match disclosed_proof::to_string(proof_handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_disclosed_proof_serialize_cb(command_handle: {}, rc: {}, data: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, x, source_id);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, error::SUCCESS.message, err, source_id);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_serialize_cb(command_handle: {}, rc: {}, data: {}) source_id: {}",
-                       command_handle, x, 0, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -619,17 +621,17 @@ pub extern fn vcx_disclosed_proof_deserialize(command_handle: CommandHandle,
 
     execute(move || {
         match disclosed_proof::from_string(&proof_data) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_disclosed_proof_deserialize_cb(command_handle: {}, rc: {}, proof_handle: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, x, disclosed_proof::get_source_id(x).unwrap_or_default());
+                       command_handle, error::SUCCESS.message, err, disclosed_proof::get_source_id(err).unwrap_or_default());
 
-                cb(command_handle, 0, x);
+                cb(command_handle, 0, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_deserialize_cb(command_handle: {}, rc: {}, proof_handle: {}) source_id: {}",
-                       command_handle, x, 0, "");
-                cb(command_handle, x.into(), 0);
+                       command_handle, err, 0, "");
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -667,17 +669,17 @@ pub extern fn vcx_disclosed_proof_retrieve_credentials(command_handle: CommandHa
 
     execute(move || {
         match disclosed_proof::retrieve_credentials(proof_handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_disclosed_proof_retrieve_credentials(command_handle: {}, rc: {}, data: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, x, source_id);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, error::SUCCESS.message, err, source_id);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_retrieve_credentials(command_handle: {}, rc: {}, data: {}) source_id: {}",
-                       command_handle, x, 0, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+                       command_handle, err, 0, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -751,11 +753,11 @@ pub extern fn vcx_disclosed_proof_generate_proof(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_generate_proof(command_handle: {}, rc: {}) source_id: {}",
-                       command_handle, x, source_id);
-                cb(command_handle, x.into());
+                       command_handle, err, source_id);
+                cb(command_handle, err.into());
             }
         };
 
@@ -850,11 +852,11 @@ pub extern fn vcx_disclosed_proof_decline_presentation_request(command_handle: u
                        command_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_disclosed_proof_decline_presentation_request(command_handle: {}, rc: {}) source_id: {}",
-                       command_handle, x, source_id);
-                cb(command_handle, x.into());
+                       command_handle, err, source_id);
+                cb(command_handle, err.into());
             }
         };
 
@@ -883,10 +885,10 @@ pub extern fn vcx_disclosed_proof_get_thread_id(command_handle: CommandHandle,
                 let thread_id = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, thread_id.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_disclosed_proof_get_thread_id_cb(commmand_handle: {}, rc: {}, thread_id: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -914,10 +916,10 @@ pub extern fn vcx_disclosed_proof_release(handle: u32) -> u32 {
                    handle, error::SUCCESS.message, source_id);
             error::SUCCESS.code_num
         }
-        Err(e) => {
+        Err(err) => {
             error!("vcx_disclosed_proof_release(handle: {}, rc: {}), source_id: {:?}",
-                   handle, e, source_id);
-            e.into()
+                   handle, err, source_id);
+            err.into()
         }
     }
 }

--- a/libvcx/src/api_lib/api_c/filters.rs
+++ b/libvcx/src/api_lib/api_c/filters.rs
@@ -38,11 +38,11 @@ pub extern fn vcx_filter_proof_requests_by_name(command_handle: CommandHandle,
 
     execute(move || {
         match filters::filter_proof_requests_by_name(&requests, &match_name) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_filter_proof_requests_by_name_cb(command_handle: {}, requests: {}, rc: {}, requests: {})",
-                       command_handle, requests, error::SUCCESS.message, x);
-                let x = CStringUtils::string_to_cstring(x);
-                cb(command_handle, error::SUCCESS.code_num, x.as_ptr());
+                       command_handle, requests, error::SUCCESS.message, err);
+                let err = CStringUtils::string_to_cstring(err);
+                cb(command_handle, error::SUCCESS.code_num, err.as_ptr());
             }
             Err(err) => {
                 set_current_error_vcx(&err);

--- a/libvcx/src/api_lib/api_c/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_c/issuer_credential.rs
@@ -93,16 +93,16 @@ pub extern fn vcx_issuer_create_credential(command_handle: CommandHandle,
 
     execute(move || {
         let (rc, handle) = match issuer_credential::issuer_credential_create(source_id) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_issuer_create_credential_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, x, issuer_credential::get_source_id(x).unwrap_or_default());
-                (error::SUCCESS.code_num, x)
+                       command_handle, error::SUCCESS.message, err, issuer_credential::get_source_id(err).unwrap_or_default());
+                (error::SUCCESS.code_num, err)
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_create_credential_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                      command_handle, x, 0, "");
-                (x.into(), 0)
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_create_credential_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
+                      command_handle, err, 0, "");
+                (err.into(), 0)
             }
         };
 
@@ -155,16 +155,16 @@ pub extern fn vcx_issuer_send_credential_offer(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         let err = match issuer_credential::send_credential_offer(credential_handle, cred_def_handle, connection_handle, &credential_data, None).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_issuer_send_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
                        command_handle, credential_handle, error::SUCCESS.message, source_id);
-                x
+                err
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_send_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
-                      command_handle, credential_handle, x, source_id);
-                x.into()
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_send_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
+                      command_handle, credential_handle, err, source_id);
+                err.into()
             }
         };
 
@@ -192,16 +192,16 @@ pub extern fn vcx_issuer_send_credential_offer_v2(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         let err = match issuer_credential::send_credential_offer_v2(credential_handle, connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_issuer_send_credential_offer_v2(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
                        command_handle, credential_handle, error::SUCCESS.message, source_id);
-                x
+                err
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_send_credential_offer_v2(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
-                      command_handle, credential_handle, x, source_id);
-                x.into()
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_send_credential_offer_v2(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
+                      command_handle, credential_handle, err, source_id);
+                err.into()
             }
         };
 
@@ -245,11 +245,11 @@ pub extern fn vcx_issuer_get_credential_offer_msg(command_handle: CommandHandle,
                        command_handle, credential_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, offer_msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_get_credential_offer_msg_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
-                      command_handle, credential_handle, x, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_get_credential_offer_msg_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
+                      command_handle, credential_handle, err, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -291,11 +291,11 @@ pub extern fn vcx_issuer_build_credential_offer_msg(command_handle: CommandHandl
                        command_handle, credential_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, offer_msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_build_credential_offer_msg_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
-                      command_handle, credential_handle, x, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_build_credential_offer_msg_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
+                      command_handle, credential_handle, err, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -326,11 +326,11 @@ pub extern fn vcx_mark_credential_offer_msg_sent(command_handle: CommandHandle,
                        command_handle, credential_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, offer_msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_mark_credential_offer_msg_sent_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
-                      command_handle, credential_handle, x, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_mark_credential_offer_msg_sent_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
+                      command_handle, credential_handle, err, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -375,16 +375,16 @@ pub extern fn vcx_v2_issuer_credential_update_state(command_handle: CommandHandl
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match issuer_credential::update_state(credential_handle, None, connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_v2_issuer_credential_update_state_cb(command_handle: {}, credential_handle: {}, connection_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, credential_handle, connection_handle, error::SUCCESS.message, x, source_id);
-                cb(command_handle, error::SUCCESS.code_num, x);
+                       command_handle, credential_handle, connection_handle, error::SUCCESS.message, err, source_id);
+                cb(command_handle, error::SUCCESS.code_num, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_v2_issuer_credential_update_state_cb(command_handle: {}, credential_handle: {}, connection_handle: {}, rc: {}, state: {}) source_id: {}",
-                      command_handle, credential_handle, connection_handle, x, 0, source_id);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_v2_issuer_credential_update_state_cb(command_handle: {}, credential_handle: {}, connection_handle: {}, rc: {}, state: {}) source_id: {}",
+                      command_handle, credential_handle, connection_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -431,16 +431,16 @@ pub extern fn vcx_v2_issuer_credential_update_state_with_message(command_handle:
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match issuer_credential::update_state(credential_handle, Some(&message), connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_v2_issuer_credential_update_state_with_message_cb(command_handle: {}, credential_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, credential_handle, error::SUCCESS.message, x, source_id);
-                cb(command_handle, error::SUCCESS.code_num, x);
+                       command_handle, credential_handle, error::SUCCESS.message, err, source_id);
+                cb(command_handle, error::SUCCESS.code_num, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_v2_issuer_credential_update_state_with_message_cb(command_handle: {}, credential_handle: {}, rc: {}, state: {}) source_id: {}",
-                      command_handle, credential_handle, x, 0, source_id);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_v2_issuer_credential_update_state_with_message_cb(command_handle: {}, credential_handle: {}, rc: {}, state: {}) source_id: {}",
+                      command_handle, credential_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -480,16 +480,16 @@ pub extern fn vcx_issuer_credential_get_state(command_handle: CommandHandle,
 
     execute(move || {
         match issuer_credential::get_state(credential_handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_issuer_credential_get_state_cb(command_handle: {}, credential_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, credential_handle, error::SUCCESS.message, x, source_id);
-                cb(command_handle, error::SUCCESS.code_num, x);
+                       command_handle, credential_handle, error::SUCCESS.message, err, source_id);
+                cb(command_handle, error::SUCCESS.code_num, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_credential_get_state_cb(command_handle: {}, credential_handle: {}, rc: {}, state: {}) source_id: {}",
-                      command_handle, credential_handle, x, 0, source_id);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_credential_get_state_cb(command_handle: {}, credential_handle: {}, rc: {}, state: {}) source_id: {}",
+                      command_handle, credential_handle, err, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -538,16 +538,16 @@ pub extern fn vcx_issuer_send_credential(command_handle: CommandHandle,
            command_handle, credential_handle, connection_handle, source_id);
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         let err = match issuer_credential::send_credential(credential_handle, connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_issuer_send_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
                        command_handle, credential_handle, error::SUCCESS.message, source_id);
-                x
+                err
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_send_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
-                      command_handle, credential_handle, x, source_id);
-                x.into()
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_send_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
+                      command_handle, credential_handle, err, source_id);
+                err.into()
             }
         };
 
@@ -593,11 +593,11 @@ pub extern fn vcx_issuer_get_credential_msg(command_handle: CommandHandle,
                        command_handle, credential_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_get_credential_msg_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
-                      command_handle, credential_handle, x, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_get_credential_msg_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
+                      command_handle, credential_handle, err, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -626,11 +626,11 @@ pub extern fn vcx_issuer_credential_get_rev_reg_id(command_handle: CommandHandle
                        command_handle, credential_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, rev_reg_id.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_credential_get_rev_reg_id_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
-                      command_handle, credential_handle, x, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_credential_get_rev_reg_id_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
+                      command_handle, credential_handle, err, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -658,11 +658,11 @@ pub extern fn vcx_issuer_credential_is_revokable(command_handle: CommandHandle,
                        command_handle, credential_handle, revokable, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, revokable);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_credential_is_revokable_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
-                      command_handle, credential_handle, x, source_id);
-                cb(command_handle, x.into(), false);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_credential_is_revokable_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
+                      command_handle, credential_handle, err, source_id);
+                cb(command_handle, err.into(), false);
             }
         };
 
@@ -702,17 +702,17 @@ pub extern fn vcx_issuer_credential_serialize(command_handle: CommandHandle,
            command_handle, credential_handle, source_id);
     execute(move || {
         match issuer_credential::to_string(credential_handle) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_issuer_credential_serialize_cb(command_handle: {}, credential_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, credential_handle, error::SUCCESS.message, x, source_id);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, credential_handle, error::SUCCESS.message, err, source_id);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_issuer_credential_serialize_cb(command_handle: {}, credential_handle: {}, rc: {}, state: {}) source_id: {})",
-                       command_handle, credential_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+                       command_handle, credential_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -746,16 +746,16 @@ pub extern fn vcx_issuer_credential_deserialize(command_handle: CommandHandle,
 
     execute(move || {
         let (rc, handle) = match issuer_credential::from_string(&credential_data) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_issuer_credential_deserialize_cb(command_handle: {}, rc: {}, handle: {}), source_id: {}",
-                       command_handle, error::SUCCESS.message, x, issuer_credential::get_source_id(x).unwrap_or_default());
-                (error::SUCCESS.code_num, x)
+                       command_handle, error::SUCCESS.message, err, issuer_credential::get_source_id(err).unwrap_or_default());
+                (error::SUCCESS.code_num, err)
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_credential_deserialize_cb(command_handle: {}, rc: {}, handle: {})",
-                      command_handle, x, 0);
-                (x.into(), 0)
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_credential_deserialize_cb(command_handle: {}, rc: {}, handle: {})",
+                      command_handle, err, 0);
+                (err.into(), 0)
             }
         };
 
@@ -784,10 +784,10 @@ pub extern fn vcx_issuer_credential_release(credential_handle: u32) -> u32 {
                    credential_handle, error::SUCCESS.message, source_id);
             error::SUCCESS.code_num
         }
-        Err(e) => {
-            warn!("(vcx_issuer_credential_release credential_handle: {}, rc: {}), source_id: {}",
-                  credential_handle, e, source_id);
-            e.into()
+        Err(err) => {
+            error!("(vcx_issuer_credential_release credential_handle: {}, rc: {}), source_id: {}",
+                  credential_handle, err, source_id);
+            err.into()
         }
     }
 }
@@ -820,11 +820,11 @@ pub extern fn vcx_issuer_revoke_credential(command_handle: CommandHandle,
                       command_handle, credential_handle, error::SUCCESS.message, source_id);
                 error::SUCCESS.code_num
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_revoke_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
-                      command_handle, credential_handle, x, source_id);
-                x.into()
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_revoke_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
+                      command_handle, credential_handle, err, source_id);
+                err.into()
             }
         };
 
@@ -853,11 +853,11 @@ pub extern fn vcx_issuer_revoke_credential_local(command_handle: CommandHandle,
                       command_handle, credential_handle, error::SUCCESS.message, source_id);
                 error::SUCCESS.code_num
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_issuer_revoke_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
-                      command_handle, credential_handle, x, source_id);
-                x.into()
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_issuer_revoke_credential_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
+                      command_handle, credential_handle, err, source_id);
+                err.into()
             }
         };
 
@@ -889,10 +889,10 @@ pub extern fn vcx_issuer_credential_get_thread_id(command_handle: CommandHandle,
                 let thread_id = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, thread_id.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_issuer_credential_get_thread_id_cb(commmand_handle: {}, rc: {}, thread_id: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 

--- a/libvcx/src/api_lib/api_c/out_of_band.rs
+++ b/libvcx/src/api_lib/api_c/out_of_band.rs
@@ -30,11 +30,11 @@ pub extern fn vcx_out_of_band_sender_create(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, handle);
                 cb(command_handle, error::SUCCESS.code_num, handle);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_sender_create_cb(command_handle: {}, rc: {}, handle: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_sender_create_cb(command_handle: {}, rc: {}, handle: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), 0);
             }
         }
         Ok(())
@@ -61,11 +61,11 @@ pub extern fn vcx_out_of_band_receiver_create(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, handle);
                 cb(command_handle, error::SUCCESS.code_num, handle);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_receiver_create_cb(command_handle: {}, rc: {}, handle: {}):",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_receiver_create_cb(command_handle: {}, rc: {}, handle: {}):",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), 0);
             }
         }
         Ok(())
@@ -92,10 +92,11 @@ pub extern fn vcx_out_of_band_sender_get_thread_id(command_handle: CommandHandle
                 let thid = CStringUtils::string_to_cstring(thid);
                 cb(command_handle, error::SUCCESS.code_num, thid.as_ptr());
             }
-            Err(x) => {
-                warn!("vcx_out_of_band_sender_get_thread_id_cb(command_handle: {}, rc: {}, thid: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_sender_get_thread_id_cb(command_handle: {}, rc: {}, thid: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -122,10 +123,11 @@ pub extern fn vcx_out_of_band_receiver_get_thread_id(command_handle: CommandHand
                 let thid = CStringUtils::string_to_cstring(thid);
                 cb(command_handle, error::SUCCESS.code_num, thid.as_ptr());
             }
-            Err(x) => {
-                warn!("vcx_out_of_band_receiver_get_thread_id_cb(command_handle: {}, rc: {}, thid: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_receiver_get_thread_id_cb(command_handle: {}, rc: {}, thid: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -153,11 +155,11 @@ pub extern fn vcx_out_of_band_sender_append_message(command_handle: CommandHandl
                        command_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_sender_append_message_cb(command_handle: {}, rc: {})",
-                      command_handle, x);
-                cb(command_handle, x.into());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_sender_append_message_cb(command_handle: {}, rc: {})",
+                      command_handle, err);
+                cb(command_handle, err.into());
             }
         }
         Ok(())
@@ -185,11 +187,11 @@ pub extern fn vcx_out_of_band_sender_append_service(command_handle: CommandHandl
                        command_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_sender_append_service_cb(command_handle: {}, rc: {})",
-                      command_handle, x);
-                cb(command_handle, x.into());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_sender_append_service_cb(command_handle: {}, rc: {})",
+                      command_handle, err);
+                cb(command_handle, err.into());
             }
         }
         Ok(())
@@ -217,11 +219,11 @@ pub extern fn vcx_out_of_band_sender_append_service_did(command_handle: CommandH
                        command_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_sender_append_service_did_cb(command_handle: {}, rc: {})",
-                      command_handle, x);
-                cb(command_handle, x.into());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_sender_append_service_did_cb(command_handle: {}, rc: {})",
+                      command_handle, err);
+                cb(command_handle, err.into());
             }
         }
         Ok(())
@@ -248,11 +250,11 @@ pub extern fn vcx_out_of_band_receiver_extract_message(command_handle: CommandHa
                 let msg = CStringUtils::string_to_cstring(msg);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_receiver_extract_message_cb(command_handle: {}, rc: {}, msg: {})",
-                      command_handle, x, "");
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_receiver_extract_message_cb(command_handle: {}, rc: {}, msg: {})",
+                      command_handle, err, "");
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -279,11 +281,11 @@ pub extern fn vcx_out_of_band_to_message(command_handle: CommandHandle,
                 let msg = CStringUtils::string_to_cstring(msg);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_to_message_cb(command_handle: {}, rc: {}, msg: {})",
-                      command_handle, x, "");
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_to_message_cb(command_handle: {}, rc: {}, msg: {})",
+                      command_handle, err, "");
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -320,11 +322,11 @@ pub extern fn vcx_out_of_band_receiver_connection_exists(command_handle: Command
                        command_handle, error::SUCCESS.message, conn_handle, found_one);
                 cb(command_handle, error::SUCCESS.code_num, conn_handle, found_one);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_receiver_connection_exists_cb(command_handle: {}, rc: {}, conn_handle: {}, found_one: {})",
-                      command_handle, x, 0, false);
-                cb(command_handle, x.into(), 0, false);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_receiver_connection_exists_cb(command_handle: {}, rc: {}, conn_handle: {}, found_one: {})",
+                      command_handle, err, 0, false);
+                cb(command_handle, err.into(), 0, false);
             }
         }
         Ok(())
@@ -351,11 +353,11 @@ pub extern fn vcx_out_of_band_receiver_build_connection(command_handle: CommandH
                 let connection = CStringUtils::string_to_cstring(connection);
                 cb(command_handle, error::SUCCESS.code_num, connection.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_receiver_build_connection_cb(command_handle: {}, rc: {}, connection: {})",
-                      command_handle, x, "");
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_receiver_build_connection_cb(command_handle: {}, rc: {}, connection: {})",
+                      command_handle, err, "");
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -382,11 +384,11 @@ pub extern fn vcx_out_of_band_sender_serialize(command_handle: CommandHandle,
                 let oob_json = CStringUtils::string_to_cstring(oob_json);
                 cb(command_handle, error::SUCCESS.code_num, oob_json.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_sender_serialize_cb(command_handle: {}, rc: {}, oob_json: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_sender_serialize_cb(command_handle: {}, rc: {}, oob_json: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -413,11 +415,11 @@ pub extern fn vcx_out_of_band_receiver_serialize(command_handle: CommandHandle,
                 let oob_json = CStringUtils::string_to_cstring(oob_json);
                 cb(command_handle, error::SUCCESS.code_num, oob_json.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_receiver_serialize_cb(command_handle: {}, rc: {}, oob_json: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), ptr::null());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_receiver_serialize_cb(command_handle: {}, rc: {}, oob_json: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), ptr::null());
             }
         }
         Ok(())
@@ -444,11 +446,11 @@ pub extern fn vcx_out_of_band_sender_deserialize(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.message, handle);
                 cb(command_handle, error::SUCCESS.code_num, handle);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_sender_deserialize_cb(command_handle: {}, rc: {}, handle: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_sender_deserialize_cb(command_handle: {}, rc: {}, handle: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), 0);
             }
         }
         Ok(())
@@ -475,11 +477,11 @@ pub extern fn vcx_out_of_band_receiver_deserialize(command_handle: CommandHandle
                        command_handle, error::SUCCESS.message, handle);
                 cb(command_handle, error::SUCCESS.code_num, handle);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_out_of_band_receiver_deserialize_cb(command_handle: {}, rc: {}, handle: {})",
-                      command_handle, x, 0);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_out_of_band_receiver_deserialize_cb(command_handle: {}, rc: {}, handle: {})",
+                      command_handle, err, 0);
+                cb(command_handle, err.into(), 0);
             }
         }
         Ok(())
@@ -498,10 +500,10 @@ pub extern fn vcx_out_of_band_sender_release(handle: u32) -> u32 {
                    handle, error::SUCCESS.message);
             error::SUCCESS.code_num
         }
-        Err(e) => {
-            warn!("vcx_out_of_band_sender_release(handle: {}), rc: {})",
-                  handle, e);
-            e.into()
+        Err(err) => {
+            error!("vcx_out_of_band_sender_release(handle: {}), rc: {})",
+                  handle, err);
+            err.into()
         }
     }
 }
@@ -516,10 +518,10 @@ pub extern fn vcx_out_of_band_receiver_release(handle: u32) -> u32 {
                    handle, error::SUCCESS.message);
             error::SUCCESS.code_num
         }
-        Err(e) => {
-            warn!("vcx_out_of_band_receiver_release(handle: {}), rc: {})",
-                  handle, e);
-            e.into()
+        Err(err) => {
+            error!("vcx_out_of_band_receiver_release(handle: {}), rc: {})",
+                  handle, err);
+            err.into()
         }
     }
 }

--- a/libvcx/src/api_lib/api_c/proof.rs
+++ b/libvcx/src/api_lib/api_c/proof.rs
@@ -137,16 +137,16 @@ pub extern fn vcx_proof_create(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         let (rc, handle) = match proof::create_proof(source_id, requested_attrs, requested_predicates, revocation_interval, name).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_proof_create_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, x, proof::get_source_id(x).unwrap_or_default());
-                (error::SUCCESS.code_num, x)
+                       command_handle, error::SUCCESS.message, err, proof::get_source_id(err).unwrap_or_default());
+                (error::SUCCESS.code_num, err)
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_proof_create_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                      command_handle, x, 0, x);
-                (x.into(), 0)
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_proof_create_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
+                      command_handle, err, 0, err);
+                (err.into(), 0)
             }
         };
         cb(command_handle, rc, handle);
@@ -191,16 +191,16 @@ pub extern fn vcx_v2_proof_update_state(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match proof::update_state(proof_handle, None, connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_v2_proof_update_state_cb(command_handle: {}, rc: {}, proof_handle: {}, state: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, proof_handle, x, source_id);
-                cb(command_handle, error::SUCCESS.code_num, x);
+                       command_handle, error::SUCCESS.message, proof_handle, err, source_id);
+                cb(command_handle, error::SUCCESS.code_num, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_v2_proof_update_state_cb(command_handle: {}, rc: {}, proof_handle: {}, state: {}) source_id: {}",
-                       command_handle, x, proof_handle, 0, source_id);
-                cb(command_handle, x.into(), 0);
+                       command_handle, err, proof_handle, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         }
 
@@ -247,16 +247,16 @@ pub extern fn vcx_v2_proof_update_state_with_message(command_handle: CommandHand
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match proof::update_state(proof_handle, Some(&message), connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_v2_proof_update_state_with_message_cb(command_handle: {}, rc: {}, proof_handle: {}, state: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, proof_handle, x, source_id);
-                cb(command_handle, error::SUCCESS.code_num, x);
+                       command_handle, error::SUCCESS.message, proof_handle, err, source_id);
+                cb(command_handle, error::SUCCESS.code_num, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_v2_proof_update_state_with_message_cb(command_handle: {}, rc: {}, proof_handle: {}, state: {}) source_id: {}",
-                      command_handle, x, proof_handle, 0, source_id);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_v2_proof_update_state_with_message_cb(command_handle: {}, rc: {}, proof_handle: {}, state: {}) source_id: {}",
+                      command_handle, err, proof_handle, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         }
 
@@ -296,16 +296,16 @@ pub extern fn vcx_proof_get_state(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match proof::get_state(proof_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_proof_get_state_cb(command_handle: {}, rc: {}, proof_handle: {}, state: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, proof_handle, x, source_id);
-                cb(command_handle, error::SUCCESS.code_num, x);
+                       command_handle, error::SUCCESS.message, proof_handle, err, source_id);
+                cb(command_handle, error::SUCCESS.code_num, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_proof_get_state_cb(command_handle: {}, rc: {}, proof_handle: {}, state: {}) source_id: {}",
-                      command_handle, x, proof_handle, 0, source_id);
-                cb(command_handle, x.into(), 0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_proof_get_state_cb(command_handle: {}, rc: {}, proof_handle: {}, state: {}) source_id: {}",
+                      command_handle, err, proof_handle, 0, source_id);
+                cb(command_handle, err.into(), 0);
             }
         }
 
@@ -339,17 +339,17 @@ pub extern fn vcx_proof_serialize(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         match proof::to_string(proof_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_proof_serialize_cb(command_handle: {}, proof_handle: {}, rc: {}, state: {}) source_id: {}",
-                       command_handle, proof_handle, error::SUCCESS.message, x, source_id);
-                let msg = CStringUtils::string_to_cstring(x);
+                       command_handle, proof_handle, error::SUCCESS.message, err, source_id);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_proof_serialize_cb(command_handle: {}, proof_handle: {}, rc: {}, state: {}) source_id: {}",
-                      command_handle, proof_handle, x, "null", source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_proof_serialize_cb(command_handle: {}, proof_handle: {}, rc: {}, state: {}) source_id: {}",
+                      command_handle, proof_handle, err, "null", source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -384,16 +384,16 @@ pub extern fn vcx_proof_deserialize(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         let (rc, handle) = match proof::from_string(&proof_data).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_proof_deserialize_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                       command_handle, error::SUCCESS.message, x, proof::get_source_id(x).unwrap_or_default());
-                (error::SUCCESS.code_num, x)
+                       command_handle, error::SUCCESS.message, err, proof::get_source_id(err).unwrap_or_default());
+                (error::SUCCESS.code_num, err)
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_proof_deserialize_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
-                      command_handle, x, 0, "");
-                (x.into(), 0)
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_proof_deserialize_cb(command_handle: {}, rc: {}, handle: {}) source_id: {}",
+                      command_handle, err, 0, "");
+                (err.into(), 0)
             }
         };
         cb(command_handle, rc, handle);
@@ -422,10 +422,11 @@ pub extern fn vcx_proof_release(proof_handle: u32) -> u32 {
                    proof_handle, error::SUCCESS.message, source_id);
             error::SUCCESS.code_num
         }
-        Err(e) => {
-            warn!("vcx_proof_release(proof_handle: {}, rc: {}), source_id: {}",
-                  proof_handle, e, source_id);
-            e.into()
+        Err(err) => {
+            set_current_error_vcx(&err);
+            error!("vcx_proof_release(proof_handle: {}, rc: {}), source_id: {}",
+                  proof_handle, err, source_id);
+            err.into()
         }
     }
 }
@@ -458,16 +459,16 @@ pub extern fn vcx_proof_send_request(command_handle: CommandHandle,
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
         let err = match proof::send_proof_request(proof_handle, connection_handle).await {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_proof_send_request_cb(command_handle: {}, rc: {}, proof_handle: {}) source_id: {}",
                        command_handle, 0, proof_handle, source_id);
-                x
+                err
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_proof_send_request_cb(command_handle: {}, rc: {}, proof_handle: {}) source_id: {}",
-                      command_handle, x, proof_handle, source_id);
-                x.into()
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_proof_send_request_cb(command_handle: {}, rc: {}, proof_handle: {}) source_id: {}",
+                      command_handle, err, proof_handle, source_id);
+                err.into()
             }
         };
 
@@ -513,11 +514,11 @@ pub extern fn vcx_proof_get_request_msg(command_handle: CommandHandle,
                        command_handle, error::SUCCESS.code_num, proof_handle, source_id);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_proof_get_request_msg_cb(command_handle: {}, rc: {}, proof_handle: {}) source_id: {}",
-                      command_handle, x, proof_handle, source_id);
-                cb(command_handle, x.into(), ptr::null_mut())
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_proof_get_request_msg_cb(command_handle: {}, rc: {}, proof_handle: {}) source_id: {}",
+                      command_handle, err, proof_handle, source_id);
+                cb(command_handle, err.into(), ptr::null_mut())
             }
         };
 
@@ -562,7 +563,7 @@ pub extern fn vcx_get_proof_msg(command_handle: CommandHandle,
             }
             Err(err) => {
                 set_current_error_vcx(&err);
-                warn!("vcx_get_proof_cb(command_handle: {}, proof_handle: {}, rc: {}, proof: {}) source_id: {}", command_handle, proof_handle, err, "null", source_id);
+                error!("vcx_get_proof_cb(command_handle: {}, proof_handle: {}, rc: {}, proof: {}) source_id: {}", command_handle, proof_handle, err, "null", source_id);
                 cb(command_handle, err.into(), proof::get_proof_state(proof_handle).await.unwrap_or(0), ptr::null_mut());
             }
         };
@@ -593,11 +594,11 @@ pub extern fn vcx_mark_presentation_request_msg_sent(command_handle: CommandHand
                        command_handle, proof_handle, error::SUCCESS.message, source_id);
                 cb(command_handle, error::SUCCESS.code_num, offer_msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
-                warn!("vcx_mark_presentation_request_msg_sent_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
-                      command_handle, proof_handle, x, source_id);
-                cb(command_handle, x.into(), ptr::null_mut());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_mark_presentation_request_msg_sent_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {})",
+                      command_handle, proof_handle, err, source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 
@@ -633,10 +634,10 @@ pub extern fn vcx_proof_get_thread_id(command_handle: CommandHandle,
                 let thread_id = CStringUtils::string_to_cstring(s);
                 cb(command_handle, error::SUCCESS.code_num, thread_id.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
                 error!("vcx_proof_get_thread_id_cb(commmand_handle: {}, rc: {}, thread_id: {}) source_id: {}",
-                       command_handle, e, "".to_string(), source_id);
-                cb(command_handle, e.into(), ptr::null_mut());
+                       command_handle, err, "".to_string(), source_id);
+                cb(command_handle, err.into(), ptr::null_mut());
             }
         };
 

--- a/libvcx/src/api_lib/api_c/vcx.rs
+++ b/libvcx/src/api_lib/api_c/vcx.rs
@@ -113,9 +113,10 @@ pub extern fn vcx_create_agency_client_for_main_wallet(command_handle: CommandHa
                 info!("vcx_create_agency_client_for_main_wallet_cb >>> command_handle: {}, rc {}", command_handle, error::SUCCESS.code_num);
                 cb(command_handle, error::SUCCESS.code_num)
             }
-            Err(e) => {
-                error!("vcx_create_agency_client_for_main_wallet_cb >>> command_handle: {}, error {}", command_handle, e);
-                cb(command_handle, e.into());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_create_agency_client_for_main_wallet_cb >>> command_handle: {}, error {}", command_handle, err);
+                cb(command_handle, err.into());
                 return Ok(());
             }
         }
@@ -164,9 +165,10 @@ pub extern fn vcx_init_issuer_config(command_handle: CommandHandle, config: *con
                 info!("vcx_init_issuer_config_cb >>> command_handle: {}, rc: {}", command_handle, error::SUCCESS.code_num);
                 cb(command_handle, error::SUCCESS.code_num)
             }
-            Err(e) => {
-                error!("vcx_init_issuer_config_cb >>> command_handle: {}, error {}", command_handle, e);
-                cb(command_handle, e.into());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_init_issuer_config_cb >>> command_handle: {}, error {}", command_handle, err);
+                cb(command_handle, err.into());
                 return Ok(());
             }
         }
@@ -230,9 +232,10 @@ pub extern fn vcx_open_main_pool(command_handle: CommandHandle, pool_config: *co
                 info!("vcx_open_main_pool_cb :: Vcx Pool Init Successful");
                 cb(command_handle, error::SUCCESS.code_num)
             }
-            Err(e) => {
-                error!("vcx_open_main_pool_cb :: Vcx Pool Init Error {}.", e);
-                cb(command_handle, e.into());
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_open_main_pool_cb :: Vcx Pool Init Error {}.", err);
+                cb(command_handle, err.into());
                 return Ok(());
             }
         }
@@ -370,7 +373,7 @@ pub extern fn vcx_update_webhook_url(command_handle: CommandHandle,
             }
             Err(err) => {
                 set_current_error_agency(&err);
-                warn!("vcx_update_webhook_url_cb(command_handle: {}, rc: {})",
+                error!("vcx_update_webhook_url_cb(command_handle: {}, rc: {})",
                       command_handle, err);
 
                 cb(command_handle, err.into());
@@ -395,17 +398,18 @@ pub extern fn vcx_get_ledger_author_agreement(command_handle: CommandHandle,
 
     execute(move || {
         match ledger::libindy_get_txn_author_agreement() {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_get_ledger_author_agreement(command_handle: {}, rc: {}, author_agreement: {})",
-                       command_handle, error::SUCCESS.message, x);
+                       command_handle, error::SUCCESS.message, err);
 
-                let msg = CStringUtils::string_to_cstring(x);
+                let msg = CStringUtils::string_to_cstring(err);
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(e) => {
+            Err(err) => {
+                set_current_error_vcx(&err);
                 error!("vcx_get_ledger_author_agreement(command_handle: {}, rc: {})",
-                       command_handle, e);
-                cb(command_handle, e.into(), std::ptr::null_mut());
+                       command_handle, err);
+                cb(command_handle, err.into(), std::ptr::null_mut());
             }
         };
 

--- a/libvcx/src/api_lib/api_c/wallet.rs
+++ b/libvcx/src/api_lib/api_c/wallet.rs
@@ -58,9 +58,9 @@ pub extern fn vcx_create_wallet(command_handle: CommandHandle,
 
     thread::spawn(move || {
         match wallet::create_wallet(&wallet_config) {
-            Err(e) => {
-                error!("vcx_create_wallet_cb(command_handle: {}, rc: {}", command_handle, e);
-                cb(command_handle, e.into());
+            Err(err) => {
+                error!("vcx_create_wallet_cb(command_handle: {}, rc: {}", command_handle, err);
+                cb(command_handle, err.into());
             }
             Ok(_) => {
                 trace!("vcx_create_wallet_cb(command_handle: {}, rc: {})",
@@ -103,9 +103,9 @@ pub extern fn vcx_configure_issuer_wallet(command_handle: CommandHandle,
 
     thread::spawn(move || {
         match wallet::configure_issuer_wallet(&enterprise_seed) {
-            Err(e) => {
-                error!("vcx_configure_issuer_wallet_cb(command_handle: {}, rc: {}", command_handle, e);
-                cb(command_handle, e.into(), null());
+            Err(err) => {
+                error!("vcx_configure_issuer_wallet_cb(command_handle: {}, rc: {}", command_handle, err);
+                cb(command_handle, err.into(), null());
             }
             Ok(conf) => {
                 let conf = serde_json::to_string(&conf).unwrap();
@@ -153,9 +153,10 @@ pub extern fn vcx_open_main_wallet(command_handle: CommandHandle,
 
     thread::spawn(move || {
         match open_as_main_wallet(&wallet_config) {
-            Err(e) => {
-                error!("vcx_open_main_wallet_cb(command_handle: {}, rc: {}", command_handle, e);
-                cb(command_handle, e.into(), aries_vcx::indy::INVALID_WALLET_HANDLE.0);
+            Err(err) => {
+                set_current_error_vcx(&err);
+                error!("vcx_open_main_wallet_cb(command_handle: {}, rc: {}", command_handle, err);
+                cb(command_handle, err.into(), aries_vcx::indy::INVALID_WALLET_HANDLE.0);
             }
             Ok(wh) => {
                 trace!("vcx_open_main_wallet_cb(command_handle: {}, rc: {}, wh: {})",
@@ -186,9 +187,9 @@ pub extern fn vcx_close_main_wallet(command_handle: CommandHandle,
 
     thread::spawn(move || {
         match wallet::close_main_wallet() {
-            Err(e) => {
-                error!("vcx_close_main_wallet_cb(command_handle: {}, rc: {}", command_handle, e);
-                cb(command_handle, e.into());
+            Err(err) => {
+                error!("vcx_close_main_wallet_cb(command_handle: {}, rc: {}", command_handle, err);
+                cb(command_handle, err.into());
             }
             Ok(_) => {
                 trace!("vcx_close_main_wallet_cb(command_handle: {}, rc: {})",
@@ -254,12 +255,12 @@ pub extern fn vcx_wallet_add_record(command_handle: CommandHandle,
 
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_wallet_add_record(command_handle: {}, rc: {})",
-                       command_handle, x);
+                       command_handle, err);
 
-                cb(command_handle, x.into());
+                cb(command_handle, err.into());
             }
         };
 
@@ -310,12 +311,12 @@ pub extern fn vcx_wallet_update_record_value(command_handle: CommandHandle,
 
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_wallet_update_record_value(command_handle: {}, rc: {})",
-                       command_handle, x);
+                       command_handle, err);
 
-                cb(command_handle, x.into());
+                cb(command_handle, err.into());
             }
         };
 
@@ -366,12 +367,12 @@ pub extern fn vcx_wallet_update_record_tags(command_handle: CommandHandle,
 
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_wallet_update_record_tags(command_handle: {}, rc: {})",
-                       command_handle, x);
+                       command_handle, err);
 
-                cb(command_handle, x.into());
+                cb(command_handle, err.into());
             }
         };
 
@@ -422,12 +423,12 @@ pub extern fn vcx_wallet_add_record_tags(command_handle: CommandHandle,
 
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_wallet_add_record_tags(command_handle: {}, rc: {})",
-                       command_handle, x);
+                       command_handle, err);
 
-                cb(command_handle, x.into());
+                cb(command_handle, err.into());
             }
         };
 
@@ -478,12 +479,12 @@ pub extern fn vcx_wallet_delete_record_tags(command_handle: CommandHandle,
 
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_wallet_delete_record_tags(command_handle: {}, rc: {})",
-                       command_handle, x);
+                       command_handle, err);
 
-                cb(command_handle, x.into());
+                cb(command_handle, err.into());
             }
         };
 
@@ -527,21 +528,21 @@ pub extern fn vcx_wallet_get_record(command_handle: CommandHandle,
 
     execute(move || {
         match wallet::get_record(&type_, &id, &options_json) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_wallet_get_record(command_handle: {}, rc: {}, record_json: {})",
-                       command_handle, error::SUCCESS.message, x);
+                       command_handle, error::SUCCESS.message, err);
 
-                let msg = CStringUtils::string_to_cstring(x);
+                let msg = CStringUtils::string_to_cstring(err);
 
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_wallet_get_record(command_handle: {}, rc: {}, record_json: {})",
-                       command_handle, x, "null");
+                       command_handle, err, "null");
 
                 let msg = CStringUtils::string_to_cstring("".to_string());
-                cb(command_handle, x.into(), msg.as_ptr());
+                cb(command_handle, err.into(), msg.as_ptr());
             }
         };
 
@@ -589,12 +590,12 @@ pub extern fn vcx_wallet_delete_record(command_handle: CommandHandle,
 
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_wallet_delete_record(command_handle: {}, rc: {})",
-                       command_handle, x);
+                       command_handle, err);
 
-                cb(command_handle, x.into());
+                cb(command_handle, err.into());
             }
         };
 
@@ -651,18 +652,18 @@ pub extern fn vcx_wallet_open_search(command_handle: CommandHandle,
 
     execute(move || {
         match wallet::open_search(&type_, &query_json, &options_json) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_wallet_open_search(command_handle: {}, rc_: {}, search_handle: {})",
-                       command_handle, error::SUCCESS.message, x);
+                       command_handle, error::SUCCESS.message, err);
 
-                cb(command_handle, error::SUCCESS.code_num, x);
+                cb(command_handle, error::SUCCESS.code_num, err);
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_wallet_get_record(command_handle: {}, rc: {}, record_json: {})",
-                       command_handle, x, "null");
+                       command_handle, err, "null");
 
-                cb(command_handle, x.into(), 0);
+                cb(command_handle, err.into(), 0);
             }
         };
 
@@ -707,21 +708,21 @@ pub extern fn vcx_wallet_search_next_records(command_handle: CommandHandle,
 
     execute(move || {
         match wallet::fetch_next_records(wallet_search_handle, count) {
-            Ok(x) => {
+            Ok(err) => {
                 trace!("vcx_wallet_search_next_records(command_handle: {}, rc: {}, record_json: {})",
-                       command_handle, error::SUCCESS.message, x);
+                       command_handle, error::SUCCESS.message, err);
 
-                let msg = CStringUtils::string_to_cstring(x);
+                let msg = CStringUtils::string_to_cstring(err);
 
                 cb(command_handle, error::SUCCESS.code_num, msg.as_ptr());
             }
-            Err(x) => {
-                set_current_error_vcx(&x);
+            Err(err) => {
+                set_current_error_vcx(&err);
                 trace!("vcx_wallet_get_record(command_handle: {}, rc: {}, record_json: {})",
-                       command_handle, x, "null");
+                       command_handle, err, "null");
 
                 let msg = CStringUtils::string_to_cstring("".to_string());
-                cb(command_handle, x.into(), msg.as_ptr());
+                cb(command_handle, err.into(), msg.as_ptr());
             }
         };
 
@@ -762,9 +763,9 @@ pub extern fn vcx_wallet_close_search(command_handle: CommandHandle,
                 trace!("vcx_wallet_close_search(command_handle: {}, rc: {})", command_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(e) => {
-                trace!("vcx_wallet_close_search(command_handle: {}, rc: {})", command_handle, e);
-                cb(command_handle, e.into());
+            Err(err) => {
+                trace!("vcx_wallet_close_search(command_handle: {}, rc: {})", command_handle, err);
+                cb(command_handle, err.into());
             }
         };
 
@@ -811,9 +812,9 @@ pub extern fn vcx_wallet_export(command_handle: CommandHandle,
                 trace!("vcx_wallet_export(command_handle: {}, rc: {})", command_handle, return_code);
                 cb(command_handle, return_code);
             }
-            Err(e) => {
-                warn!("vcx_wallet_export(command_handle: {}, rc: {})", command_handle, e);
-                cb(command_handle, e.into());
+            Err(err) => {
+                error!("vcx_wallet_export(command_handle: {}, rc: {})", command_handle, err);
+                cb(command_handle, err.into());
             }
         };
 
@@ -870,9 +871,9 @@ pub extern fn vcx_wallet_import(command_handle: CommandHandle,
                 trace!("vcx_wallet_import(command_handle: {}, rc: {})", command_handle, error::SUCCESS.message);
                 cb(command_handle, error::SUCCESS.code_num);
             }
-            Err(e) => {
-                warn!("vcx_wallet_import(command_handle: {}, rc: {})", command_handle, e);
-                cb(command_handle, e.into());
+            Err(err) => {
+                error!("vcx_wallet_import(command_handle: {}, rc: {})", command_handle, err);
+                cb(command_handle, err.into());
             }
         };
     });


### PR DESCRIPTION
- use `error` instead of `warn` in `libvcx` on error
- unify naming
- add missing `set_current_error_vcx` calls

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>