### PR TITLE
AFJ interop: change format of 'id' value in public_key portion of DDO

### DIFF
--- a/aries_vcx/src/did_doc/mod.rs
+++ b/aries_vcx/src/did_doc/mod.rs
@@ -61,7 +61,7 @@ impl DidDoc {
 
                 self.public_key.push(
                     Ed25519PublicKey {
-                        id: key_id,
+                        id: key_reference.clone(),
                         type_: String::from(KEY_TYPE),
                         controller: self.id.clone(),
                         public_key_base_58: key.clone(),
@@ -213,14 +213,13 @@ impl DidDoc {
     }
 
     fn find_key_by_reference(&self, key_ref: &DdoKeyReference) -> VcxResult<Ed25519PublicKey> {
-        let public_key = self.public_key.iter().find(|ddo_keys| {
-            match &key_ref.did {
-                None => ddo_keys.id == key_ref.key_id,
-                Some(did) => {
-                    ddo_keys.id == key_ref.key_id || ddo_keys.id == format!("{}#{}", did, key_ref.key_id)
+        let public_key = self.public_key.iter()
+            .find(|ddo_keys| {
+                match &key_ref.did {
+                    None => ddo_keys.id == key_ref.key_id,
+                    Some(did) => ddo_keys.id == key_ref.key_id || ddo_keys.id == format!("{}#{}", did, key_ref.key_id)
                 }
-            }
-        })
+            })
             .ok_or(VcxError::from_msg(VcxErrorKind::InvalidJson, format!("Failed to find entry in public_key by key reference: {:?}", key_ref)))?;
         Ok(public_key.clone())
     }
@@ -426,7 +425,6 @@ mod unit_tests {
     use crate::did_doc::test_utils::*;
     use crate::utils::devsetup::SetupEmpty;
 
-
     #[test]
     fn test_did_doc_build_works() {
         let mut did_doc: DidDoc = DidDoc::default();
@@ -435,7 +433,7 @@ mod unit_tests {
         did_doc.set_recipient_keys(_recipient_keys());
         did_doc.set_routing_keys(_routing_keys());
 
-        assert_eq!(_did_doc_vcx_legacy(), did_doc);
+        assert_eq!(_did_doc_vcx_new(), did_doc);
     }
 
     #[test]

--- a/aries_vcx/src/messages/connection/request.rs
+++ b/aries_vcx/src/messages/connection/request.rs
@@ -1,5 +1,5 @@
-use crate::did_doc::DidDoc;
 use crate::messages::a2a::{A2AMessage, MessageId};
+use crate::did_doc::DidDoc;
 use crate::messages::thread::Thread;
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
@@ -69,7 +69,7 @@ pub mod unit_tests {
             label: _label(),
             connection: ConnectionData {
                 did: _did(),
-                did_doc: _did_doc_vcx_legacy(),
+                did_doc: _did_doc_vcx_new(),
             },
             thread: None,
         }

--- a/aries_vcx/src/messages/connection/response.rs
+++ b/aries_vcx/src/messages/connection/response.rs
@@ -157,7 +157,7 @@ impl Default for ConnectionSignature {
 
 #[cfg(feature = "test_utils")]
 pub mod test_utils {
-    use crate::did_doc::test_utils::_did_doc_vcx_legacy;
+    use crate::did_doc::test_utils::_did_doc_vcx_new;
 
     use super::*;
 
@@ -187,7 +187,7 @@ pub mod test_utils {
             thread: _thread(),
             connection: ConnectionData {
                 did: _did(),
-                did_doc: _did_doc_vcx_legacy(),
+                did_doc: _did_doc_vcx_new(),
             },
             please_ack: None,
         }
@@ -199,7 +199,7 @@ pub mod test_utils {
             thread: _thread(),
             connection_sig: ConnectionSignature {
                 signature: String::from("yeadfeBWKn09j5XU3ITUE3gPbUDmPNeblviyjrOIDdVMT5WZ8wxMCxQ3OpAnmq1o-Gz0kWib9zr0PLsbGc2jCA=="),
-                sig_data: serde_json::to_string(&_did_doc_vcx_legacy()).unwrap(),
+                sig_data: serde_json::to_string(&_did_doc_vcx_new()).unwrap(),
                 signer: _key(),
                 ..Default::default()
             },

--- a/aries_vcx/tests/test_connection.rs
+++ b/aries_vcx/tests/test_connection.rs
@@ -207,13 +207,6 @@ mod integration_tests {
         let mut faber = Faber::setup().await;
         let mut alice = Alice::setup().await;
 
-        // Publish Schema and Credential Definition
-        faber.create_schema().await;
-
-        std::thread::sleep(std::time::Duration::from_secs(2));
-
-        faber.create_nonrevocable_credential_definition().await;
-
         // Connection
         let invite = faber.create_invite().await;
         alice.accept_invite(&invite).await;
@@ -225,9 +218,9 @@ mod integration_tests {
         // Ping
         faber.ping().await;
 
-        alice.update_state(4).await;
+        alice.handle_messages().await;
 
-        faber.update_state(4).await;
+        faber.handle_messages().await;
 
         let faber_connection_info = faber.connection_info().await;
         assert!(faber_connection_info["their"]["protocols"].as_array().is_none());


### PR DESCRIPTION
# Changes:
- AFJ Interop effort: Set value of `id` attribute on `publicKey` object in format `<ddo_id>#<key_id>` instead of `<key_id>`
Eg what previously was

```
{
	"@context": "https://w3id.org/did/v1",
	"publicKey": [
	  {
	    "id": "1",
	    "controller": "S3GarpQp2ec7xh22mEvtUr",
	    "type": "Ed25519VerificationKey2018",
	    "publicKeyBase58": "EeY5R8rDJxaCoAM1ttFrCJpWCmckJqHq6CGcEjgMbb5u"
	  }
	]
}
```

Now is
```
{
	"@context": "https://w3id.org/did/v1",
	"publicKey": [
	  {
	    "id": "S3GarpQp2ec7xh22mEvtUr#1",
	    "controller": "S3GarpQp2ec7xh22mEvtUr",
	    "type": "Ed25519VerificationKey2018",
	    "publicKeyBase58": "EeY5R8rDJxaCoAM1ttFrCJpWCmckJqHq6CGcEjgMbb5u"
	  }
	]
}
```


Signed-off-by: Patrik Stas <patrik.stas@absa.africa>