### PR TITLE
Make wallet_handle injectable when creating connection

### DIFF
--- a/aries_vcx/src/handlers/out_of_band/receiver.rs
+++ b/aries_vcx/src/handlers/out_of_band/receiver.rs
@@ -96,7 +96,7 @@ impl OutOfBandReceiver {
 
     pub async fn build_connection(&self, agency_client: &AgencyClient, autohop_enabled: bool) -> VcxResult<Connection> {
         trace!("OutOfBandReceiver::build_connection >>> autohop_enabled: {}", autohop_enabled);
-        Connection::create_with_invite(&self.oob.id.0, Invitation::OutOfBand(self.oob.clone()), autohop_enabled, agency_client).await
+        Connection::create_with_invite(&self.oob.id.0, agency_client.get_wallet_handle(), agency_client, Invitation::OutOfBand(self.oob.clone()), autohop_enabled).await
     }
 
     pub fn to_a2a_message(&self) -> A2AMessage {

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -159,7 +159,7 @@ pub mod test_utils {
             init_issuer_config(&config_issuer).unwrap();
             let mut agency_client = AgencyClient::new();
             let config_agency = provision_cloud_agent(&mut agency_client, wallet_handle, &config_provision_agent).await.unwrap();
-            let connection = Connection::create("faber", true, &agency_client).await.unwrap();
+            let connection = Connection::create("faber", agency_client.get_wallet_handle(), &agency_client, true).await.unwrap();
             let agent = PublicAgent::create(wallet_handle, &agency_client, "faber", &config_issuer.institution_did).await.unwrap();
             let faber = Faber {
                 wallet_handle,
@@ -354,7 +354,7 @@ pub mod test_utils {
             let wallet_handle = open_wallet(&config_wallet).await.unwrap();
             let mut agency_client = AgencyClient::new();
             let config_agency = provision_cloud_agent(&mut agency_client, wallet_handle, &config_provision_agent).await.unwrap();
-            let connection = Connection::create("tmp_empoty", true, &agency_client).await.unwrap();
+            let connection = Connection::create("tmp_empoty", agency_client.get_wallet_handle(), &agency_client, true).await.unwrap();
             let alice = Alice {
                 wallet_handle,
                 agency_client,
@@ -370,7 +370,7 @@ pub mod test_utils {
 
         pub async fn accept_invite(&mut self, invite: &str) {
             self.activate().await.unwrap();
-            self.connection = Connection::create_with_invite("faber", serde_json::from_str(invite).unwrap(), true, &self.agency_client).await.unwrap();
+            self.connection = Connection::create_with_invite("faber", self.wallet_handle, &self.agency_client, serde_json::from_str(invite).unwrap(), true).await.unwrap();
             self.connection.connect(self.wallet_handle, &self.agency_client).await.unwrap();
             self.connection.update_state(self.wallet_handle, &self.agency_client).await.unwrap();
             assert_eq!(ConnectionState::Invitee(InviteeState::Requested), self.connection.get_state());

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -590,7 +590,7 @@ pub mod test_utils {
         let public_invite: Invitation = serde_json::from_str(&public_invite_json).unwrap();
 
         alice.activate().await.unwrap();
-        let mut consumer_to_institution = Connection::create_with_invite("institution", public_invite, true, &alice.agency_client).await.unwrap();
+        let mut consumer_to_institution = Connection::create_with_invite("institution", alice.wallet_handle, &alice.agency_client, public_invite, true).await.unwrap();
         consumer_to_institution.connect(alice.wallet_handle, &alice.agency_client).await.unwrap();
         consumer_to_institution.update_state(alice.wallet_handle, &alice.agency_client).await.unwrap();
 
@@ -602,13 +602,13 @@ pub mod test_utils {
     pub async fn create_connected_connections(alice: &mut Alice, faber: &mut Faber) -> (Connection, Connection) {
         debug!("Institution is going to create connection.");
         faber.activate().await.unwrap();
-        let mut institution_to_consumer = Connection::create("consumer", true, &faber.agency_client).await.unwrap();
+        let mut institution_to_consumer = Connection::create("consumer", faber.wallet_handle, &faber.agency_client, true).await.unwrap();
         institution_to_consumer.connect(faber.wallet_handle, &faber.agency_client).await.unwrap();
         let details = institution_to_consumer.get_invite_details().unwrap();
 
         alice.activate().await.unwrap();
         debug!("Consumer is going to accept connection invitation.");
-        let mut consumer_to_institution = Connection::create_with_invite("institution", details.clone(), true, &alice.agency_client).await.unwrap();
+        let mut consumer_to_institution = Connection::create_with_invite("institution", alice.wallet_handle, &alice.agency_client, details.clone(), true).await.unwrap();
 
         consumer_to_institution.connect(alice.wallet_handle, &alice.agency_client).await.unwrap();
         consumer_to_institution.update_state(alice.wallet_handle, &alice.agency_client).await.unwrap();

--- a/libvcx/src/api_lib/api_handle/connection.rs
+++ b/libvcx/src/api_lib/api_handle/connection.rs
@@ -96,14 +96,14 @@ pub fn store_connection(connection: Connection) -> VcxResult<u32> {
 
 pub async fn create_connection(source_id: &str) -> VcxResult<u32> {
     trace!("create_connection >>> source_id: {}", source_id);
-    let connection = Connection::create(source_id, true, &get_main_agency_client().unwrap()).await?;
+    let connection = Connection::create(source_id, get_main_wallet_handle(), &get_main_agency_client().unwrap(), true).await?;
     store_connection(connection)
 }
 
 pub async fn create_connection_with_invite(source_id: &str, details: &str) -> VcxResult<u32> {
     debug!("create connection {} with invite {}", source_id, details);
     if let Some(invitation) = serde_json::from_str::<InvitationV3>(details).ok() {
-        let connection = Connection::create_with_invite(source_id, invitation, true, &get_main_agency_client().unwrap()).await?;
+        let connection = Connection::create_with_invite(source_id, get_main_wallet_handle(), &get_main_agency_client().unwrap(), invitation, true).await?;
         store_connection(connection)
     } else {
         Err(VcxError::from_msg(VcxErrorKind::InvalidJson, "Used invite has invalid structure")) // TODO: Specific error type


### PR DESCRIPTION
- Make `wallet_handle` injectable in all functions for `Connection`. This will be needed when building agency-less Connection implementation
- Delete commented code which was originally trying to retrieve messages from bootstrap agent, but getting this code restored is nowhere near priority, hence deleting


Signed-off-by: Patrik Stas <patrik.stas@absa.africa>