### PR TITLE
Builder pattern in agency client configuration

### DIFF
--- a/agency_client/src/agency_client.rs
+++ b/agency_client/src/agency_client.rs
@@ -85,7 +85,7 @@ impl AgencyClient {
         self.my_vk = vk.to_string();
     }
 
-    pub fn configure(&mut self, config: &AgencyClientConfig) -> AgencyClientResult<()> {
+    pub fn configure(mut self, config: &AgencyClientConfig) -> AgencyClientResult<Self> {
         info!("AgencyClient::configure >>> config {:?}", config);
 
         validate_mandotory_config_val(
@@ -128,7 +128,7 @@ impl AgencyClient {
         self.set_my_pwdid(&config.sdk_to_remote_did);
         self.set_my_vk(&config.sdk_to_remote_verkey);
 
-        Ok(())
+        Ok(self)
     }
 
     pub fn set_testing_defaults_agency(&mut self) {

--- a/aries_vcx/tests/test_agency.rs
+++ b/aries_vcx/tests/test_agency.rs
@@ -12,7 +12,6 @@ pub mod utils;
 #[cfg(test)]
 #[cfg(feature = "agency_v2")]
 mod integration_tests {
-    use std::fmt;
     use std::thread;
     use std::time::Duration;
 
@@ -395,7 +394,7 @@ mod integration_tests {
     #[cfg(feature = "agency_v2")]
     #[tokio::test]
     async fn test_update_agent_webhook() {
-        let setup = SetupPool::init().await;
+        let _setup = SetupPool::init().await;
         let wallet_config = WalletConfig {
             wallet_name: format!("wallet_{}", uuid::Uuid::new_v4().to_string()),
             wallet_key: settings::DEFAULT_WALLET_KEY.into(),
@@ -419,7 +418,7 @@ mod integration_tests {
             .await
             .unwrap();
         let config = client.get_config().unwrap();
-        client.configure(&config);
+        let client = client.configure(&config).unwrap();
         client.update_agent_webhook("https://example.org").await.unwrap();
         close_wallet(wallet_handle).await.unwrap();
     }

--- a/libvcx/src/api_lib/global/agency_client.rs
+++ b/libvcx/src/api_lib/global/agency_client.rs
@@ -22,7 +22,8 @@ pub fn get_main_agency_client() -> VcxResult<AgencyClient> {
 }
 
 pub fn create_agency_client_for_main_wallet(config: &AgencyClientConfig) -> VcxResult<()> {
-    get_main_agency_client_mut()?.configure(config)?;
+    let client = get_main_agency_client()?.configure(config)?;
+    set_main_agency_client(client);
     get_main_agency_client_mut()?.set_wallet_handle(get_main_wallet_handle());
     Ok(())
 }


### PR DESCRIPTION
Allows constructing agency client more eloquently as

```let agency_client = AgencyClient::new().configure(&agency_client_config)?;```

Signed-off-by: Miroslav Kovar <miroslav.kovar@absa.africa>