### PR TITLE
Refactor connection protocol

### DIFF
--- a/aries_vcx/src/handlers/connection/connection.rs
+++ b/aries_vcx/src/handlers/connection/connection.rs
@@ -515,16 +515,12 @@ impl Connection {
                                 .await?;
                             (sm_connection, Some(new_cloud_agent), true)
                         }
-                        msg @ A2AMessage::Ack(_) | msg @ A2AMessage::Ping(_) => (
-                            sm_inviter.handle_confirmation_message(&msg).await?,
-                            None,
-                            false,
-                        ),
-                        A2AMessage::ConnectionProblemReport(problem_report) => (
-                            sm_inviter.handle_problem_report(problem_report)?,
-                            None,
-                            false,
-                        ),
+                        msg @ A2AMessage::Ack(_) | msg @ A2AMessage::Ping(_) => {
+                            (sm_inviter.handle_confirmation_message(&msg).await?, None, false)
+                        }
+                        A2AMessage::ConnectionProblemReport(problem_report) => {
+                            (sm_inviter.handle_problem_report(problem_report)?, None, false)
+                        }
                         _ => (sm_inviter.clone(), None, false),
                     },
                     None => {

--- a/aries_vcx/src/handlers/connection/connection.rs
+++ b/aries_vcx/src/handlers/connection/connection.rs
@@ -515,20 +515,16 @@ impl Connection {
                                 .await?;
                             (sm_connection, Some(new_cloud_agent), true)
                         }
-                        A2AMessage::Ack(ack) => (
-                            sm_inviter.handle_ack(wallet_handle, ack, send_message).await?,
+                        msg @ A2AMessage::Ack(_) | msg @ A2AMessage::Ping(_) => (
+                            sm_inviter.handle_confirmation_message(&msg).await?,
                             None,
                             false,
                         ),
-                        A2AMessage::Ping(ping) => (
-                            sm_inviter.handle_ping(wallet_handle, ping, send_message).await?,
+                        A2AMessage::ConnectionProblemReport(problem_report) => (
+                            sm_inviter.handle_problem_report(problem_report)?,
                             None,
                             false,
                         ),
-                        A2AMessage::ConnectionProblemReport(problem_report) => {
-                            (sm_inviter.handle_problem_report(problem_report)?, None, false)
-                        }
-                        A2AMessage::Disclose(disclose) => (sm_inviter.handle_disclose(disclose)?, None, false),
                         _ => (sm_inviter.clone(), None, false),
                     },
                     None => {
@@ -574,11 +570,9 @@ impl Connection {
                         A2AMessage::ConnectionResponse(response) => {
                             (sm_invitee.handle_connection_response(response)?, true)
                         }
-                        A2AMessage::Ack(ack) => (sm_invitee.handle_ack(ack)?, false),
                         A2AMessage::ConnectionProblemReport(problem_report) => {
                             (sm_invitee.handle_problem_report(problem_report)?, false)
                         }
-                        A2AMessage::Disclose(disclose) => (sm_invitee.handle_disclose(disclose)?, false),
                         _ => (sm_invitee, false),
                     },
                     None => (sm_invitee.handle_send_ack(wallet_handle, &send_message).await?, false),

--- a/aries_vcx/src/handlers/connection/connection.rs
+++ b/aries_vcx/src/handlers/connection/connection.rs
@@ -602,14 +602,14 @@ impl Connection {
     pub async fn connect(&mut self, wallet_handle: WalletHandle, agency_client: &AgencyClient) -> VcxResult<()> {
         trace!("Connection::connect >>> source_id: {}", self.source_id());
         self.connection_sm = match &self.connection_sm {
-            SmConnection::Inviter(sm_inviter) => SmConnection::Inviter(sm_inviter.clone().handle_connect(
+            SmConnection::Inviter(sm_inviter) => SmConnection::Inviter(sm_inviter.clone().create_invitation(
                 self.cloud_agent_info.routing_keys(agency_client)?,
                 self.cloud_agent_info.service_endpoint(agency_client)?,
             )?),
             SmConnection::Invitee(sm_invitee) => SmConnection::Invitee(
                 sm_invitee
                     .clone()
-                    .handle_connect(
+                    .send_connection_request(
                         wallet_handle,
                         self.cloud_agent_info.routing_keys(agency_client)?,
                         self.cloud_agent_info.service_endpoint(agency_client)?,

--- a/aries_vcx/src/handlers/util.rs
+++ b/aries_vcx/src/handlers/util.rs
@@ -3,7 +3,7 @@ use crate::global::settings;
 use crate::messages::a2a::A2AMessage;
 
 pub fn verify_thread_id(thread_id: &str, message: &A2AMessage) -> VcxResult<()> {
-    if !settings::indy_mocks_enabled() && !message.thread_id_matches(thread_id) {
+    if !message.thread_id_matches(thread_id) {
         return Err(VcxError::from_msg(
             VcxErrorKind::InvalidJson,
             format!(

--- a/aries_vcx/src/messages/ack.rs
+++ b/aries_vcx/src/messages/ack.rs
@@ -55,7 +55,7 @@ macro_rules! please_ack (($type:ident) => (
 
 #[cfg(feature = "test_utils")]
 pub mod test_utils {
-    use crate::messages::connection::response::test_utils::{_thread, _thread_1};
+    use crate::messages::connection::response::test_utils::{_thread, _thread_1, _thread_random};
 
     use super::*;
 
@@ -64,6 +64,14 @@ pub mod test_utils {
             id: MessageId::id(),
             status: AckStatus::Fail,
             thread: _thread(),
+        }
+    }
+
+    pub fn _ack_random_thread() -> Ack {
+        Ack {
+            id: MessageId::id(),
+            status: AckStatus::Ok,
+            thread: _thread_random(),
         }
     }
 

--- a/aries_vcx/src/messages/basic_message/message.rs
+++ b/aries_vcx/src/messages/basic_message/message.rs
@@ -2,6 +2,7 @@ use chrono::prelude::*;
 
 use crate::messages::a2a::{A2AMessage, MessageId};
 use crate::messages::localization::Localization;
+use crate::messages::thread::Thread;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct BasicMessage {
@@ -12,7 +13,11 @@ pub struct BasicMessage {
     #[serde(rename = "~l10n")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub l10n: Option<Localization>,
+    #[serde(rename = "~thread")]
+    pub thread: Option<Thread>,
 }
+
+threadlike_optional!(BasicMessage);
 
 impl BasicMessage {
     pub fn create() -> BasicMessage {

--- a/aries_vcx/src/messages/connection/response.rs
+++ b/aries_vcx/src/messages/connection/response.rs
@@ -174,6 +174,7 @@ impl Default for ConnectionSignature {
 #[cfg(feature = "test_utils")]
 pub mod test_utils {
     use crate::did_doc::test_utils::_did_doc_inlined_recipient_keys;
+    use crate::utils::uuid::uuid;
 
     use super::*;
 
@@ -187,6 +188,10 @@ pub mod test_utils {
 
     pub fn _thread() -> Thread {
         Thread::new().set_thid(String::from("testid"))
+    }
+
+    pub fn _thread_random() -> Thread {
+        Thread::new().set_thid(uuid())
     }
 
     pub fn _thread_1() -> Thread {

--- a/aries_vcx/src/protocols/connection/invitee/state_machine.rs
+++ b/aries_vcx/src/protocols/connection/invitee/state_machine.rs
@@ -250,7 +250,7 @@ impl SmConnectionInvitee {
         })
     }
 
-    pub async fn handle_connect<F, T>(
+    pub async fn send_connection_request<F, T>(
         self,
         wallet_handle: WalletHandle,
         routing_keys: Vec<String>,
@@ -434,7 +434,7 @@ pub mod unit_tests {
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
                 self = self
-                    .handle_connect(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
+                    .send_connection_request(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
                     .await
                     .unwrap();
                 self
@@ -450,7 +450,7 @@ pub mod unit_tests {
                 let routing_keys: Vec<String> = vec![key.clone()];
                 let service_endpoint = String::from("https://example.org/agent");
                 self = self
-                    .handle_connect(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
+                    .send_connection_request(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
                     .await
                     .unwrap();
                 self = self
@@ -516,7 +516,7 @@ pub mod unit_tests {
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
                 invitee = invitee
-                    .handle_connect(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
+                    .send_connection_request(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
                     .await
                     .unwrap();
                 assert_match!(InviteeState::Requested, invitee.get_state());
@@ -565,7 +565,7 @@ pub mod unit_tests {
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
                 did_exchange_sm = did_exchange_sm
-                    .handle_connect(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
+                    .send_connection_request(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
                     .await
                     .unwrap();
                 assert_match!(InviteeFullState::Initial(_), did_exchange_sm.state);
@@ -594,7 +594,7 @@ pub mod unit_tests {
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
                 did_exchange_sm = did_exchange_sm
-                    .handle_connect(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
+                    .send_connection_request(_dummy_wallet_handle(), routing_keys, service_endpoint, _send_message)
                     .await
                     .unwrap();
 

--- a/aries_vcx/src/protocols/connection/inviter/state_machine.rs
+++ b/aries_vcx/src/protocols/connection/inviter/state_machine.rs
@@ -205,7 +205,7 @@ impl SmConnectionInviter {
         .await
     }
 
-    pub fn handle_connect(self, routing_keys: Vec<String>, service_endpoint: String) -> VcxResult<Self> {
+    pub fn create_invitation(self, routing_keys: Vec<String>, service_endpoint: String) -> VcxResult<Self> {
         let state = match self.state {
             InviterFullState::Initial(state) => {
                 let invite: PairwiseInvitation = PairwiseInvitation::create()
@@ -412,14 +412,14 @@ pub mod unit_tests {
             fn to_inviter_invited_state(mut self) -> SmConnectionInviter {
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
-                self = self.handle_connect(routing_keys, service_endpoint).unwrap();
+                self = self.create_invitation(routing_keys, service_endpoint).unwrap();
                 self
             }
 
             async fn to_inviter_responded_state(mut self) -> SmConnectionInviter {
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
-                self = self.handle_connect(routing_keys, service_endpoint).unwrap();
+                self = self.create_invitation(routing_keys, service_endpoint).unwrap();
 
                 let new_pairwise_info = PairwiseInfo::create(_dummy_wallet_handle()).await.unwrap();
                 let new_routing_keys: Vec<String> = vec!["verkey456".into()];
@@ -445,7 +445,7 @@ pub mod unit_tests {
             async fn to_inviter_completed_state(mut self) -> SmConnectionInviter {
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
-                self = self.handle_connect(routing_keys, service_endpoint).unwrap();
+                self = self.create_invitation(routing_keys, service_endpoint).unwrap();
 
                 let new_pairwise_info = PairwiseInfo {
                     pw_did: "AC3Gx1RoAz8iYVcfY47gjJ".to_string(),
@@ -487,7 +487,7 @@ pub mod unit_tests {
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
                 let mut inviter = inviter_sm().await;
-                inviter = inviter.handle_connect(routing_keys, service_endpoint).unwrap();
+                inviter = inviter.create_invitation(routing_keys, service_endpoint).unwrap();
 
                 let new_pairwise_info = PairwiseInfo {
                     pw_did: "AC3Gx1RoAz8iYVcfY47gjJ".to_string(),
@@ -556,7 +556,7 @@ pub mod unit_tests {
 
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
-                did_exchange_sm = did_exchange_sm.handle_connect(routing_keys, service_endpoint).unwrap();
+                did_exchange_sm = did_exchange_sm.create_invitation(routing_keys, service_endpoint).unwrap();
 
                 assert_match!(InviterFullState::Invited(_), did_exchange_sm.state);
             }
@@ -661,7 +661,7 @@ pub mod unit_tests {
 
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
-                did_exchange_sm = did_exchange_sm.handle_connect(routing_keys, service_endpoint).unwrap();
+                did_exchange_sm = did_exchange_sm.create_invitation(routing_keys, service_endpoint).unwrap();
                 assert_match!(InviterFullState::Invited(_), did_exchange_sm.state);
 
                 did_exchange_sm = did_exchange_sm
@@ -722,7 +722,7 @@ pub mod unit_tests {
 
                 let routing_keys: Vec<String> = vec!["verkey123".into()];
                 let service_endpoint = String::from("https://example.org/agent");
-                did_exchange_sm = did_exchange_sm.handle_connect(routing_keys, service_endpoint).unwrap();
+                did_exchange_sm = did_exchange_sm.create_invitation(routing_keys, service_endpoint).unwrap();
 
                 assert_match!(InviterFullState::Responded(_), did_exchange_sm.state);
             }

--- a/aries_vcx/src/protocols/connection/inviter/states/responded.rs
+++ b/aries_vcx/src/protocols/connection/inviter/states/responded.rs
@@ -1,6 +1,7 @@
 use std::clone::Clone;
 
 use crate::did_doc::DidDoc;
+use crate::messages::a2a::A2AMessage;
 use crate::messages::ack::Ack;
 use crate::messages::connection::problem_report::ProblemReport;
 use crate::messages::connection::response::SignedResponse;
@@ -25,30 +26,8 @@ impl From<(RespondedState, ProblemReport)> for InitialState {
     }
 }
 
-impl From<(RespondedState, Ack)> for CompleteState {
-    fn from((state, _ack): (RespondedState, Ack)) -> CompleteState {
-        trace!("ConnectionInviter: transit state from RespondedState to CompleteState");
-        CompleteState {
-            did_doc: state.did_doc,
-            thread_id: Some(state.signed_response.get_thread_id()),
-            protocols: None,
-        }
-    }
-}
-
-impl From<(RespondedState, Ping)> for CompleteState {
-    fn from((state, _ping): (RespondedState, Ping)) -> CompleteState {
-        trace!("ConnectionInviter: transit state from RespondedState to CompleteState");
-        CompleteState {
-            did_doc: state.did_doc,
-            thread_id: Some(state.signed_response.get_thread_id()),
-            protocols: None,
-        }
-    }
-}
-
-impl From<(RespondedState, PingResponse)> for CompleteState {
-    fn from((state, _ping_response): (RespondedState, PingResponse)) -> CompleteState {
+impl From<RespondedState> for CompleteState {
+    fn from(state: RespondedState) -> CompleteState {
         trace!("ConnectionInviter: transit state from RespondedState to CompleteState");
         CompleteState {
             did_doc: state.did_doc,


### PR DESCRIPTION
- Removes forgotten `disclose` protocol handling on Aries SM level
- Weakens assumptions about connection confirmation message on Connection protocol Aries SM level. We have required that inviter must receive Ping or Ack message to progress to final state on Inviter side, however as [rfc states](https://github.com/hyperledger/aries-rfcs/blob/main/features/0160-connection-protocol/README.md#3-connection-acknowledgement), "any message will do":
> After the Response is received, the connection is technically complete. This remains unconfirmed to the inviter however. The invitee SHOULD send a message to the inviter. As any message will confirm the connection, any message will do.

So instead of having `handle_ping` and `handle_ack` in inviter SM, these are replaced by `handle_confirmation_message`. If the final message happens to be `Ping`, it's up to upper layers to perhaps respond to ping, but shouldn't be part of Connection SM responsibility to respond Ping message (and no longer is, with the changes made).
- Adds optional thread attribute to `BasicMessage`
- Adds thread_id matching for all message types. 
- Update `verify_thread_id` to not skip thread verification if `indy_mocks_enabled == true`
- Renamed `handle_connect` to more descriptive names `send_connection_request` for invitee and `create_invitation` for inviter FSMs.

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>