### PR TITLE
iOS Wrapper abstraction

### DIFF
--- a/wrappers/ios/vcx/ConnectMeVcx.h
+++ b/wrappers/ios/vcx/ConnectMeVcx.h
@@ -10,73 +10,6 @@
 #define init_h
 #import "libvcx.h"
 
-extern void VcxWrapperCommonCallback(vcx_command_handle_t xcommand_handle,
-                                     vcx_error_t err);
-
-extern void VcxWrapperCommonHandleCallback(vcx_command_handle_t xcommand_handle,
-                                           vcx_error_t err,
-                                           vcx_command_handle_t pool_handle);
-
-extern void VcxWrapperCommonSignedHandleCallback(vcx_command_handle_t xcommand_handle,
-                                           vcx_error_t err,
-                                           vcx_i32_t handle);
-
-extern void VcxWrapperCommonStringCallback(vcx_command_handle_t xcommand_handle,
-                                           vcx_error_t err,
-                                           const char *const arg1);
-
-extern void VcxWrapperCommonBoolCallback(vcx_command_handle_t xcommand_handle,
-                                         vcx_error_t err,
-                                         unsigned int arg1);
-
-extern void VcxWrapperCommonStringStringCallback(vcx_command_handle_t xcommand_handle,
-                                                 vcx_error_t err,
-                                                 const char *const arg1,
-                                                 const char *const arg2);
-
-extern void VcxWrapperCommonStringOptStringCallback(vcx_command_handle_t xcommand_handle,
-                                                    vcx_error_t err,
-                                                    const char *const arg1,
-                                                    const char *const arg2);
-
-extern void VcxWrapperCommonDataCallback(vcx_command_handle_t xcommand_handle,
-                                         vcx_error_t err,
-                                         const uint8_t *const arg1,
-                                         uint32_t arg2);
-
-extern void VcxWrapperCommonStringStringStringCallback(vcx_command_handle_t xcommand_handle,
-                                                       vcx_error_t err,
-                                                       const char *const arg1,
-                                                       const char *const arg2,
-                                                       const char *const arg3);
-
-extern void VcxWrapperCommonStringDataCallback(vcx_command_handle_t xcommand_handle,
-                                               vcx_error_t err,
-                                               const char *const arg1,
-                                               const uint8_t *const arg2,
-                                               uint32_t arg3);
-
-extern void VcxWrapperCommonNumberCallback(vcx_command_handle_t xcommand_handle,
-                                           vcx_error_t err,
-                                           vcx_command_handle_t handle);
-
-extern void VcxWrapperCommonStringOptStringOptStringCallback(vcx_command_handle_t xcommand_handle,
-                                                             vcx_error_t err,
-                                                             const char *const arg1,
-                                                             const char *const arg2,
-                                                             const char *const arg3);
-
-extern void VcxWrapperCommonStringStringLongCallback(vcx_command_handle_t xcommand_handle,
-                                                     vcx_error_t err,
-                                                     const char *arg1,
-                                                     const char *arg2,
-                                                     unsigned long long arg3);
-
-extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
-                                                 vcx_error_t err,
-                                                 vcx_command_handle_t handle,
-                                                 const char *const arg2);
-
 @interface ConnectMeVcx : NSObject
 
 - (vcx_error_t) vcxInitCore:(NSString *)config;
@@ -85,7 +18,7 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
 - (void) createWallet:(NSString *)config
                  completion:(void (^)(NSError *error))completion;
 - (void) openMainWallet:(NSString *)config
-                 completion:(void (^)(NSError *error, NSInteger handle))completion;
+                 completion:(void (^)(NSError *error, NSNumber *handle))completion;
 - (void) closeMainWallet:(void (^)(NSError *error)) completion;
 - (void) vcxOpenPool:(void (^)(NSError *error)) completion;
 - (void) vcxOpenMainPool:(NSString *)config
@@ -106,128 +39,123 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
 
 - (void)connectionCreateWithInvite:(NSString *)invitationId
                      inviteDetails:(NSString *)inviteDetails
-                        completion:(void (^)(NSError *error, NSInteger connectionHandle))completion;
+                        completion:(void (^)(NSError *error, NSNumber *connectionHandle))completion;
 
-- (void)connectionConnect:(VcxHandle)connectionHandle
+- (void)connectionConnect:(NSNumber *)connectionHandle
            connectionType:(NSString *)connectionType
-               completion:(void (^)(NSError *error, NSString *inviteDetails))completion;
+               completion:(void (^)(NSError *error))completion;
 
-- (void)connectionGetState:(NSInteger)connectionHandle
-                completion:(void (^)(NSError *error, NSInteger state))completion;
+- (void)connectionGetState:(NSNumber *)connectionHandle
+                completion:(void (^)(NSError *error, NSNumber *state))completion;
 
-- (void)connectionUpdateState:(NSInteger) connectionHandle
-                   completion:(void (^)(NSError *error, NSInteger state))completion;
+- (void)connectionUpdateState:(NSNumber *)connectionHandle
+                   completion:(void (^)(NSError *error, NSNumber *state))completion;
 
-- (void)connectionSerialize:(NSInteger)connectionHandle
+- (void)connectionSerialize:(NSNumber *)connectionHandle
                  completion:(void (^)(NSError *error, NSString *serializedConnection))completion;
 
 - (void)connectionDeserialize:(NSString *)serializedConnection
-                   completion:(void (^)(NSError *error, NSInteger connectionHandle))completion;
+                   completion:(void (^)(NSError *error, NSNumber *connectionHandle))completion;
 
-- (int)connectionRelease:(NSInteger) connectionHandle;
+- (int)connectionRelease:(NSNumber *)connectionHandle;
 
-- (void)deleteConnection:(VcxHandle)connectionHandle
+- (void)deleteConnection:(NSNumber *)connectionHandle
           withCompletion:(void (^)(NSError *error))completion;
 
-- (void)connectionGetPwDid:(NSInteger)connectionHandle
+- (void)connectionGetPwDid:(NSNumber *)connectionHandle
                 completion:(void (^)(NSError *error, NSString *pwDid))completion;
 
-- (void)connectionGetTheirPwDid:(NSInteger)connectionHandle
+- (void)connectionGetTheirPwDid:(NSNumber *)connectionHandle
                      completion:(void (^)(NSError *error, NSString *theirPwDid))completion;
 
-- (void)connectionSendMessage:(VcxHandle)connectionHandle
+- (void)connectionSendMessage:(NSNumber *)connectionHandle
                   withMessage:(NSString *)message
        withSendMessageOptions:(NSString *)sendMessageOptions
                withCompletion:(void (^)(NSError *error, NSString *msg_id))completion;
 
-- (void)connectionSignData:(VcxHandle)connectionHandle
+- (void)connectionSignData:(NSNumber *)connectionHandle
                   withData:(NSData *)dataRaw
-            withCompletion:(void (^)(NSError *error, NSData *signature_raw, vcx_u32_t signature_len))completion;
+            withCompletion:(void (^)(NSError *error, NSData *signature_raw))completion;
 
-- (void)connectionVerifySignature:(VcxHandle)connectionHandle
+- (void)connectionVerifySignature:(NSNumber *)connectionHandle
                          withData:(NSData *)dataRaw
                 withSignatureData:(NSData *)signatureRaw
                    withCompletion:(void (^)(NSError *error, vcx_bool_t valid))completion;
 
-- (void)connectionDownloadMessages:(VcxHandle)connectionHandle
+- (void)connectionDownloadMessages:(NSNumber *)connectionHandle
                     messageStatus:(NSString *)messageStatus
                             uid_s:(NSString *)uid_s
                       completion:(void (^)(NSError *error, NSString* messages))completion;
 
-- (void)connectionSendHandshakeReuse:(VcxHandle)connectionHandle
+- (void)connectionSendHandshakeReuse:(NSNumber *)connectionHandle
                               oobMsg:(NSString *)oobMsg
                           completion:(void (^)(NSError *error))completion;
 
 - (void)agentUpdateInfo:(NSString *)config
              completion:(void (^)(NSError *error))completion;
 
-- (void)getCredential:(NSInteger )credentialHandle
+- (void)getCredential:(NSNumber *)credentialHandle
            completion:(void (^)(NSError *error, NSString *credential))completion;
 
 - (void)credentialCreateWithOffer:(NSString *)sourceId
                             offer:(NSString *)credentialOffer
-                       completion:(void (^)(NSError *error, NSInteger credentialHandle))completion;
+                       completion:(void (^)(NSError *error, NSNumber *credentialHandle))completion;
 
 - (void)credentialCreateWithMsgid:(NSString *)sourceId
-                 connectionHandle:(VcxHandle)connectionHandle
+                 connectionHandle:(NSNumber *)connectionHandle
                             msgId:(NSString *)msgId
-                       completion:(void (^)(NSError *error, NSInteger credentialHandle, NSString *credentialOffer))completion;
+                       completion:(void (^)(NSError *error, NSNumber *credentialHandle, NSString *credentialOffer))completion;
 
-- (void)credentialSendRequest:(NSInteger)credentialHandle
-             connectionHandle:(VcxHandle)connectionHandle
-                paymentHandle:(vcx_payment_handle_t)paymentHandle
+- (void)credentialSendRequest:(NSNumber *)credentialHandle
+             connectionHandle:(NSNumber *)connectionHandle
+                paymentHandle:(NSNumber *)paymentHandle
                    completion:(void (^)(NSError *error))completion;
 
-- (void)credentialGetState:(NSInteger )credentialHandle
-                completion:(void (^)(NSError *error, NSInteger state))completion;
+- (void)credentialGetState:(NSNumber *)credentialHandle
+                completion:(void (^)(NSError *error, NSNumber *state))completion;
 
-- (void)credentialUpdateState:(NSInteger )credentialHandle
-                completion:(void (^)(NSError *error, NSInteger state))completion;
+- (void)credentialUpdateState:(NSNumber *)credentialHandle
+                completion:(void (^)(NSError *error, NSNumber *state))completion;
 
-- (void)credentialUpdateStateV2:(NSInteger )credentailHandle
-                connectionHandle:(VcxHandle)connectionHandle
-                completion:(void (^)(NSError *error, NSInteger state))completion;
+- (void)credentialUpdateStateV2:(NSNumber *)credentailHandle
+                connectionHandle:(NSNumber *)connectionHandle
+                completion:(void (^)(NSError *error, NSNumber *state))completion;
 
-- (void)credentialUpdateStateWithMessageV2:(NSInteger )credentialHandle
-                connectionHandle:(VcxHandle)connectionHandle
-                message:(NSString *)message
-                completion:(void (^)(NSError *error, NSInteger state))completion;
-
-- (void)credentialGetOffers:(VcxHandle)connectionHandle
+- (void)credentialGetOffers:(NSNumber *)connectionHandle
                  completion:(void (^)(NSError *error, NSString *offers))completion;
 
-- (void)credentialGetAttributes:(VcxHandle)credentialHandle
+- (void)credentialGetAttributes:(NSNumber *)credentialHandle
                  completion:(void (^)(NSError *error, NSString *attributes))completion;
 
-- (void)credentialGetAttachment:(VcxHandle)credentialHandle
+- (void)credentialGetAttachment:(NSNumber *)credentialHandle
                  completion:(void (^)(NSError *error, NSString *attach))completion;
 
-- (void)credentialGetTailsLocation:(VcxHandle)credentialHandle
+- (void)credentialGetTailsLocation:(NSNumber *)credentialHandle
                  completion:(void (^)(NSError *error, NSString *tailsLocation))completion;
 
-- (void)credentialGetTailsHash:(VcxHandle)credentialHandle
+- (void)credentialGetTailsHash:(NSNumber *)credentialHandle
                  completion:(void (^)(NSError *error, NSString *tailsHash))completion;
 
-- (void)credentialGetRevRegId:(VcxHandle)credentialHandle
+- (void)credentialGetRevRegId:(NSNumber *)credentialHandle
                  completion:(void (^)(NSError *error, NSString *revRegId))completion;
 
-- (void)credentialIsRevokable:(VcxHandle)credentialHandle
-                 completion:(void (^)(NSError *error, vcx_bool_t revokable))completion;
+- (void)credentialIsRevokable:(NSNumber *)credentialHandle
+                 completion:(void (^)(NSError *error, BOOL revokable))completion;
 
-- (void)credentialSerialize:(NSInteger)credentialHandle
+- (void)credentialSerialize:(NSNumber *)credentialHandle
                  completion:(void (^)(NSError *error, NSString *state))completion;
 
 - (void)credentialDeserialize:(NSString *)serializedCredential
-                   completion:(void (^)(NSError *error, NSInteger credentialHandle))completion;
+                   completion:(void (^)(NSError *error, NSNumber *credentialHandle))completion;
 
-- (int)credentialRelease:(NSInteger) credentialHandle;
+- (int)credentialRelease:(NSNumber *) credentialHandle;
 
-- (void)deleteCredential:(NSInteger)credentialHandle
+- (void)deleteCredential:(NSNumber *)credentialHandle
                   completion:(void (^)(NSError *error))completion;
 
 - (void)exportWallet:(NSString *)exportPath
          encryptWith:(NSString *)encryptionKey
-          completion:(void (^)(NSError *error, NSInteger exportHandle))completion;
+          completion:(void (^)(NSError *error))completion;
 
 - (void)importWallet:(NSString *)config
            completion:(void (^)(NSError *error))completion;
@@ -270,76 +198,76 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
 - (void)openSearchWallet:(NSString *)recordType
                queryJson:(NSString *)queryJson
              optionsJson:(NSString *)optionsJson
-              completion:(void (^)(NSError *error, NSInteger searchHandle))completion;
+              completion:(void (^)(NSError *error, NSNumber *searchHandle))completion;
 
-- (void)searchNextRecordsWallet:(NSInteger)searchHandle
-                          count:(int)count
+- (void)searchNextRecordsWallet:(NSNumber *)searchHandle
+                          count:(NSNumber *)count
                      completion:(void (^)(NSError *error, NSString* records))completion;
 
-- (void)closeSearchWallet:(NSInteger)searchHandle
+- (void)closeSearchWallet:(NSNumber *)searchHandle
                completion:(void (^)(NSError *error))completion;
 
-- (void) proofGetRequests:(NSInteger)connectionHandle
+- (void) proofGetRequests:(NSNumber *)connectionHandle
               completion:(void (^)(NSError *error, NSString *requests))completion;
 
-- (void) proofGetProofRequestAttachment:(NSInteger)proofHandle
+- (void) proofGetProofRequestAttachment:(NSNumber *)proofHandle
               completion:(void (^)(NSError *error, NSString *attach))completion;
 
-- (void) proofRetrieveCredentials:(vcx_proof_handle_t)proofHandle
+- (void) proofRetrieveCredentials:(NSNumber *)proofHandle
                    withCompletion:(void (^)(NSError *error, NSString *matchingCredentials))completion;
 
-- (void) proofGenerate:(vcx_proof_handle_t)proofHandle
+- (void) proofGenerate:(NSNumber *)proofHandle
 withSelectedCredentials:(NSString *)selectedCredentials
  withSelfAttestedAttrs:(NSString *)selfAttestedAttributes
         withCompletion:(void (^)(NSError *error))completion;
 
 - (void) proofCreateWithMsgId:(NSString *)source_id
-         withConnectionHandle:(vcx_connection_handle_t)connectionHandle
+         withConnectionHandle:(NSNumber *)connectionHandle
                     withMsgId:(NSString *)msgId
-               withCompletion:(void (^)(NSError *error, vcx_proof_handle_t proofHandle, NSString *proofRequest))completion;
+               withCompletion:(void (^)(NSError *error, NSNumber *proofHandle, NSString *proofRequest))completion;
 
 - (void) proofSend:(vcx_proof_handle_t)proof_handle
 withConnectionHandle:(vcx_connection_handle_t)connection_handle
     withCompletion:(void (^)(NSError *error))completion;
 
-- (void)proofGetState:(NSInteger)proofHandle
-           completion:(void (^)(NSError *error, NSInteger state))completion;
+- (void)proofGetState:(NSNumber *)proofHandle
+           completion:(void (^)(NSError *error, NSNumber *state))completion;
 
-- (void)proofUpdateState:(NSInteger) proofHandle
-              completion:(void (^)(NSError *error, NSInteger state))completion;
+- (void)proofUpdateState:(NSNumber *) proofHandle
+              completion:(void (^)(NSError *error, NSNumber *state))completion;
 
-- (void)proofUpdateStateV2:(NSInteger) proofHandle
-              connectionHandle:(vcx_connection_handle_t)connectionHandle
-              completion:(void (^)(NSError *error, NSInteger state))completion;
+- (void)proofUpdateStateV2:(NSNumber *) proofHandle
+              connectionHandle:(NSNumber *)connectionHandle
+              completion:(void (^)(NSError *error, NSNumber *state))completion;
 
-- (void)proofUpdateStateWithMessageV2:(NSInteger) proofHandle
-              connectionHandle:(vcx_connection_handle_t)connectionHandle
-              message:(NSString *)message
-              completion:(void (^)(NSError *error, NSInteger state))completion;
+- (void) proofReject:(NSNumber *)proof_handle
+      withConnectionHandle:(NSNumber *)connection_handle
+      withCompletion:(void (^)(NSError *error))completion;
 
-- (void) proofReject: (vcx_proof_handle_t)proof_handle
-      withConnectionHandle:(vcx_connection_handle_t)connection_handle
-      withCompletion: (void (^)(NSError *error))completion;
-
-- (void) getProofMsg:(vcx_proof_handle_t) proofHandle
+- (void) getProofMsg:(NSNumber *) proofHandle
       withCompletion:(void (^)(NSError *error, NSString *proofMsg))completion;
 
-- (void) getRejectMsg:(vcx_proof_handle_t) proofHandle
+- (void) getRejectMsg:(NSNumber *) proofHandle
        withCompletion:(void (^)(NSError *error, NSString *rejectMsg))completion;
 
 - (void) proofCreateWithRequest:(NSString *) source_id
                withProofRequest:(NSString *) proofRequest
-                 withCompletion:(void (^)(NSError *error, vcx_proof_handle_t proofHandle))completion;
+                 withCompletion:(void (^)(NSError *error, NSNumber *proofHandle))completion;
 
-- (void) proofSerialize:(vcx_proof_handle_t) proofHandle
+- (void) proofSerialize:(NSNumber *) proofHandle
          withCompletion:(void (^)(NSError *error, NSString *proof_request))completion;
 
 - (void) proofDeserialize:(NSString *) serializedProof
-           withCompletion:(void (^)(NSError *error, vcx_proof_handle_t proofHandle)) completion;
+           withCompletion:(void (^)(NSError *error, NSNumber *proofHandle)) completion;
 
-- (int)proofRelease:(NSInteger) proofHandle;
+- (int)proofRelease:(NSNumber *) proofHandle;
 
 - (int)vcxShutdown:(BOOL *)deleteWallet;
+
+- (void)downloadMessages:(NSString *)messageStatus
+                    uid_s:(NSString *)uid_s
+                  pwdids:(NSString *)pwdids
+              completion:(void (^)(NSError *error, NSString* messages))completion;
 
 - (void)downloadMessagesV2:(NSString *)connectionHandles
             messageStatus:(NSString *)messageStatus

--- a/wrappers/ios/vcx/ConnectMeVcx.h
+++ b/wrappers/ios/vcx/ConnectMeVcx.h
@@ -264,11 +264,6 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
 
 - (int)vcxShutdown:(BOOL *)deleteWallet;
 
-- (void)downloadMessages:(NSString *)messageStatus
-                    uid_s:(NSString *)uid_s
-                  pwdids:(NSString *)pwdids
-              completion:(void (^)(NSError *error, NSString* messages))completion;
-
 - (void)downloadMessagesV2:(NSString *)connectionHandles
             messageStatus:(NSString *)messageStatus
                     uid_s:(NSString *)uid_s

--- a/wrappers/ios/vcx/ConnectMeVcx.m
+++ b/wrappers/ios/vcx/ConnectMeVcx.m
@@ -30,47 +30,50 @@ void VcxWrapperCommonCallback(vcx_command_handle_t xcommand_handle,
 
 void VcxWrapperCommonHandleCallback(vcx_command_handle_t xcommand_handle,
                                     vcx_error_t err,
-                                    vcx_command_handle_t pool_handle) {
+                                    vcx_command_handle_t h) {
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, VcxHandle) = (void (^)(NSError *, VcxHandle)) block;
+    void (^completion)(NSError *, NSNumber *) = (void (^)(NSError *, NSNumber *)) block;
 
     if (completion) {
         dispatch_async(dispatch_get_main_queue(), ^{
             NSError *error = [NSError errorFromVcxError:err];
-            completion(error, (VcxHandle) pool_handle);
+            NSNumber *handle = [NSNumber numberWithUnsignedInt:h];
+            completion(error, handle);
         });
     }
 }
 
 void VcxWrapperCommonSignedHandleCallback(vcx_command_handle_t xcommand_handle,
-                                    vcx_error_t err,
-                                    vcx_i32_t handle) {
+                                          vcx_error_t err,
+                                          VcxHandle h) {
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, VcxHandle) = (void (^)(NSError *, VcxHandle)) block;
+    void (^completion)(NSError *, NSNumber *) = (void (^)(NSError *, NSNumber *)) block;
 
     if (completion) {
         dispatch_async(dispatch_get_main_queue(), ^{
             NSError *error = [NSError errorFromVcxError:err];
-            completion(error, (VcxHandle) handle);
+            NSNumber *handle = [NSNumber numberWithInt:h];
+            completion(error, handle);
         });
     }
 }
 
 void VcxWrapperCommonNumberCallback(vcx_command_handle_t xcommand_handle,
                                     vcx_error_t err,
-                                    vcx_command_handle_t handle) {
+                                    vcx_u32_t h) {
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, vcx_command_handle_t) = (void (^)(NSError *, vcx_command_handle_t)) block;
+    void (^completion)(NSError *, NSNumber *) = (void (^)(NSError *, NSNumber *)) block;
 
     if (completion) {
         dispatch_async(dispatch_get_main_queue(), ^{
             NSError *error = [NSError errorFromVcxError:err];
+            NSNumber *handle = [NSNumber numberWithUnsignedInt:h];
             completion(error, handle);
         });
     }
@@ -98,11 +101,11 @@ void VcxWrapperCommonStringCallback(vcx_command_handle_t xcommand_handle,
 
 void VcxWrapperCommonBoolCallback(vcx_command_handle_t xcommand_handle,
                                   vcx_error_t err,
-                                  unsigned int arg1) {
+                                  vcx_bool_t arg1) {
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, BOOL) = (void (^)(NSError *, BOOL arg1)) block;
+    void (^completion)(NSError *, BOOL) = (void (^)(NSError *, BOOL)) block;
 
     if (completion) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -119,7 +122,7 @@ void VcxWrapperCommonStringStringCallback(vcx_command_handle_t xcommand_handle,
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, NSString *arg1, NSString *arg2) = (void (^)(NSError *, NSString *arg1, NSString *arg2)) block;
+    void (^completion)(NSError *, NSString *, NSString *) = (void (^)(NSError *, NSString *, NSString *)) block;
 
     NSString *sarg1 = nil;
     if (arg1) {
@@ -145,7 +148,7 @@ void VcxWrapperCommonStringOptStringCallback(vcx_command_handle_t xcommand_handl
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, NSString *arg1, NSString *arg2) = (void (^)(NSError *, NSString *arg1, NSString *arg2)) block;
+    void (^completion)(NSError *, NSString *, NSString *) = (void (^)(NSError *, NSString *, NSString *)) block;
 
     NSString *sarg1 = nil;
     if (arg1) {
@@ -172,7 +175,7 @@ void VcxWrapperCommonStringOptStringOptStringCallback(vcx_command_handle_t xcomm
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, NSString *arg1, NSString *arg2, NSString *arg3) = (void (^)(NSError *, NSString *arg1, NSString *arg2, NSString *arg3)) block;
+    void (^completion)(NSError *, NSString *, NSString *, NSString *) = (void (^)(NSError *, NSString *, NSString *, NSString *)) block;
 
     NSString *sarg1 = nil;
     if (arg1) {
@@ -203,7 +206,7 @@ void VcxWrapperCommonStringStringStringCallback(vcx_command_handle_t xcommand_ha
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, NSString *arg1, NSString *arg2, NSString *arg3) = (void (^)(NSError *, NSString *arg1, NSString *arg2, NSString *arg3)) block;
+    void (^completion)(NSError *, NSString *, NSString *, NSString *) = (void (^)(NSError *, NSString *, NSString *, NSString *)) block;
 
     NSString *sarg1 = nil;
     if (arg1) {
@@ -234,7 +237,7 @@ void VcxWrapperCommonDataCallback(vcx_command_handle_t xcommand_handle,
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, NSData *arg) = (void (^)(NSError *, NSData *arg)) block;
+    void (^completion)(NSError *, NSData *) = (void (^)(NSError *, NSData *)) block;
 
     NSData *sarg = [NSData dataWithBytes:arg1 length:arg2];
 
@@ -281,7 +284,7 @@ void VcxWrapperCommonStringStringLongCallback(vcx_command_handle_t xcommand_hand
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, NSString *, NSString *, NSNumber *) = (void (^)(NSError *, NSString *arg1, NSString *arg2, NSNumber *arg3)) block;
+    void (^completion)(NSError *, NSString *, NSString *, NSNumber *) = (void (^)(NSError *, NSString *, NSString *, NSNumber *)) block;
     NSString *sarg1 = nil;
     if (arg1) {
         sarg1 = [NSString stringWithUTF8String:arg1];
@@ -290,26 +293,26 @@ void VcxWrapperCommonStringStringLongCallback(vcx_command_handle_t xcommand_hand
     if (arg2) {
         sarg2 = [NSString stringWithUTF8String:arg2];
     }
-    NSNumber *sarg3 = [NSNumber numberWithInt:arg3];
+    NSNumber *sarg3 = [NSNumber numberWithUnsignedLongLong:arg3];
 
 
     if (completion) {
         dispatch_async(dispatch_get_main_queue(), ^{
             NSError *error = [NSError errorFromVcxError:err];
-            completion(error, (NSString *) sarg1, (NSString *) sarg2, (NSNumber *) sarg3);
+            completion(error, sarg1, sarg2, sarg3);
         });
     }
 }
 
 void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
                                           vcx_error_t err,
-                                          vcx_command_handle_t handle,
+                                          vcx_command_handle_t h,
                                           const char *const arg2
                                           ) {
     id block = [[VcxCallbacks sharedInstance] commandCompletionFor:xcommand_handle];
     [[VcxCallbacks sharedInstance] deleteCommandHandleFor:xcommand_handle];
 
-    void (^completion)(NSError *, vcx_command_handle_t arg1, NSString *arg2) = (void (^)(NSError *, vcx_command_handle_t arg1, NSString *arg2)) block;
+    void (^completion)(NSError *, NSNumber *, NSString *) = (void (^)(NSError *, NSNumber *, NSString *)) block;
 
     NSString *sarg2 = nil;
     if (arg2) {
@@ -319,7 +322,8 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     if (completion) {
         dispatch_async(dispatch_get_main_queue(), ^{
             NSError *error = [NSError errorFromVcxError:err];
-            completion(error, handle, (NSString *) sarg2);
+            NSNumber *handle = [NSNumber numberWithUnsignedInt:h];
+            completion(error, handle, sarg2);
         });
     }
 }
@@ -351,7 +355,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 }
 
 - (void) openMainWallet: (NSString *) config
-            completion: (void (^)(NSError *error)) completion
+            completion: (void (^)(NSError *error, NSNumber *handle)) completion
 {
    vcx_error_t ret;
 
@@ -363,7 +367,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
 
        dispatch_async(dispatch_get_main_queue(), ^{
-           completion([NSError errorFromVcxError: ret]);
+           completion([NSError errorFromVcxError: ret], nil);
        });
    }
 }
@@ -414,13 +418,13 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 
         dispatch_async(dispatch_get_main_queue(), ^{
             NSLog(@"ERROR: agentProvision: calling completion");
-            completion([NSError errorFromVcxError: ret], false);
+            completion([NSError errorFromVcxError: ret], nil);
         });
     }
 }
 
 - (void)vcxCreateAgencyClientForMainWallet:(NSString *)config
-               completion:(void (^)(NSError *error, NSString *config))completion
+               completion:(void (^)(NSError *error))completion
 {
     const char *config_char = [config cStringUsingEncoding:NSUTF8StringEncoding];
     vcx_command_handle_t handle= [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
@@ -431,7 +435,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 
         dispatch_async(dispatch_get_main_queue(), ^{
             NSLog(@"ERROR: vcxCreateAgencyClientForMainWallet: calling completion");
-            completion([NSError errorFromVcxError: ret], false);
+            completion([NSError errorFromVcxError: ret]);
         });
     }
 }
@@ -467,33 +471,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 
 - (void)connectionCreateWithInvite:(NSString *)invitationId
                 inviteDetails:(NSString *)inviteDetails
-             completion:(void (^)(NSError *error, NSInteger connectionHandle)) completion
+             completion:(void (^)(NSError *error, NSNumber *connectionHandle)) completion
 {
    vcx_error_t ret;
 
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
    const char *invitationId_char = [invitationId cStringUsingEncoding:NSUTF8StringEncoding];
    const char *inviteDetails_char = [inviteDetails cStringUsingEncoding:NSUTF8StringEncoding];
-   ret = vcx_connection_create_with_invite(handle, invitationId_char, inviteDetails_char, VcxWrapperCommonHandleCallback);
-   if( ret != 0 )
-   {
-       [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
-
-       dispatch_async(dispatch_get_main_queue(), ^{
-           completion([NSError errorFromVcxError: ret], 0);
-       });
-   }
-}
-
-- (void)connectionConnect: (NSInteger) connectionHandle
-        connectionType: (NSString *) connectionType
-            completion: (void (^)(NSError *error, NSString *inviteDetails)) completion
-{
-   vcx_error_t ret;
-
-   vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-   const char *connectionType_char = [connectionType cStringUsingEncoding:NSUTF8StringEncoding];
-    ret = vcx_connection_connect(handle, connectionHandle, connectionType_char, VcxWrapperCommonStringCallback);
+   ret = vcx_connection_create_with_invite(handle, invitationId_char, inviteDetails_char, VcxWrapperCommonNumberCallback);
    if( ret != 0 )
    {
        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
@@ -504,79 +489,98 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)connectionGetState:(NSInteger)connectionHandle
-                completion:(void (^)(NSError *error, NSInteger state))completion {
+- (void)connectionConnect: (NSNumber *)connectionHandle
+        connectionType: (NSString *) connectionType
+            completion: (void (^)(NSError *error)) completion
+{
+   vcx_error_t ret;
+
+   vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+   const char *connectionType_char = [connectionType cStringUsingEncoding:NSUTF8StringEncoding];
+    ret = vcx_connection_connect(handle, connectionHandle.unsignedIntValue, connectionType_char, VcxWrapperCommonCallback);
+   if( ret != 0 )
+   {
+       [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+       dispatch_async(dispatch_get_main_queue(), ^{
+           completion([NSError errorFromVcxError: ret]);
+       });
+   }
+}
+
+- (void)connectionGetState:(NSNumber *)connectionHandle
+                completion:(void (^)(NSError *error, NSNumber *state))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    ret = vcx_connection_get_state(handle, connectionHandle, VcxWrapperCommonNumberCallback);
+    ret = vcx_connection_get_state(handle, connectionHandle.unsignedIntValue, VcxWrapperCommonNumberCallback);
     
     if( ret != 0 )
     {
         [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            completion([NSError errorFromVcxError: ret], 0);
+            completion([NSError errorFromVcxError: ret], nil);
         });
     }
 }
 
-- (void)connectionUpdateState:(NSInteger) connectionHandle
-                   completion:(void (^)(NSError *error, NSInteger state))completion {
+- (void)connectionUpdateState:(NSNumber *)connectionHandle
+                   completion:(void (^)(NSError *error, NSNumber *state))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    ret = vcx_connection_update_state(handle, connectionHandle, VcxWrapperCommonNumberCallback);
+    ret = vcx_connection_update_state(handle, connectionHandle.unsignedIntValue, VcxWrapperCommonNumberCallback);
     if( ret != 0 )
     {
         [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
         dispatch_async(dispatch_get_main_queue(), ^{
-            completion([NSError errorFromVcxError: ret], 0);
+            completion([NSError errorFromVcxError: ret], nil);
         });
     }
 }
 
-- (void)connectionSerialize:(NSInteger)connectionHandle
+- (void)connectionSerialize:(NSNumber *)connectionHandle
                   completion:(void (^)(NSError *error, NSString *serializedConnection))completion{
     vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_connection_serialize(handle, connectionHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_connection_serialize(handle, connectionHandle.unsignedIntValue, VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
 
        dispatch_async(dispatch_get_main_queue(), ^{
-           completion([NSError errorFromVcxError: ret],nil);
+           completion([NSError errorFromVcxError: ret], nil);
        });
    }
 }
 
 - (void)connectionDeserialize:(NSString *)serializedConnection
-                    completion:(void (^)(NSError *error, NSInteger connectionHandle))completion{
+                    completion:(void (^)(NSError *error, NSNumber *connectionHandle))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char *serialized_connection=[serializedConnection cStringUsingEncoding:NSUTF8StringEncoding];
-    ret = vcx_connection_deserialize(handle, serialized_connection, VcxWrapperCommonHandleCallback);
+    ret = vcx_connection_deserialize(handle, serialized_connection, VcxWrapperCommonNumberCallback);
 
    if( ret != 0 )
    {
        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
 
        dispatch_async(dispatch_get_main_queue(), ^{
-           completion([NSError errorFromVcxError: ret],0);
+           completion([NSError errorFromVcxError: ret], nil);
        });
    }
 }
 
-- (int)connectionRelease:(NSInteger) connectionHandle {
-    return vcx_connection_release(connectionHandle);
+- (int)connectionRelease:(NSNumber *)connectionHandle {
+    return vcx_connection_release(connectionHandle.unsignedIntValue);
 }
 
-- (void)deleteConnection:(VcxHandle)connectionHandle
+- (void)deleteConnection:(NSNumber *)connectionHandle
           withCompletion:(void (^)(NSError *error))completion
 {
     vcx_command_handle_t handle= [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    vcx_error_t ret = vcx_connection_delete_connection(handle, connectionHandle, VcxWrapperCommonCallback);
+    vcx_error_t ret = vcx_connection_delete_connection(handle, connectionHandle.unsignedIntValue, VcxWrapperCommonCallback);
     if( ret != 0 )
     {
         [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
@@ -588,43 +592,43 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)connectionGetPwDid:(NSInteger)connectionHandle
+- (void)connectionGetPwDid:(NSNumber *)connectionHandle
                    completion:(void (^)(NSError *error, NSString *pwDid))completion
 {
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_connection_get_pw_did(handle,connectionHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_connection_get_pw_did(handle,connectionHandle.unsignedIntValue, VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
 
        dispatch_async(dispatch_get_main_queue(), ^{
-           completion([NSError errorFromVcxError: ret],nil);
+           completion([NSError errorFromVcxError: ret], nil);
        });
    }
 }
 
-- (void)connectionGetTheirPwDid:(NSInteger)connectionHandle
+- (void)connectionGetTheirPwDid:(NSNumber *)connectionHandle
                    completion:(void (^)(NSError *error, NSString *theirPwDid))completion
 {
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_connection_get_their_pw_did(handle,connectionHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_connection_get_their_pw_did(handle,connectionHandle.unsignedIntValue, VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
 
        dispatch_async(dispatch_get_main_queue(), ^{
-           completion([NSError errorFromVcxError: ret],nil);
+           completion([NSError errorFromVcxError: ret], nil);
        });
    }
 }
 
-- (void)connectionSendMessage:(VcxHandle)connectionHandle
+- (void)connectionSendMessage:(NSNumber *)connectionHandle
                   withMessage:(NSString *)message
        withSendMessageOptions:(NSString *)sendMessageOptions
                withCompletion:(void (^)(NSError *error, NSString *msg_id))completion
@@ -633,7 +637,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     const char *message_ctype = [message cStringUsingEncoding:NSUTF8StringEncoding];
     const char *sendMessageOptions_ctype = [sendMessageOptions cStringUsingEncoding:NSUTF8StringEncoding];
     vcx_error_t ret = vcx_connection_send_message(handle,
-                                                  connectionHandle,
+                                                  connectionHandle.unsignedIntValue,
                                                   message_ctype,
                                                   sendMessageOptions_ctype,
                                                   VcxWrapperCommonStringCallback);
@@ -646,26 +650,30 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)connectionSignData:(VcxHandle)connectionHandle
+- (void)connectionSignData:(NSNumber *)connectionHandle
                   withData:(NSData *)dataRaw
-            withCompletion:(void (^)(NSError *error, NSData *signature_raw, vcx_u32_t signature_len))completion
+            withCompletion:(void (^)(NSError *error, NSData *signature_raw))completion
 {
     vcx_command_handle_t handle= [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
     uint8_t *data_raw = (uint8_t *) [dataRaw bytes];
     uint32_t data_length = (uint32_t) [dataRaw length];
 
-    vcx_error_t ret = vcx_connection_sign_data(handle, connectionHandle, data_raw, data_length, VcxWrapperCommonDataCallback);
+    vcx_error_t ret = vcx_connection_sign_data(handle,
+                                               connectionHandle.unsignedIntValue,
+                                               data_raw,
+                                               data_length,
+                                               VcxWrapperCommonDataCallback);
     if (ret != 0)
     {
         [[VcxCallbacks sharedInstance] deleteCommandHandleFor:handle];
         dispatch_async(dispatch_get_main_queue(), ^{
-            completion([NSError errorFromVcxError: ret], nil, 0);
+            completion([NSError errorFromVcxError: ret], nil);
         });
     }
 }
 
-- (void)connectionVerifySignature:(VcxHandle)connectionHandle
+- (void)connectionVerifySignature:(NSNumber *)connectionHandle
                          withData:(NSData *)dataRaw
                 withSignatureData:(NSData *)signatureRaw
                    withCompletion:(void (^)(NSError *error, vcx_bool_t valid))completion
@@ -679,7 +687,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     uint32_t signature_length = (uint32_t) [signatureRaw length];
 
     vcx_error_t ret = vcx_connection_verify_signature(handle,
-                                                      connectionHandle,
+                                                      connectionHandle.unsignedIntValue,
                                                       data_raw,
                                                       data_length,
                                                       signature_raw,
@@ -694,14 +702,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)connectionDownloadMessages:(VcxHandle)connectionHandle
+- (void)connectionDownloadMessages:(NSNumber *)connectionHandle
                     messageStatus:(NSString *)messageStatus
                             uid_s:(NSString *)uid_s
                       completion:(void (^)(NSError *error, NSString* messages))completion {
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char * message_status = [messageStatus cStringUsingEncoding:NSUTF8StringEncoding];
     const char * uids = [uid_s cStringUsingEncoding:NSUTF8StringEncoding];
-    vcx_error_t ret = vcx_connection_messages_download(handle, connectionHandle, message_status, uids, VcxWrapperCommonStringCallback);
+    vcx_error_t ret = vcx_connection_messages_download(handle, connectionHandle.unsignedIntValue, message_status, uids, VcxWrapperCommonStringCallback);
 
     if( ret != 0 )
     {
@@ -713,12 +721,12 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)connectionSendHandshakeReuse:(VcxHandle)connectionHandle
+- (void)connectionSendHandshakeReuse:(NSNumber *)connectionHandle
                               oobMsg:(NSString *)oobMsg
                           completion:(void (^)(NSError *error))completion {
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char *oobMsg_ctype = [oobMsg cStringUsingEncoding:NSUTF8StringEncoding];
-    vcx_error_t ret = vcx_connection_send_handshake_reuse(handle, connectionHandle, oobMsg_ctype, VcxWrapperCommonCallback);
+    vcx_error_t ret = vcx_connection_send_handshake_reuse(handle, connectionHandle.unsignedIntValue, oobMsg_ctype, VcxWrapperCommonCallback);
 
     if( ret != 0 )
     {
@@ -730,11 +738,11 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)getCredential:(NSInteger)credentialHandle
+- (void)getCredential:(NSNumber *)credentialHandle
            completion:(void (^)(NSError *error, NSString *credential))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    ret = vcx_get_credential(handle, credentialHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_get_credential(handle, credentialHandle.unsignedIntValue, VcxWrapperCommonStringCallback);
 
     if( ret != 0 )
     {
@@ -748,7 +756,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 
 - (void)credentialCreateWithOffer:(NSString *)sourceId
             offer:(NSString *)credentialOffer
-           completion:(void (^)(NSError *error, NSInteger credentialHandle))completion{
+           completion:(void (^)(NSError *error, NSNumber *credentialHandle))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
    const char * credential_offer=[credentialOffer cStringUsingEncoding:NSUTF8StringEncoding];
@@ -766,14 +774,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 }
 
 - (void)credentialCreateWithMsgid:(NSString *)sourceId
-                 connectionHandle:(VcxHandle)connectionHandle
+                 connectionHandle:(NSNumber *)connectionHandle
                             msgId:(NSString *)msgId
-                       completion:(void (^)(NSError *error, NSInteger credentialHandle, NSString *credentialOffer))completion {
+                       completion:(void (^)(NSError *error, NSNumber *credentialHandle, NSString *credentialOffer))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char * source_id = [sourceId cStringUsingEncoding:NSUTF8StringEncoding];
     const char * msg_id= [msgId cStringUsingEncoding:NSUTF8StringEncoding];
-    ret = vcx_credential_create_with_msgid(handle, source_id, connectionHandle, msg_id, VcxWrapperCommonNumberStringCallback);
+    ret = vcx_credential_create_with_msgid(handle, source_id, connectionHandle.unsignedIntValue, msg_id, VcxWrapperCommonNumberStringCallback);
 
     if( ret != 0 )
     {
@@ -785,13 +793,17 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)credentialSendRequest:(NSInteger)credentialHandle
-             connectionHandle:(VcxHandle)connectionHandle
-                paymentHandle:(vcx_payment_handle_t)paymentHandle
+- (void)credentialSendRequest:(NSNumber *)credentialHandle
+             connectionHandle:(NSNumber *)connectionHandle
+                paymentHandle:(NSNumber *)paymentHandle
                    completion:(void (^)(NSError *))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    ret = vcx_credential_send_request(handle, credentialHandle, connectionHandle, paymentHandle, VcxWrapperCommonCallback);
+    ret = vcx_credential_send_request(handle,
+                                      credentialHandle.unsignedIntValue,
+                                      connectionHandle.unsignedIntValue,
+                                      paymentHandle.unsignedIntValue,
+                                      VcxWrapperCommonCallback);
 
     if( ret != 0 )
     {
@@ -802,11 +814,13 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
        });
     }
 }
-- (void)credentialGetState:(NSInteger)credentialHandle
-                completion:(void (^)(NSError *error, NSInteger state))completion{
+- (void)credentialGetState:(NSNumber *)credentialHandle
+                completion:(void (^)(NSError *error, NSNumber *state))completion{
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    ret = vcx_credential_get_state(handle, credentialHandle, VcxWrapperCommonNumberCallback);
+    ret = vcx_credential_get_state(handle,
+                                   credentialHandle.unsignedIntValue,
+                                   VcxWrapperCommonNumberCallback);
 
     if( ret != 0 )
     {
@@ -818,12 +832,15 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)credentialUpdateStateV2:(NSInteger)credentialHandle
-               connectionHandle:(vcx_connection_handle_t)connectionHandle
-               completion:(void (^)(NSError *error, NSInteger state))completion {
+- (void)credentialUpdateStateV2:(NSNumber *)credentialHandle
+               connectionHandle:(NSNumber *)connectionHandle
+               completion:(void (^)(NSError *error, NSNumber *state))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    ret = vcx_v2_credential_update_state(handle, credentialHandle, connectionHandle, VcxWrapperCommonNumberCallback);
+    ret = vcx_v2_credential_update_state(handle,
+                                         credentialHandle.unsignedIntValue,
+                                         connectionHandle.unsignedIntValue,
+                                         VcxWrapperCommonNumberCallback);
 
     if( ret != 0 )
     {
@@ -835,31 +852,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)credentialUpdateStateWithMessageV2:(NSInteger)credentialHandle
-               connectionHandle:(vcx_connection_handle_t)connectionHandle
-               message:(NSString *)message
-               completion:(void (^)(NSError *error, NSInteger state))completion {
-    vcx_error_t ret;
-    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    const char *msg = [message cStringUsingEncoding:NSUTF8StringEncoding];
-    ret = vcx_v2_credential_update_state_with_message(handle, credentialHandle, connectionHandle, msg, VcxWrapperCommonNumberCallback);
-
-    if( ret != 0 )
-    {
-       [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
-
-       dispatch_async(dispatch_get_main_queue(), ^{
-           completion([NSError errorFromVcxError: ret], 0);
-       });
-    }
-}
-
-- (void)credentialGetOffers:(VcxHandle)connectionHandle
+- (void)credentialGetOffers:(NSNumber *)connectionHandle
                    completion:(void (^)(NSError *error, NSString *offers))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_credential_get_offers(handle,connectionHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_credential_get_offers(handle,
+                                    connectionHandle.unsignedIntValue,
+                                    VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
@@ -871,12 +871,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)credentialGetAttributes:(VcxHandle)credentialHandle
+- (void)credentialGetAttributes:(NSNumber *)credentialHandle
                    completion:(void (^)(NSError *error, NSString *attrs))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_credential_get_attributes(handle, credentialHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_credential_get_attributes(handle,
+                                        credentialHandle.unsignedIntValue,
+                                        VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
@@ -888,12 +890,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)credentialGetAttachment:(VcxHandle)credentialHandle
+- (void)credentialGetAttachment:(NSNumber *)credentialHandle
                    completion:(void (^)(NSError *error, NSString *attach))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_credential_get_attachment(handle, credentialHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_credential_get_attachment(handle,
+                                        credentialHandle.unsignedIntValue,
+                                        VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
@@ -905,12 +909,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)credentialGetTailsLocation:(VcxHandle)credentialHandle
+- (void)credentialGetTailsLocation:(NSNumber *)credentialHandle
                    completion:(void (^)(NSError *error, NSString *tailsLocation))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-   ret = vcx_credential_get_tails_location(handle, credentialHandle, VcxWrapperCommonStringCallback);
+   ret = vcx_credential_get_tails_location(handle,
+                                           credentialHandle.unsignedIntValue,
+                                           VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
@@ -922,12 +928,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)credentialGetTailsHash:(VcxHandle)credentialHandle
+- (void)credentialGetTailsHash:(NSNumber *)credentialHandle
                    completion:(void (^)(NSError *error, NSString *tailsHash))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-   ret = vcx_credential_get_tails_hash(handle, credentialHandle, VcxWrapperCommonStringCallback);
+   ret = vcx_credential_get_tails_hash(handle,
+                                       credentialHandle.unsignedIntValue,
+                                       VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
@@ -939,12 +947,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)credentialGetRevRegId:(VcxHandle)credentialHandle
+- (void)credentialGetRevRegId:(NSNumber *)credentialHandle
                    completion:(void (^)(NSError *error, NSString *revRegId))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-   ret = vcx_credential_get_rev_reg_id(handle, credentialHandle, VcxWrapperCommonStringCallback);
+   ret = vcx_credential_get_rev_reg_id(handle,
+                                       credentialHandle.unsignedIntValue,
+                                       VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
@@ -956,19 +966,21 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)credentialIsRevokable:(VcxHandle)credentialHandle
-                   completion:(void (^)(NSError *error, vcx_bool_t revokable))completion{
+- (void)credentialIsRevokable:(NSNumber *)credentialHandle
+                   completion:(void (^)(NSError *error, BOOL revokable))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-   ret = vcx_credential_is_revokable(handle, credentialHandle, VcxWrapperCommonBoolCallback);
+   ret = vcx_credential_is_revokable(handle,
+                                     credentialHandle.unsignedIntValue,
+                                     VcxWrapperCommonBoolCallback);
 
    if( ret != 0 )
    {
        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
 
        dispatch_async(dispatch_get_main_queue(), ^{
-           completion([NSError errorFromVcxError: ret],nil);
+           completion([NSError errorFromVcxError: ret], false);
        });
    }
 }
@@ -986,7 +998,12 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     const char *requestedAttrs_char = [requestedAttrs cStringUsingEncoding:NSUTF8StringEncoding];
     const char *requestedPredicates_char = [requestedPredicates cStringUsingEncoding:NSUTF8StringEncoding];
     const char *proofName_char = [proofName cStringUsingEncoding:NSUTF8StringEncoding];
-    ret = vcx_proof_create(handle, proofRequestId_char, requestedAttrs_char, requestedPredicates_char, proofName_char, VcxWrapperCommonStringCallback);
+    ret = vcx_proof_create(handle,
+                           proofRequestId_char,
+                           requestedAttrs_char,
+                           requestedPredicates_char,
+                           proofName_char,
+                           VcxWrapperCommonStringCallback);
 
     if ( ret != 0 )
     {
@@ -998,12 +1015,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)credentialSerialize:(NSInteger)credentialHandle
+- (void)credentialSerialize:(NSNumber *)credentialHandle
                   completion:(void (^)(NSError *error, NSString *state))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_credential_serialize(handle, credentialHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_credential_serialize(handle,
+                                   credentialHandle.unsignedIntValue,
+                                   VcxWrapperCommonStringCallback);
 
     if ( ret != 0 )
     {
@@ -1016,11 +1035,13 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 }
 
 - (void)credentialDeserialize:(NSString *)serializedCredential
-                    completion:(void (^)(NSError *error, NSInteger credentialHandle))completion{
+                    completion:(void (^)(NSError *error, NSNumber *credentialHandle))completion{
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char *serialized_credential = [serializedCredential cStringUsingEncoding:NSUTF8StringEncoding];
-    ret = vcx_credential_deserialize(handle, serialized_credential, VcxWrapperCommonNumberCallback);
+    ret = vcx_credential_deserialize(handle,
+                                     serialized_credential,
+                                     VcxWrapperCommonNumberCallback);
 
     if ( ret != 0 )
     {
@@ -1032,16 +1053,18 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (int)credentialRelease:(NSInteger) credentialHandle {
-    return vcx_credential_release(credentialHandle);
+- (int)credentialRelease:(NSNumber *) credentialHandle {
+    return vcx_credential_release(credentialHandle.unsignedIntValue);
 }
 
 
-- (void)deleteCredential:(NSInteger)credentialHandle
+- (void)deleteCredential:(NSNumber *)credentialHandle
           completion:(void (^)(NSError *error))completion
 {
     vcx_command_handle_t handle= [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    vcx_error_t ret = vcx_delete_credential(handle, credentialHandle, VcxWrapperCommonCallback);
+    vcx_error_t ret = vcx_delete_credential(handle,
+                                            credentialHandle.unsignedIntValue,
+                                            VcxWrapperCommonCallback);
     if( ret != 0 )
     {
         [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
@@ -1054,7 +1077,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 
 - (void)exportWallet:(NSString *)exportPath
             encryptWith:(NSString *)encryptionKey
-           completion:(void (^)(NSError *error, NSInteger exportHandle))completion {
+           completion:(void (^)(NSError *error))completion {
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
    const char * export_path=[exportPath cStringUsingEncoding:NSUTF8StringEncoding];
@@ -1066,7 +1089,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
 
        dispatch_async(dispatch_get_main_queue(), ^{
-           completion([NSError errorFromVcxError: ret], 0);
+           completion([NSError errorFromVcxError: ret]);
        });
    }
 }
@@ -1075,7 +1098,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
            completion:(void (^)(NSError *error))completion {
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    ret = vcx_wallet_import(handle, [config cStringUsingEncoding:NSUTF8StringEncoding], VcxWrapperCommonCallback);
+   ret = vcx_wallet_import(handle, [config cStringUsingEncoding:NSUTF8StringEncoding], VcxWrapperCommonCallback);
 
    if( ret != 0 )
    {
@@ -1252,7 +1275,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 - (void)openSearchWallet:(NSString *)recordType
                queryJson:(NSString *)queryJson
             optionsJson:(NSString *)optionsJson
-             completion:(void (^)(NSError *error, NSInteger searchHandle))completion {
+             completion:(void (^)(NSError *error, NSNumber *searchHandle))completion {
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
@@ -1263,7 +1286,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    const char * query_json = [queryJson cStringUsingEncoding:NSUTF8StringEncoding];
    const char * options_json =[optionsJson cStringUsingEncoding:NSUTF8StringEncoding];
 
-    ret = vcx_wallet_open_search(handle, record_type, query_json, options_json, VcxWrapperCommonHandleCallback);
+    ret = vcx_wallet_open_search(handle, record_type, query_json, options_json, VcxWrapperCommonNumberCallback);
 
    if( ret != 0 )
    {
@@ -1275,13 +1298,16 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)searchNextRecordsWallet:(NSInteger)searchHandle
-              count:(int)count
+- (void)searchNextRecordsWallet:(NSNumber *)searchHandle
+              count:(NSNumber *)count
             completion:(void (^)(NSError *error, NSString* records))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_wallet_search_next_records(handle, searchHandle, count, VcxWrapperCommonStringCallback);
+    ret = vcx_wallet_search_next_records(handle,
+                                         searchHandle.unsignedIntValue,
+                                         count.intValue,
+                                         VcxWrapperCommonStringCallback);
 
     if( ret != 0 )
     {
@@ -1293,12 +1319,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void)closeSearchWallet:(NSInteger)searchHandle
+- (void)closeSearchWallet:(NSNumber *)searchHandle
            completion:(void (^)(NSError *error))completion {
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-   ret = vcx_wallet_close_search(handle, searchHandle, VcxWrapperCommonCallback);
+   ret = vcx_wallet_close_search(handle,
+                                 searchHandle.unsignedIntValue,
+                                 VcxWrapperCommonCallback);
 
    if( ret != 0 )
    {
@@ -1310,12 +1338,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)proofGetRequests:(NSInteger)connectionHandle
+- (void)proofGetRequests:(NSNumber *)connectionHandle
                    completion:(void (^)(NSError *error, NSString *requests))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_disclosed_proof_get_requests(handle,connectionHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_disclosed_proof_get_requests(handle,
+                                           connectionHandle.unsignedIntValue,
+                                           VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
@@ -1327,12 +1357,14 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
    }
 }
 
-- (void)proofGetProofRequestAttachment:(NSInteger)proofHandle
+- (void)proofGetProofRequestAttachment:(NSNumber *)proofHandle
                    completion:(void (^)(NSError *error, NSString *attach))completion{
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_disclosed_proof_get_proof_request_attachment(handle, proofHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_disclosed_proof_get_proof_request_attachment(handle,
+                                                           proofHandle.unsignedIntValue,
+                                                           VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
@@ -1345,32 +1377,38 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 }
 
 - (void) proofCreateWithMsgId:(NSString *)sourceId
-         withConnectionHandle:(vcx_connection_handle_t)connectionHandle
+         withConnectionHandle:(NSNumber *)connectionHandle
                     withMsgId:(NSString *)msgId
-               withCompletion:(void (^)(NSError *error, vcx_proof_handle_t proofHandle, NSString *proofRequest))completion {
+               withCompletion:(void (^)(NSError *error, NSNumber *proofHandle, NSString *proofRequest))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char *source_id = [sourceId cStringUsingEncoding:NSUTF8StringEncoding];
     const char *msg_id = [msgId cStringUsingEncoding:NSUTF8StringEncoding];
 
-    ret = vcx_disclosed_proof_create_with_msgid(handle, source_id, connectionHandle, msg_id, VcxWrapperCommonNumberStringCallback);
+    ret = vcx_disclosed_proof_create_with_msgid(handle,
+                                                source_id,
+                                                connectionHandle.unsignedIntValue,
+                                                msg_id,
+                                                VcxWrapperCommonNumberStringCallback);
 
     if ( ret != 0 )
     {
         [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            completion([NSError errorFromVcxError: ret], 0, nil);
+            completion([NSError errorFromVcxError: ret], nil, nil);
         });
     }
 }
 
-- (void) proofRetrieveCredentials:(vcx_proof_handle_t)proofHandle
+- (void) proofRetrieveCredentials:(NSNumber *)proofHandle
                    withCompletion:(void (^)(NSError *error, NSString *matchingCredentials))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_disclosed_proof_retrieve_credentials(handle, proofHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_disclosed_proof_retrieve_credentials(handle,
+                                                   proofHandle.unsignedIntValue,
+                                                   VcxWrapperCommonStringCallback);
 
     if ( ret != 0 )
     {
@@ -1382,7 +1420,7 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
     }
 }
 
-- (void) proofGenerate:(vcx_proof_handle_t)proofHandle
+- (void) proofGenerate:(NSNumber *)proofHandle
 withSelectedCredentials:(NSString *)selectedCredentials
  withSelfAttestedAttrs:(NSString *)selfAttestedAttributes
         withCompletion:(void (^)(NSError *error))completion {
@@ -1391,7 +1429,11 @@ withSelectedCredentials:(NSString *)selectedCredentials
     const char *selected_credentials = [selectedCredentials cStringUsingEncoding:NSUTF8StringEncoding];
     const char *self_attested_attributes = [selfAttestedAttributes cStringUsingEncoding:NSUTF8StringEncoding];
 
-    ret = vcx_disclosed_proof_generate_proof(handle, proofHandle, selected_credentials, self_attested_attributes, VcxWrapperCommonCallback);
+    ret = vcx_disclosed_proof_generate_proof(handle,
+                                             proofHandle.unsignedIntValue,
+                                             selected_credentials,
+                                             self_attested_attributes,
+                                             VcxWrapperCommonCallback);
 
     if ( ret != 0 )
     {
@@ -1421,60 +1463,52 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     }
 }
 
-- (void)proofGetState:(NSInteger)proofHandle
-                completion:(void (^)(NSError *error, NSInteger state))completion {
+- (void)proofGetState:(NSNumber *)proofHandle
+                completion:(void (^)(NSError *error, NSNumber *state))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    ret = vcx_disclosed_proof_get_state(handle, proofHandle, VcxWrapperCommonNumberCallback);
+    ret = vcx_disclosed_proof_get_state(handle,
+                                        proofHandle.unsignedIntValue,
+                                        VcxWrapperCommonNumberCallback);
     
     if( ret != 0 )
     {
         [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            completion([NSError errorFromVcxError: ret], 0);
+            completion([NSError errorFromVcxError: ret], nil);
         });
     }
 }
 
-- (void)proofUpdateStateV2:(NSInteger) proofHandle
-               connectionHandle:(vcx_connection_handle_t)connectionHandle
-               completion:(void (^)(NSError *error, NSInteger state))completion {
+- (void) proofUpdateStateV2:(NSNumber *) proofHandle
+           connectionHandle:(NSNumber *)connectionHandle
+                 completion:(void (^)(NSError *error, NSNumber *state))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    ret = vcx_v2_disclosed_proof_update_state(handle, proofHandle, connectionHandle, VcxWrapperCommonNumberCallback);
+    ret = vcx_v2_disclosed_proof_update_state(handle,
+                                              proofHandle.unsignedIntValue,
+                                              connectionHandle.unsignedIntValue,
+                                              VcxWrapperCommonNumberCallback);
     if( ret != 0 )
     {
         [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
         dispatch_async(dispatch_get_main_queue(), ^{
-            completion([NSError errorFromVcxError: ret], 0);
+            completion([NSError errorFromVcxError: ret], nil);
         });
     }
 }
 
-- (void)proofUpdateStateWithMessageV2:(NSInteger) proofHandle
-               connectionHandle:(vcx_connection_handle_t)connectionHandle
-               message:(NSString *)message
-               completion:(void (^)(NSError *error, NSInteger state))completion {
-    vcx_error_t ret;
-    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    const char *msg = [message cStringUsingEncoding:NSUTF8StringEncoding];
-    ret = vcx_v2_disclosed_proof_update_state_with_message(handle, proofHandle, connectionHandle, msg, VcxWrapperCommonNumberCallback);
-    if( ret != 0 )
-    {
-        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            completion([NSError errorFromVcxError: ret], 0);
-        });
-    }
-}
-
-- (void) proofReject: (vcx_proof_handle_t)proof_handle withConnectionHandle:(vcx_connection_handle_t)connection_handle
-      withCompletion: (void (^)(NSError *error))completion {
+- (void) proofReject:(NSNumber *)proof_handle
+withConnectionHandle:(NSNumber *)connection_handle
+      withCompletion:(void (^)(NSError *error))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor: completion];
 
-    ret = vcx_disclosed_proof_reject_proof(handle, proof_handle, connection_handle, VcxWrapperCommonCallback);
+    ret = vcx_disclosed_proof_reject_proof(handle,
+                                           proof_handle.unsignedIntValue,
+                                           connection_handle.unsignedIntValue,
+                                           VcxWrapperCommonCallback);
 
     if (ret != 0)
     {
@@ -1486,12 +1520,14 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     }
 }
 
-- (void) getProofMsg:(vcx_proof_handle_t) proofHandle
+- (void) getProofMsg:(NSNumber *) proofHandle
          withCompletion:(void (^)(NSError *error, NSString *proofMsg))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_disclosed_proof_get_proof_msg(handle, proofHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_disclosed_proof_get_proof_msg(handle,
+                                            proofHandle.unsignedIntValue,
+                                            VcxWrapperCommonStringCallback);
 
     if( ret != 0 )
     {
@@ -1503,12 +1539,14 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     }
 }
 
-- (void) getRejectMsg:(vcx_proof_handle_t) proofHandle
+- (void) getRejectMsg:(NSNumber *) proofHandle
          withCompletion:(void (^)(NSError *error, NSString *rejectMsg))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_disclosed_proof_get_reject_msg(handle, proofHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_disclosed_proof_get_reject_msg(handle,
+                                             proofHandle.unsignedIntValue,
+                                             VcxWrapperCommonStringCallback);
 
     if( ret != 0 )
     {
@@ -1522,12 +1560,15 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
 
 - (void) proofCreateWithRequest:(NSString *) source_id
                withProofRequest:(NSString *) proofRequest
-                 withCompletion:(void (^)(NSError *error, vcx_proof_handle_t proofHandle))completion {
+                 withCompletion:(void (^)(NSError *error, NSNumber *proofHandle))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char *sourceId = [source_id cStringUsingEncoding:NSUTF8StringEncoding];
     const char *proof_request = [proofRequest cStringUsingEncoding:NSUTF8StringEncoding];
-    ret = vcx_disclosed_proof_create_with_request(handle, sourceId, proof_request, VcxWrapperCommonNumberCallback);
+    ret = vcx_disclosed_proof_create_with_request(handle,
+                                                  sourceId,
+                                                  proof_request,
+                                                  VcxWrapperCommonNumberCallback);
 
     if ( ret != 0 )
     {
@@ -1539,12 +1580,14 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     }
 }
 
-- (void) proofSerialize:(vcx_proof_handle_t) proofHandle
+- (void) proofSerialize:(NSNumber *) proofHandle
          withCompletion:(void (^)(NSError *error, NSString *proof_request))completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    ret = vcx_disclosed_proof_serialize(handle, proofHandle, VcxWrapperCommonStringCallback);
+    ret = vcx_disclosed_proof_serialize(handle,
+                                        proofHandle.unsignedIntValue,
+                                        VcxWrapperCommonStringCallback);
 
     if( ret != 0 )
     {
@@ -1557,7 +1600,7 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
 }
 
 - (void) proofDeserialize:(NSString *) serializedProof
-           withCompletion:(void (^)(NSError *error, vcx_proof_handle_t proofHandle)) completion {
+           withCompletion:(void (^)(NSError *error, NSNumber *proofHandle)) completion {
     vcx_error_t ret;
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
     const char *serialized_proof = [serializedProof cStringUsingEncoding:NSUTF8StringEncoding];
@@ -1574,8 +1617,29 @@ withConnectionHandle:(vcx_connection_handle_t)connection_handle
     }
 }
 
-- (int)proofRelease:(NSInteger) proofHandle {
-    return vcx_disclosed_proof_release(proofHandle);
+- (int)proofRelease:(NSNumber *) proofHandle {
+    return vcx_disclosed_proof_release(proofHandle.unsignedIntValue);
+}
+
+- (void)downloadMessages:(NSString *)messageStatus
+                    uid_s:(NSString *)uid_s
+                  pwdids:(NSString *)pwdids
+              completion:(void (^)(NSError *error, NSString* messages))completion{
+    vcx_error_t ret;
+    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    const char * message_status = [messageStatus cStringUsingEncoding:NSUTF8StringEncoding];
+    const char * uids = [uid_s cStringUsingEncoding:NSUTF8StringEncoding];
+    const char * pw_dids = [pwdids cStringUsingEncoding:NSUTF8StringEncoding];
+    ret = vcx_messages_download(handle, message_status, uids, pw_dids, VcxWrapperCommonStringCallback);
+
+    if( ret != 0 )
+    {
+        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion([NSError errorFromVcxError: ret], nil);
+        });
+    }
 }
 
 - (void)downloadMessagesV2:(NSString *)connectionHandles

--- a/wrappers/ios/vcx/ConnectMeVcx.m
+++ b/wrappers/ios/vcx/ConnectMeVcx.m
@@ -1621,27 +1621,6 @@ withConnectionHandle:(NSNumber *)connection_handle
     return vcx_disclosed_proof_release(proofHandle.unsignedIntValue);
 }
 
-- (void)downloadMessages:(NSString *)messageStatus
-                    uid_s:(NSString *)uid_s
-                  pwdids:(NSString *)pwdids
-              completion:(void (^)(NSError *error, NSString* messages))completion{
-    vcx_error_t ret;
-    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
-    const char * message_status = [messageStatus cStringUsingEncoding:NSUTF8StringEncoding];
-    const char * uids = [uid_s cStringUsingEncoding:NSUTF8StringEncoding];
-    const char * pw_dids = [pwdids cStringUsingEncoding:NSUTF8StringEncoding];
-    ret = vcx_messages_download(handle, message_status, uids, pw_dids, VcxWrapperCommonStringCallback);
-
-    if( ret != 0 )
-    {
-        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            completion([NSError errorFromVcxError: ret], nil);
-        });
-    }
-}
-
 - (void)downloadMessagesV2:(NSString *)connectionHandles
             messageStatus:(NSString *)messageStatus
                     uid_s:(NSString *)uid_s


### PR DESCRIPTION
iOS Wrapper abstraction: Some information, such as handler types (u32, i32) or callback definitions, is only useful within vcx and the client code that uses them doesn't need to know the details. Hiding them from the client code will improve maintainability.

Signed-off-by: kukgini <kukgini@gmail.com>