### PR TITLE
Remove json log formatter, add color format, fix timestamp

### DIFF
--- a/aries_vcx/src/utils/test_logger.rs
+++ b/aries_vcx/src/utils/test_logger.rs
@@ -21,11 +21,23 @@ use crate::chrono::Local;
 pub struct LibvcxDefaultLogger;
 
 fn standard_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
-    writeln!(buf, "{:>5}|{:<30}|{:>35}:{:<4}| {}", record.level(), record.target(), record.file().get_or_insert(""), record.line().get_or_insert(0), record.args())
+    writeln!(buf, "{}|{:>5}|{:<30}|{:>35}:{:<4}| {}",
+             Local::now().format("%Y-%m-%d %H:%M.%S.%f"),
+             record.level(),
+             record.target(),
+             record.file().get_or_insert(""),
+             record.line().get_or_insert(0),
+             record.args()
+    )
 }
 
 fn json_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
-    writeln!(buf, "{{\"timestamp\":\"{}\",\"level\":\"{}\",\"filename\":\"{}\",message:\"{}\"}}", Local::now().format("%Y-%m-%d %H:%M.%S"), record.level(), record.file().get_or_insert(""), record.args())
+    writeln!(buf, "{{\"timestamp\":\"{}\",\"level\":\"{}\",\"filename\":\"{}\",\"message\":\"{}\"}}",
+             Local::now().format("%Y-%m-%d %H:%M:%S.%f"),
+             record.level(),
+             record.file().get_or_insert(""),
+             record.args()
+    )
 }
 
 impl LibvcxDefaultLogger {

--- a/aries_vcx/src/utils/test_logger.rs
+++ b/aries_vcx/src/utils/test_logger.rs
@@ -50,15 +50,6 @@ fn text_no_color_format(buf: &mut Formatter, record: &Record) -> std::io::Result
     )
 }
 
-fn json_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
-    writeln!(buf, "{{\"timestamp\":\"{}\",\"level\":\"{}\",\"filename\":\"{}\",\"message\":\"{}\"}}",
-             _get_timestamp(),
-             record.level(),
-             record.file().get_or_insert(""),
-             record.args()
-    )
-}
-
 impl LibvcxDefaultLogger {
     pub fn init_testing_logger() {
         trace!("LibvcxDefaultLogger::init_testing_logger >>>");
@@ -92,7 +83,6 @@ impl LibvcxDefaultLogger {
         } else {
             let formatter = match env::var("RUST_LOG_FORMATTER") {
                 Ok(val) => match val.as_str() {
-                    "json" => json_format,
                     "text_no_color" => text_no_color_format,
                     _ => text_format
                 }

--- a/libvcx/src/api_lib/utils/logger.rs
+++ b/libvcx/src/api_lib/utils/logger.rs
@@ -8,6 +8,7 @@ use std::env;
 use std::ffi::CString;
 use std::io::Write;
 use std::ptr;
+use chrono::format::{DelayedFormat, StrftimeItems};
 
 pub use aries_vcx::indy_sys::{CVoid, logger::{EnabledCB, FlushCB, LogCB}};
 use aries_vcx::libindy;
@@ -134,12 +135,42 @@ impl log::Log for LibvcxLogger {
 //WARN	Designates potentially harmful situations.
 pub struct LibvcxDefaultLogger;
 
-fn standard_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
-    writeln!(buf, "{:>5}|{:<30}|{:>35}:{:<4}| {}", record.level(), record.target(), record.file().get_or_insert(""), record.line().get_or_insert(0), record.args())
+
+fn _get_timestamp<'a>() -> DelayedFormat<StrftimeItems<'a>> {
+    Local::now().format("%Y-%m-%d %H:%M:%S.%f")
+}
+
+fn text_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
+    let level = buf.default_styled_level(record.level());
+    writeln!(buf, "{}|{:>5}|{:<30}|{:>35}:{:<4}| {}",
+             _get_timestamp(),
+             level,
+             record.target(),
+             record.file().get_or_insert(""),
+             record.line().get_or_insert(0),
+             record.args()
+    )
+}
+
+fn text_no_color_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
+    let level = record.level();
+    writeln!(buf, "{}|{:>5}|{:<30}|{:>35}:{:<4}| {}",
+             _get_timestamp(),
+             level,
+             record.target(),
+             record.file().get_or_insert(""),
+             record.line().get_or_insert(0),
+             record.args()
+    )
 }
 
 fn json_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
-    writeln!(buf, "{{\"timestamp\":\"{}\",\"level\":\"{}\",\"filename\":\"{}\",message:\"{}\"}}", Local::now().format("%Y-%m-%d %H:%M.%S"), record.level(), record.file().get_or_insert(""), record.args())
+    writeln!(buf, "{{\"timestamp\":\"{}\",\"level\":\"{}\",\"filename\":\"{}\",\"message\":\"{}\"}}",
+             _get_timestamp(),
+             record.level(),
+             record.file().get_or_insert(""),
+             record.args()
+    )
 }
 
 impl LibvcxDefaultLogger {
@@ -169,9 +200,10 @@ impl LibvcxDefaultLogger {
             let formatter = match env::var("RUST_LOG_FORMATTER") {
                 Ok(val) => match val.as_str() {
                     "json" => json_format,
-                    _ => standard_format
+                    "text_no_color" => text_no_color_format,
+                    _ => text_format
                 }
-                _ => standard_format
+                _ => text_format
             };
             EnvLoggerBuilder::new()
                 .format(formatter)

--- a/libvcx/src/api_lib/utils/logger.rs
+++ b/libvcx/src/api_lib/utils/logger.rs
@@ -142,7 +142,7 @@ fn _get_timestamp<'a>() -> DelayedFormat<StrftimeItems<'a>> {
 
 fn text_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
     let level = buf.default_styled_level(record.level());
-    writeln!(buf, "{}|{:>5}|{:<30}|{:>35}:{:<4}| {}",
+    writeln!(buf, "{} | {:>5} | {:<30} | {:>35}:{:<4} | {}",
              _get_timestamp(),
              level,
              record.target(),
@@ -154,21 +154,12 @@ fn text_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
 
 fn text_no_color_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
     let level = record.level();
-    writeln!(buf, "{}|{:>5}|{:<30}|{:>35}:{:<4}| {}",
+    writeln!(buf, "{} | {:>5} | {:<30} | {:>35}:{:<4} | {}",
              _get_timestamp(),
              level,
              record.target(),
              record.file().get_or_insert(""),
              record.line().get_or_insert(0),
-             record.args()
-    )
-}
-
-fn json_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
-    writeln!(buf, "{{\"timestamp\":\"{}\",\"level\":\"{}\",\"filename\":\"{}\",\"message\":\"{}\"}}",
-             _get_timestamp(),
-             record.level(),
-             record.file().get_or_insert(""),
              record.args()
     )
 }
@@ -199,7 +190,6 @@ impl LibvcxDefaultLogger {
         } else {
             let formatter = match env::var("RUST_LOG_FORMATTER") {
                 Ok(val) => match val.as_str() {
-                    "json" => json_format,
                     "text_no_color" => text_no_color_format,
                     _ => text_format
                 }


### PR DESCRIPTION
- Change minute/second separator from `.` to `:`
- Add nanoseconds to timestamp
- Colorize log level by default
- Add `text_no_color` formatter which logs text without colorization
- Remove support for json log formatter - it wouldn't produce valid json logs if they contain non-ascii characters


Signed-off-by: Patrik Stas <patrik.stas@absa.africa>