### PR TITLE
Optimize publish-ios-wrapper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1005,10 +1005,17 @@ jobs:
       - name: Cache tools
         uses: actions/cache@v3
         with:
-          key: ios-tools-${{ hashFiles('.github/workflows/main.yml', './wrappers/ios/**') }}
+          key: ios-tools-${{ hashFiles('.github/workflows/main.yml', './wrappers/ios/ci/**') }}
           path: |
             ~/.cargo/bin/cargo-lipo
             ~/.cargo/bin/cargo-xcode
+
+      - name: Cache external deps
+        uses: actions/cache@v3
+        with:
+          key: ios-deps-${{ hashFiles('.github/workflows/main.yml', './wrappers/ios/ci/**') }}
+          path: |
+            /tmp/artifacts/libs
 
       - name: Build iOS wrapper
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1002,13 +1002,23 @@ jobs:
         run: |
           sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
           xcodebuild -version
+      - name: Cache tools
+        uses: actions/cache@v3
+        with:
+          key: ios-tools-${{ hashFiles('.github/workflows/main.yml', './wrappers/ios/**') }}
+          path: |
+            ~/.cargo/bin/cargo-lipo
+            ~/.cargo/bin/cargo-xcode
+
       - name: Build iOS wrapper
         run: |
           ./wrappers/ios/ci/build.sh
+
       - uses: actions/upload-artifact@v2
         with:
           name: libvcx-ios-${{ env.PUBLISH_VERSION }}-device
           path: /tmp/artifacts/libvcx-ios-${{ env.PUBLISH_VERSION }}-device.zip
+
       - uses: actions/upload-artifact@v2
         with:
           name: libvcx-ios-${{ env.PUBLISH_VERSION }}-universal

--- a/wrappers/ios/ci/build.sh
+++ b/wrappers/ios/ci/build.sh
@@ -342,24 +342,27 @@ abspath() {
     fi
 }
 
+
 # Setup environment
 setup
 
-# Build 3rd party libraries
-build_crypto    # builds into: $OUTPUT_DIR/OpenSSL-for-iPhone # builds: x86_64 arm64 arm64e, TODO: keep only arm64, x86_64
-build_libsodium # builds into: $OUTPUT_DIR/libsodium-ios # builds: armv7 armv7s i386 x86_64 arm64, TODO: keep only arm64, x86_64
+if [ ! -d $OUTPUT_DIR/libs ]; then
+    # Build 3rd party libraries
+    build_crypto    # builds into: $OUTPUT_DIR/OpenSSL-for-iPhone # builds: x86_64 arm64 arm64e, TODO: keep only arm64, x86_64
+    build_libsodium # builds into: $OUTPUT_DIR/libsodium-ios # builds: armv7 armv7s i386 x86_64 arm64, TODO: keep only arm64, x86_64
 
-# TODO: also remove excessively building non-ios platform artifacts:
-# Architectures in the fat file: ./libsodium-ios/dist/macos/lib/libsodium.a are: x86_64
-# Architectures in the fat file: ./libsodium-ios/dist/watchos/lib/libsodium.a are: armv7k i386
-# Architectures in the fat file: ./libsodium-ios/dist/ios/lib/libsodium.a are: armv7 armv7s i386 x86_64 arm64
-build_libzmq   # builds into:  $OUTPUT_DIR/libzmq-ios # builds: x86_64 arm64
+    # TODO: also remove excessively building non-ios platform artifacts:
+    # Architectures in the fat file: ./libsodium-ios/dist/macos/lib/libsodium.a are: x86_64
+    # Architectures in the fat file: ./libsodium-ios/dist/watchos/lib/libsodium.a are: armv7k i386
+    # Architectures in the fat file: ./libsodium-ios/dist/ios/lib/libsodium.a are: armv7 armv7s i386 x86_64 arm64
+    build_libzmq   # builds into:  $OUTPUT_DIR/libzmq-ios # builds: x86_64 arm64
 
-# Extract architectures from fat files into non-fat files
-extract_architectures $OUTPUT_DIR/libsodium-ios/dist/ios/lib/libsodium.a libsodium sodium
-extract_architectures $OUTPUT_DIR/libzmq-ios/dist/ios/lib/libzmq.a libzmq zmq
-extract_architectures $OUTPUT_DIR/OpenSSL-for-iPhone/lib/libssl.a libssl openssl
-extract_architectures $OUTPUT_DIR/OpenSSL-for-iPhone/lib/libcrypto.a libcrypto openssl
+    # Extract architectures from fat files into non-fat files
+    extract_architectures $OUTPUT_DIR/libsodium-ios/dist/ios/lib/libsodium.a libsodium sodium
+    extract_architectures $OUTPUT_DIR/libzmq-ios/dist/ios/lib/libzmq.a libzmq zmq
+    extract_architectures $OUTPUT_DIR/OpenSSL-for-iPhone/lib/libssl.a libssl openssl
+    extract_architectures $OUTPUT_DIR/OpenSSL-for-iPhone/lib/libcrypto.a libcrypto openssl
+fi
 
 # Build vcx
 build_libvcx

--- a/wrappers/ios/ci/build.sh
+++ b/wrappers/ios/ci/build.sh
@@ -13,9 +13,6 @@ OUTPUT_DIR=/tmp/artifacts
 
 setup() {
     echo "ios/ci/build.sh: running setup()"
-    echo "Setup rustup"
-    rustup default 1.62.1
-    rustup component add rls-preview rust-analysis rust-src
 
     echo "Setup rustup target platforms"
     rustup target add aarch64-apple-ios x86_64-apple-ios
@@ -27,8 +24,13 @@ setup() {
     fi
 
     echo "Install Rust Xcode tools"
-    cargo install cargo-lipo
-    cargo install cargo-xcode
+    if [ ! -x ~/.cargo/bin/cargo-lipo ]; then
+        cargo install cargo-lipo
+    fi
+
+    if [ ! -x ~/.cargo/bin/cargo-xcode ]; then
+        cargo install cargo-xcode
+    fi
 
     echo "Check Homebrew"
     BREW_VERSION=$(brew --version)
@@ -156,7 +158,7 @@ build_libvcx() {
 
             export OPENSSL_LIB_DIR=$WORK_DIR/libs/openssl/${ARCH}
             echo "Building vcx. OPENSSL_LIB_DIR=${OPENSSL_LIB_DIR}"
-            cargo build -vv --target "${TRIPLET}" --release --no-default-features
+            cargo build --target "${TRIPLET}" --release --no-default-features
         done
     popd
 }
@@ -344,8 +346,9 @@ abspath() {
 setup
 
 # Build 3rd party libraries
-build_crypto   # builds into:  $OUTPUT_DIR/OpenSSL-for-iPhone # builds: x86_64 arm64 arm64e, TODO: keep only arm64, x86_64
+build_crypto    # builds into: $OUTPUT_DIR/OpenSSL-for-iPhone # builds: x86_64 arm64 arm64e, TODO: keep only arm64, x86_64
 build_libsodium # builds into: $OUTPUT_DIR/libsodium-ios # builds: armv7 armv7s i386 x86_64 arm64, TODO: keep only arm64, x86_64
+
 # TODO: also remove excessively building non-ios platform artifacts:
 # Architectures in the fat file: ./libsodium-ios/dist/macos/lib/libsodium.a are: x86_64
 # Architectures in the fat file: ./libsodium-ios/dist/watchos/lib/libsodium.a are: armv7k i386


### PR DESCRIPTION
- use rust provided by runner
- don't install components that we don't use
- cache cargo-lipo & cargo-xcode

Signed-off-by: Artem Mironov <artem.mironov@absa.africa>