### PR TITLE
Do not try to initialize logger more then ones.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -572,8 +572,11 @@ jobs:
              --name libvcx \
              --network host \
              $DOCKER_IMG_NAME_LIBVCX_TESTER \
-             sh -c 'set -e; export RUST_TEST_THREADS=1; export RUST_BACKTRACE=full; \
-                    cd $HOME; cargo test --release --features "general_test"'
+             sh -c 'set -e; \
+                    export RUST_TEST_THREADS=1; \
+                    export RUST_BACKTRACE=full; \
+                    export RUST_LOG=error; \
+                    cd $HOME; cargo test --features "general_test"'
 
   test-libvcx-image-pool-tests:
     runs-on: ubuntu-20.04

--- a/aries_vcx/src/utils/test_logger.rs
+++ b/aries_vcx/src/utils/test_logger.rs
@@ -56,14 +56,12 @@ fn text_no_color_format(buf: &mut Formatter, record: &Record) -> std::io::Result
 
 impl LibvcxDefaultLogger {
     pub fn init_testing_logger() {
-        trace!("LibvcxDefaultLogger::init_testing_logger >>>");
-
-        env::var("RUST_LOG").map_or((), |log_pattern| LibvcxDefaultLogger::init(Some(log_pattern)).unwrap())
+        env::var("RUST_LOG").map_or((), |log_pattern| {
+            LibvcxDefaultLogger::init(Some(log_pattern)).unwrap();
+        });
     }
 
     pub fn init(pattern: Option<String>) -> VcxResult<()> {
-        info!("LibvcxDefaultLogger::init >>> pattern: {:?}", pattern);
-
         let pattern = pattern.or(env::var("RUST_LOG").ok());
         if cfg!(target_os = "android") {
             #[cfg(target_os = "android")]
@@ -100,17 +98,6 @@ impl LibvcxDefaultLogger {
                     VcxError::from_msg(VcxErrorKind::LoggingError, format!("Cannot init logger: {:?}", err))
                 })?;
         }
-        indy::utils::logger::set_default_logger(pattern.as_deref())
-    }
-}
-
-#[cfg(test)]
-#[cfg(feature = "general_test")]
-mod unit_tests {
-    use super::*;
-
-    #[test]
-    fn test_logger_for_testing() {
-        LibvcxDefaultLogger::init_testing_logger();
+        Ok(())
     }
 }

--- a/messages/src/utils/test_logger.rs
+++ b/messages/src/utils/test_logger.rs
@@ -8,7 +8,6 @@ use chrono::format::{DelayedFormat, StrftimeItems};
 
 use crate::chrono::Local;
 use crate::error::prelude::*;
-use vdrtoolsrs::logger;
 
 use self::env_logger::fmt::Formatter;
 use self::env_logger::Builder as EnvLoggerBuilder;
@@ -48,15 +47,11 @@ fn text_no_color_format(buf: &mut Formatter, record: &Record) -> std::io::Result
     )
 }
 
-fn set_default_logger(patter: Option<&str>) -> MessagesResult<()> {
-    logger::set_default_logger(patter).map_err(MessagesError::from)
-}
-
 impl LibvcxDefaultLogger {
     pub fn init_testing_logger() {
-        trace!("LibvcxDefaultLogger::init_testing_logger >>>");
-
-        env::var("RUST_LOG").map_or((), |log_pattern| LibvcxDefaultLogger::init(Some(log_pattern)).unwrap())
+        env::var("RUST_LOG").map_or((), |log_pattern| {
+            LibvcxDefaultLogger::init(Some(log_pattern)).unwrap();
+        });
     }
 
     pub fn init(pattern: Option<String>) -> MessagesResult<()> {
@@ -77,17 +72,6 @@ impl LibvcxDefaultLogger {
             .map_err(|err| {
                 MessagesError::from_msg(MesssagesErrorKind::LoggingError, format!("Cannot init logger: {:?}", err))
             })?;
-        set_default_logger(pattern.as_deref())
-    }
-}
-
-#[cfg(test)]
-#[cfg(feature = "general_test")]
-mod unit_tests {
-    use super::*;
-
-    #[test]
-    fn test_logger_for_testing() {
-        LibvcxDefaultLogger::init_testing_logger();
+        Ok(())
     }
 }


### PR DESCRIPTION
- remove test test_logger_for_testing(), it clashes with init_test_logging() in devsetup

- remove call of indy::utils::logger::set_default_logger()

Signed-off-by: Artem Mironov <artem.mironov@absa.africa>