### PR TITLE
Prevent double serialization of service attrib

### DIFF
--- a/aries_vcx/src/libindy/utils/ledger.rs
+++ b/aries_vcx/src/libindy/utils/ledger.rs
@@ -433,10 +433,9 @@ pub fn build_attrib_request(submitter_did: &str, target_did: &str, hash: Option<
     Ok(request)
 }
 
-pub fn add_attr(did: &str, key: &str, value: &str) -> VcxResult<String> {
-    trace!("add_attr >>> did: {}, key: {}, value: {}", did, key, value);
-    let attrib_json = json!({ key: value }).to_string();
-    let attrib_req = build_attrib_request(&did, &did, None, Some(&attrib_json), None)?;
+pub fn add_attr(did: &str, attrib_json: &str) -> VcxResult<String> {
+    trace!("add_attr >>> did: {}, attrib_json: {}", did, attrib_json);
+    let attrib_req = build_attrib_request(&did, &did, None, Some(attrib_json), None)?;
     libindy_sign_and_submit_request(&did, &attrib_req)
 }
 
@@ -448,16 +447,14 @@ pub fn get_attr(did: &str, attr_name: &str) -> VcxResult<String> {
 pub fn get_service(did: &Did) -> VcxResult<FullService> {
     let attr_resp = get_attr(&did.to_string(), "service")?;
     let data = get_data_from_response(&attr_resp)?;
-    let ser_service = data["service"]
-        .as_str().ok_or(VcxError::from_msg(VcxErrorKind::SerializationError, format!("Unable to read service from the ledger response")))?.to_string();
+    let ser_service = data["service"].to_string();
     serde_json::from_str(&ser_service)
         .map_err(|err| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to deserialize service read from the ledger: {:?}", err)))
 }
 
 pub fn add_service(did: &str, service: &FullService) -> VcxResult<String> {
-    let ser_service = serde_json::to_string(service)
-        .map_err(|err| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to serialize service before writing to ledger: {:?}", err)))?;
-    add_attr(did, "service", &ser_service)
+    let attrib_json = json!({ "service": service }).to_string();
+    add_attr(did, &attrib_json)
 }
 
 fn get_data_from_response(resp: &str) -> VcxResult<serde_json::Value> {


### PR DESCRIPTION
Currently, the service we write on the ledger is double-serialized: https://indyscan.io/tx/SOVRIN_STAGINGNET/domain/280689

This fix assures the serialization is performed only once.

Signed-off-by: Miroslav Kovar <miroslav.kovar@absa.africa>