### PR TITLE
Avoid HTTP request body cloning.

### DIFF
--- a/agency_client/src/api/agent.rs
+++ b/agency_client/src/api/agent.rs
@@ -26,7 +26,7 @@ impl AgencyClient {
                 agent_vk,
             )
             .await?;
-        let response = self.post_to_agency(&data).await?;
+        let response = self.post_to_agency(data).await?;
         let mut response = self.parse_response_from_agency(&response).await?;
 
         match response.remove(0) {
@@ -56,7 +56,7 @@ impl AgencyClient {
         let data = self
             .prepare_message_for_agent(&Client2AgencyMessage::CreateKey(message), &agent_pwdid)
             .await?;
-        let response = self.post_to_agency(&data).await?;
+        let response = self.post_to_agency(data).await?;
         let mut response = self.parse_response_from_agency(&response).await?;
 
         match response.remove(0) {
@@ -81,7 +81,7 @@ impl AgencyClient {
         let agent_did = self.get_agent_pwdid();
         let message = Client2AgencyMessage::UpdateComMethod(UpdateComMethod::build(com_method));
         let data = self.prepare_message_for_agent(&message, &agent_did).await?;
-        let response = self.post_to_agency(&data).await?;
+        let response = self.post_to_agency(data).await?;
         self.parse_response_from_agency(&response).await?;
 
         Ok(())

--- a/agency_client/src/api/messaging.rs
+++ b/agency_client/src/api/messaging.rs
@@ -31,7 +31,7 @@ impl AgencyClient {
                 &agent_did,
             )
             .await?;
-        let response = self.post_to_agency(&data).await?;
+        let response = self.post_to_agency(data).await?;
         let mut response = self.parse_response_from_agency(&response).await?;
 
         match response.remove(0) {
@@ -69,7 +69,7 @@ impl AgencyClient {
         let data = self
             .prepare_message_for_connection_agent(vec![message], to_pw_vk, agent_did, agent_vk)
             .await?;
-        let response = self.post_to_agency(&data).await?;
+        let response = self.post_to_agency(data).await?;
         let mut response = self.parse_response_from_agency(&response).await?;
 
         match response.remove(0) {

--- a/agency_client/src/internal/messaging.rs
+++ b/agency_client/src/internal/messaging.rs
@@ -9,7 +9,7 @@ use core::u8;
 use serde_json::Value;
 
 impl AgencyClient {
-    pub async fn post_to_agency(&self, body_content: &Vec<u8>) -> AgencyClientResult<Vec<u8>> {
+    pub async fn post_to_agency(&self, body_content: Vec<u8>) -> AgencyClientResult<Vec<u8>> {
         let url = self.get_agency_url_full();
         httpclient::post_message(body_content, &url).await
     }
@@ -203,7 +203,7 @@ impl AgencyClient {
     ) -> AgencyClientResult<Vec<Client2AgencyMessage>> {
         trace!("send_message_to_agency >>> message: ..., did: {}", did);
         let data = self.prepare_message_for_agency(message, did, verkey).await?;
-        let response = self.post_to_agency(&data).await?;
+        let response = self.post_to_agency(data).await?;
         self.parse_response_from_agency(&response).await
     }
 }

--- a/aries_vcx/src/utils/mod.rs
+++ b/aries_vcx/src/utils/mod.rs
@@ -77,8 +77,16 @@ pub async fn send_message(
     message: A2AMessage,
 ) -> VcxResult<()> {
     trace!("send_message >>> message: {:?}, did_doc: {:?}", message, &did_doc);
-    let envelope = EncryptionEnvelope::create(wallet_handle, &message, Some(&sender_verkey), &did_doc).await?;
-    agency_client::httpclient::post_message(&envelope.0, &did_doc.get_endpoint()).await?;
+
+    let EncryptionEnvelope(envelope) = EncryptionEnvelope::create(
+        wallet_handle,
+        &message,
+        Some(&sender_verkey),
+        &did_doc)
+        .await?;
+
+    agency_client::httpclient::post_message(envelope, &did_doc.get_endpoint()).await?;
+
     Ok(())
 }
 
@@ -92,7 +100,15 @@ pub async fn send_message_anonymously(
         message,
         &did_doc
     );
-    let envelope = EncryptionEnvelope::create(wallet_handle, message, None, did_doc).await?;
-    agency_client::httpclient::post_message(&envelope.0, &did_doc.get_endpoint()).await?;
+
+    let EncryptionEnvelope(envelope) = EncryptionEnvelope::create(
+        wallet_handle,
+        message,
+        None,
+        did_doc)
+        .await?;
+
+    agency_client::httpclient::post_message(envelope, &did_doc.get_endpoint()).await?;
+
     Ok(())
 }


### PR DESCRIPTION
Consume body passed to post_message(body, url) and update callers.

Fold some long lines while I'm here to improve code readability.