### PR TITLE
Reduce size of the release build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ members = [
 ]
 
 [profile.release]
-debug = true
+debug = 0
 panic = 'unwind'
 incremental = false


### PR DESCRIPTION
Disable debug in the release profile.
The build on macOS M1, libvcx.a is about 100 Mb, libvcx.dylib is about 20 Mb.