### PR TITLE
Remove function to revoke+publish individual credential

### DIFF
--- a/agents/node/vcxagent-core/demo/faber.js
+++ b/agents/node/vcxagent-core/demo/faber.js
@@ -83,7 +83,8 @@ async function runFaber (options) {
     const schemaAttrs = getAliceSchemaAttrs()
     await vcxAgent.serviceCredIssuer.sendOfferAndCredential(issuerCredId, revRegId, connectionId, credDefId, schemaAttrs)
     if (options.revocation === true) {
-      await vcxAgent.serviceCredIssuer.revokeCredential(issuerCredId)
+      await vcxAgent.serviceCredIssuer.revokeCredentialLocal(issuerCredId)
+      await revReg.publishRevocations()
     }
 
     logger.info('#19 Create a Proof object')

--- a/agents/node/vcxagent-core/src/services/service-cred-issuer.js
+++ b/agents/node/vcxagent-core/src/services/service-cred-issuer.js
@@ -90,10 +90,10 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
     await sendCredentialAndProgress(issuerCredId, connectionId)
   }
 
-  async function revokeCredential (issuerCredId) {
+  async function revokeCredentialLocal (issuerCredId) {
     const issuerCred = await loadIssuerCredential(issuerCredId)
     logger.info(`Revoking credential ${issuerCredId}`)
-    await issuerCred.revokeCredential()
+    await issuerCred.revokeCredentialLocal()
   }
 
   async function getRevRegId (issuerCredId) {
@@ -155,7 +155,7 @@ module.exports.createServiceCredIssuer = function createServiceCredIssuer ({ log
     waitForCredentialAck,
     sendCredentialAndProgress,
     sendOfferAndCredential,
-    revokeCredential,
+    revokeCredentialLocal,
     credentialUpdate,
     getVcxCredentialIssuer,
 

--- a/aries_vcx/src/handlers/issuance/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer.rs
@@ -6,6 +6,7 @@ use agency_client::agency_client::AgencyClient;
 
 use crate::error::prelude::*;
 use crate::handlers::connection::connection::Connection;
+use crate::libindy::utils::anoncreds;
 use crate::libindy::utils::anoncreds::libindy_issuer_create_credential_offer;
 use crate::messages::a2a::A2AMessage;
 use crate::messages::issuance::credential_offer::OfferInfo;
@@ -13,7 +14,7 @@ use crate::messages::issuance::credential_proposal::CredentialProposal;
 use crate::messages::issuance::CredentialPreviewData;
 use crate::messages::mime_type::MimeType;
 use crate::protocols::issuance::actions::CredentialIssuanceAction;
-use crate::protocols::issuance::issuer::state_machine::{IssuerSM, IssuerState};
+use crate::protocols::issuance::issuer::state_machine::{IssuerSM, IssuerState, RevocationInfoV1};
 use crate::protocols::SendClosure;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -163,9 +164,24 @@ impl Issuer {
         self.issuer_sm.find_message_to_handle(messages)
     }
 
-    // todo: eliminate publish parameter - only revoke locally, leave it to caller to publish accumulated deltas
-    pub async fn revoke_credential(&self, wallet_handle: WalletHandle, pool_handle: PoolHandle, issuer_did: &str, publish: bool) -> VcxResult<()> {
-        self.issuer_sm.revoke(wallet_handle, pool_handle, issuer_did, publish).await
+    pub async fn revoke_credential_local(&self, wallet_handle: WalletHandle) -> VcxResult<()> {
+        let revocation_info: RevocationInfoV1 = self.issuer_sm.get_revocation_info().ok_or(VcxError::from_msg(
+            VcxErrorKind::InvalidState,
+            "Credential is not revocable, no revocation info has been found.",
+        ))?;
+        if let (Some(cred_rev_id), Some(rev_reg_id), Some(tails_file)) = (
+            revocation_info.cred_rev_id,
+            revocation_info.rev_reg_id,
+            revocation_info.tails_file,
+        ) {
+            anoncreds::revoke_credential_local(wallet_handle, &tails_file, &rev_reg_id, &cred_rev_id).await?;
+        } else {
+            return Err(VcxError::from_msg(
+                VcxErrorKind::InvalidState,
+                "Revocation info is not complete, cannot revoke credential.",
+            ));
+        }
+        Ok(())
     }
 
     pub fn get_rev_reg_id(&self) -> VcxResult<String> {
@@ -359,8 +375,8 @@ pub mod unit_tests {
         let setup = SetupMocks::init();
         let issuer = _issuer().to_finished_state_unrevokable().await;
         assert_eq!(IssuerState::Finished, issuer.get_state());
-        let revoc_result = issuer.revoke_credential(_dummy_wallet_handle(), _dummy_pool_handle(), &setup.institution_did, true).await;
-        assert_eq!(revoc_result.unwrap_err().kind(), VcxErrorKind::InvalidRevocationDetails)
+        let revoc_result = issuer.revoke_credential_local(_dummy_wallet_handle()).await;
+        assert_eq!(revoc_result.unwrap_err().kind(), VcxErrorKind::InvalidState)
     }
 
     #[tokio::test]

--- a/aries_vcx/src/protocols/issuance/issuer/state_machine.rs
+++ b/aries_vcx/src/protocols/issuance/issuer/state_machine.rs
@@ -83,29 +83,6 @@ pub struct IssuerSM {
     state: IssuerFullState,
 }
 
-async fn _revoke(wallet_handle: WalletHandle, pool_handle: PoolHandle, issuer_did: &str, rev_info: &Option<RevocationInfoV1>, publish: bool) -> VcxResult<()> {
-    match rev_info {
-        Some(rev_info) => {
-            if let (Some(cred_rev_id), Some(rev_reg_id), Some(tails_file)) =
-                (&rev_info.cred_rev_id, &rev_info.rev_reg_id, &rev_info.tails_file)
-            {
-                if publish {
-                    anoncreds::revoke_credential(wallet_handle, pool_handle, issuer_did, tails_file, rev_reg_id, cred_rev_id).await?;
-                } else {
-                    anoncreds::revoke_credential_local(wallet_handle, tails_file, rev_reg_id, cred_rev_id).await?;
-                }
-                Ok(())
-            } else {
-                Err(VcxError::from_msg(
-                    VcxErrorKind::InvalidRevocationDetails,
-                    "Missing data to perform revocation.",
-                ))
-            }
-        }
-        None => Err(VcxError::from(VcxErrorKind::NotReady)),
-    }
-}
-
 fn build_credential_message(libindy_credential: String) -> VcxResult<Credential> {
     Ok(Credential::create().set_credential(libindy_credential)?.set_out_time())
 }
@@ -153,12 +130,11 @@ impl IssuerSM {
         }
     }
 
-    pub async fn revoke(&self, wallet_handle: WalletHandle, pool_handle: PoolHandle, issuer_did: &str, publish: bool) -> VcxResult<()> {
-        trace!("Issuer::revoke >>> publish: {}", publish);
+    pub fn get_revocation_info(&self) -> Option<RevocationInfoV1> {
         match &self.state {
-            IssuerFullState::CredentialSent(state) => _revoke(wallet_handle, pool_handle, issuer_did, &state.revocation_info_v1, publish).await,
-            IssuerFullState::Finished(state) => _revoke(wallet_handle, pool_handle, issuer_did, &state.revocation_info_v1, publish).await,
-            _ => Err(VcxError::from(VcxErrorKind::NotReady)),
+            IssuerFullState::CredentialSent(state) => state.revocation_info_v1.clone(),
+            IssuerFullState::Finished(state) => state.revocation_info_v1.clone(),
+            _ => None
         }
     }
 

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -19,6 +19,7 @@ pub mod test_utils {
     use aries_vcx::libindy::credential_def::revocation_registry::RevocationRegistry;
     use aries_vcx::libindy::credential_def::CredentialDef;
     use aries_vcx::libindy::proofs::proof_request_internal::AttrInfo;
+    use aries_vcx::libindy::utils::anoncreds::publish_local_revocations;
     use aries_vcx::libindy::utils::anoncreds::test_utils::create_and_store_credential_def;
     use aries_vcx::messages::connection::invite::Invitation;
     use aries_vcx::messages::issuance::credential_offer::{CredentialOffer, OfferInfo};
@@ -687,33 +688,22 @@ pub mod test_utils {
         );
     }
 
-    pub async fn revoke_credential(faber: &mut Faber, issuer_credential: &Issuer, rev_reg_id: String) {
-        let (_, delta, timestamp) = libindy::utils::anoncreds::get_rev_reg_delta_json(faber.pool_handle, &rev_reg_id.clone(), None, None)
-            .await
-            .unwrap();
-        info!("revoking credential");
-        issuer_credential
-            .revoke_credential(faber.wallet_handle, faber.pool_handle, &faber.config_issuer.institution_did, true)
-            .await
-            .unwrap();
-        let (_, delta_after_revoke, _) =
-            libindy::utils::anoncreds::get_rev_reg_delta_json(faber.pool_handle, &rev_reg_id, Some(timestamp + 1), None)
-                .await
-                .unwrap();
-        assert_ne!(delta, delta_after_revoke);
+    pub async fn revoke_credential_and_publish_accumulator(faber: &mut Faber, issuer_credential: &Issuer, rev_reg_id: &str) {
+        revoke_credential_local(faber, issuer_credential, &rev_reg_id).await;
+        publish_local_revocations(faber.wallet_handle, faber.pool_handle, &faber.config_issuer.institution_did, &rev_reg_id).await;
     }
 
-    pub async fn revoke_credential_local(faber: &mut Faber, issuer_credential: &Issuer, rev_reg_id: String) {
-        let (_, delta, timestamp) = libindy::utils::anoncreds::get_rev_reg_delta_json(faber.pool_handle, &rev_reg_id.clone(), None, None)
+    pub async fn revoke_credential_local(faber: &mut Faber, issuer_credential: &Issuer, rev_reg_id: &str) {
+        let (_, delta, timestamp) = libindy::utils::anoncreds::get_rev_reg_delta_json(faber.pool_handle, &rev_reg_id, None, None)
             .await
             .unwrap();
         info!("revoking credential locally");
         issuer_credential
-            .revoke_credential(faber.wallet_handle, faber.pool_handle, &faber.config_issuer.institution_did, false)
+            .revoke_credential_local(faber.wallet_handle)
             .await
             .unwrap();
         let (_, delta_after_revoke, _) =
-            libindy::utils::anoncreds::get_rev_reg_delta_json(faber.pool_handle, &rev_reg_id, Some(timestamp + 1), None)
+            libindy::utils::anoncreds::get_rev_reg_delta_json(faber.pool_handle, rev_reg_id, Some(timestamp + 1), None)
                 .await
                 .unwrap();
         assert_ne!(delta, delta_after_revoke); // They will not equal as we have saved the delta in cache

--- a/libvcx/src/api_lib/api_c/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_c/issuer_credential.rs
@@ -816,67 +816,6 @@ pub extern "C" fn vcx_issuer_credential_release(credential_handle: u32) -> u32 {
     }
 }
 
-/// Revoke Credential
-///
-/// #Params
-/// command_handle: command handle to map callback to user context.
-///
-/// credential_handle: Credential handle that was provided during creation. Used to identify credential object
-///
-/// cb: Callback that provides error status of revoking the credential
-///
-/// #Returns
-/// Error code as a u32
-#[no_mangle]
-#[deprecated(note = "Use combination of vcx_issuer_revoke_credential_local and vcx_revocation_registry_publish_revocations instead")]
-pub extern "C" fn vcx_issuer_revoke_credential(
-    command_handle: CommandHandle,
-    credential_handle: u32,
-    cb: Option<extern "C" fn(xcommand_handle: CommandHandle, err: u32)>,
-) -> u32 {
-    check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
-
-    let source_id = issuer_credential::get_source_id(credential_handle).unwrap_or_default();
-    let issuer_did: String = match settings::get_config_value(settings::CONFIG_INSTITUTION_DID) {
-        Ok(err) => err,
-        Err(err) => return err.into(),
-    };
-    info!(
-        "vcx_issuer_revoke_credential(command_handle: {}, credential_handle: {}, issuer_did: {}) source_id: {}",
-        command_handle, credential_handle, issuer_did, source_id
-    );
-
-    execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
-        let err = match issuer_credential::revoke_credential(credential_handle, &issuer_did).await {
-            Ok(()) => {
-                info!(
-                    "vcx_issuer_revoke_credential_cb(command_handle: {}, credential_handle: {}, issuer_did: {}, rc: {}) source_id: {}",
-                    command_handle,
-                    credential_handle,
-                    issuer_did,
-                    error::SUCCESS.message,
-                    source_id
-                );
-                error::SUCCESS.code_num
-            }
-            Err(err) => {
-                set_current_error_vcx(&err);
-                error!(
-                    "vcx_issuer_revoke_credential_cb(command_handle: {}, credential_handle: {}, issuer_did: {}, rc: {}) source_id: {}",
-                    command_handle, credential_handle, issuer_did, err, source_id
-                );
-                err.into()
-            }
-        };
-
-        cb(command_handle, err);
-
-        Ok(())
-    }));
-
-    error::SUCCESS.code_num
-}
-
 #[no_mangle]
 pub extern "C" fn vcx_issuer_revoke_credential_local(
     command_handle: CommandHandle,
@@ -886,23 +825,18 @@ pub extern "C" fn vcx_issuer_revoke_credential_local(
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
     let source_id = issuer_credential::get_source_id(credential_handle).unwrap_or_default();
-    let issuer_did: String = match settings::get_config_value(settings::CONFIG_INSTITUTION_DID) {
-        Ok(err) => err,
-        Err(err) => return err.into(),
-    };
     info!(
-        "vcx_issuer_revoke_credential_local(command_handle: {}, credential_handle: {}, issuer_did: {}) source_id: {}",
-        command_handle, credential_handle, issuer_did, source_id
+        "vcx_issuer_revoke_credential_local(command_handle: {}, credential_handle: {}) source_id: {}",
+        command_handle, credential_handle, source_id
     );
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
-        let err = match issuer_credential::revoke_credential_local(credential_handle, &issuer_did).await {
+        let err = match issuer_credential::revoke_credential_local(credential_handle).await {
             Ok(()) => {
                 info!(
-                    "vcx_issuer_revoke_credential_local_Cb(command_handle: {}, credential_handle: {}, issuer_did: {}, rc: {}) source_id: {}",
+                    "vcx_issuer_revoke_credential_local_Cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
                     command_handle,
                     credential_handle,
-                    issuer_did,
                     error::SUCCESS.message,
                     source_id
                 );
@@ -911,8 +845,8 @@ pub extern "C" fn vcx_issuer_revoke_credential_local(
             Err(err) => {
                 set_current_error_vcx(&err);
                 error!(
-                    "vcx_issuer_revoke_credential_local_cb(command_handle: {}, credential_handle: {}, issuer_did: {}, rc: {}) source_id: {}",
-                    command_handle, credential_handle, issuer_did, err, source_id
+                    "vcx_issuer_revoke_credential_local_cb(command_handle: {}, credential_handle: {}, rc: {}) source_id: {}",
+                    command_handle, credential_handle, err, source_id
                 );
                 err.into()
             }
@@ -1164,16 +1098,14 @@ pub mod tests {
 
     #[tokio::test]
     #[cfg(feature = "general_test")]
-    async fn test_vcx_issuer_revoke_credential() {
+    async fn test_vcx_issuer_revoke_credential_local() {
         let _setup = SetupMocks::init();
 
-        settings::set_config_value(settings::CONFIG_INSTITUTION_DID, DEFAULT_DID);
-        let handle = issuer_credential::from_string(CREDENTIAL_ISSUER_SM_FINISHED).unwrap();
+        let credential_handle = issuer_credential::from_string(CREDENTIAL_ISSUER_SM_FINISHED).unwrap();
 
-        // send the credential
         let cb = return_types_u32::Return_U32::new().unwrap();
         assert_eq!(
-            vcx_issuer_revoke_credential(cb.command_handle, handle, Some(cb.get_callback())),
+            vcx_issuer_revoke_credential_local(cb.command_handle, credential_handle, Some(cb.get_callback())),
             error::SUCCESS.code_num
         );
         cb.receive(TimeoutUtils::some_medium()).unwrap();

--- a/libvcx/src/api_lib/api_handle/issuer_credential.rs
+++ b/libvcx/src/api_lib/api_handle/issuer_credential.rs
@@ -188,20 +188,10 @@ pub async fn send_credential(handle: u32, connection_handle: u32) -> VcxResult<u
     Ok(error::SUCCESS.code_num)
 }
 
-#[deprecated(note = "Use combination of issuer_credential::revoke_credential_local and revocation_registry::publish_revocations instead")]
-pub async fn revoke_credential(handle: u32, issuer_did: &str) -> VcxResult<()> {
-    trace!("revoke_credential >>> handle: {}", handle);
+pub async fn revoke_credential_local(handle: u32) -> VcxResult<()> {
     let credential = ISSUER_CREDENTIAL_MAP.get_cloned(handle)?;
     credential
-        .revoke_credential(get_main_wallet_handle(), get_main_pool_handle()?, issuer_did, true)
-        .await
-        .map_err(|err| err.into())
-}
-
-pub async fn revoke_credential_local(handle: u32, issuer_did: &str) -> VcxResult<()> {
-    let credential = ISSUER_CREDENTIAL_MAP.get_cloned(handle)?;
-    credential
-        .revoke_credential(get_main_wallet_handle(), get_main_pool_handle()?, issuer_did, false)
+        .revoke_credential_local(get_main_wallet_handle())
         .await
         .map_err(|err| err.into())
 }

--- a/wrappers/node/src/api/issuer-credential.ts
+++ b/wrappers/node/src/api/issuer-credential.ts
@@ -465,34 +465,6 @@ export class IssuerCredential extends VCXBaseWithState<IIssuerCredentialData, Is
     }
   }
 
-  /**
-   * Revokes credential.
-   *
-   * Credential is made up of the data sent during Credential Offer
-   */
-  public async revokeCredential(): Promise<void> {
-    try {
-      await createFFICallbackPromise<void>(
-        (resolve, reject, cb) => {
-          const rc = rustAPI().vcx_issuer_revoke_credential(0, this.handle, cb);
-          if (rc) {
-            reject(rc);
-          }
-        },
-        (resolve, reject) =>
-          ffi.Callback('void', ['uint32', 'uint32'], (xcommandHandle: number, err: number) => {
-            if (err) {
-              reject(err);
-              return;
-            }
-            resolve();
-          }),
-      );
-    } catch (err) {
-      throw new VCXInternalError(err);
-    }
-  }
-
   public async revokeCredentialLocal(): Promise<void> {
     try {
       await createFFICallbackPromise<void>(

--- a/wrappers/node/src/rustlib.ts
+++ b/wrappers/node/src/rustlib.ts
@@ -285,7 +285,6 @@ export interface IFFIEntryPoint {
     sourceId: string,
     cb: ICbRef,
   ) => number;
-  vcx_issuer_revoke_credential: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_issuer_revoke_credential_local: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_issuer_credential_is_revokable: (commandId: number, handle: number, cb: ICbRef) => number;
   vcx_issuer_send_credential: (
@@ -842,10 +841,6 @@ export const FFIConfiguration: { [Key in keyof IFFIEntryPoint]: any } = {
       FFI_SOURCE_ID,
       FFI_CALLBACK_PTR,
     ],
-  ],
-  vcx_issuer_revoke_credential: [
-    FFI_ERROR_CODE,
-    [FFI_COMMAND_HANDLE, FFI_CREDENTIAL_HANDLE, FFI_CALLBACK_PTR],
   ],
   vcx_issuer_revoke_credential_local: [
     FFI_ERROR_CODE,


### PR DESCRIPTION
After changes done on https://github.com/hyperledger/aries-vcx/pull/558 it became clear that `vcx_revoke_credential` is problematic function as:
- before #558 it could cause entering problematic state after losing revocation delta
- changes in #558 prevent problematic behaviour, but causes `vcx_revoke_credential` to have side effects - if other credentials in same revocation registry has been revoked locally before and their deltas are accumulated, it would publish revocation for those credential as well. 
The pre #558 approach in unacceptable, the post #558 approach is not transparent. The right way is to revoke credential locally, then published the delta, accounting for the fact that can lead to actually publishing merged revocation delta of multiple local revocations.
