### PR TITLE
Refactor issuer / holder SMs

### DIFF
--- a/agents/rust/aries-vcx-agent/src/services/holder.rs
+++ b/agents/rust/aries-vcx-agent/src/services/holder.rs
@@ -80,8 +80,6 @@ impl ServiceCredentialsHolder {
         let mut holder = Holder::create("")?;
         holder
             .send_proposal(
-                self.wallet_handle,
-                self.pool_handle,
                 proposal_data,
                 connection.send_message_closure(self.wallet_handle).await?,
             )

--- a/aries_vcx/src/handlers/issuance/holder.rs
+++ b/aries_vcx/src/handlers/issuance/holder.rs
@@ -37,18 +37,11 @@ impl Holder {
 
     pub async fn send_proposal(
         &mut self,
-        wallet_handle: WalletHandle,
-        pool_handle: PoolHandle,
         credential_proposal: CredentialProposalData,
         send_message: SendClosure,
     ) -> VcxResult<()> {
-        self.step(
-            wallet_handle,
-            pool_handle,
-            CredentialIssuanceAction::CredentialProposalSend(credential_proposal),
-            Some(send_message),
-        )
-        .await
+        self.holder_sm = self.holder_sm.clone().send_proposal(credential_proposal, send_message).await?;
+        Ok(())
     }
 
     pub async fn send_request(
@@ -58,13 +51,14 @@ impl Holder {
         my_pw_did: String,
         send_message: SendClosure,
     ) -> VcxResult<()> {
-        self.step(
+        self.holder_sm = self.holder_sm.clone().send_request(
             wallet_handle,
             pool_handle,
-            CredentialIssuanceAction::CredentialRequestSend(my_pw_did),
-            Some(send_message),
+            my_pw_did,
+            send_message,
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     pub async fn decline_offer<'a>(
@@ -74,13 +68,14 @@ impl Holder {
         comment: Option<&'a str>,
         send_message: SendClosure,
     ) -> VcxResult<()> {
-        self.step(
+        self.holder_sm = self.holder_sm.clone().decline_offer(
             wallet_handle,
             pool_handle,
-            CredentialIssuanceAction::CredentialOfferReject(comment.map(String::from)),
-            Some(send_message),
+            comment.map(String::from),
+            send_message,
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     pub fn is_terminal_state(&self) -> bool {
@@ -292,8 +287,6 @@ pub mod unit_tests {
 
         holder
             .send_proposal(
-                _dummy_wallet_handle(),
-                _dummy_pool_handle(),
                 _credential_proposal_data(),
                 _send_message().unwrap(),
             )
@@ -313,8 +306,6 @@ pub mod unit_tests {
 
         holder
             .send_proposal(
-                _dummy_wallet_handle(),
-                _dummy_pool_handle(),
                 _credential_proposal_data(),
                 _send_message().unwrap(),
             )

--- a/aries_vcx/src/handlers/issuance/holder.rs
+++ b/aries_vcx/src/handlers/issuance/holder.rs
@@ -56,8 +56,7 @@ impl Holder {
             pool_handle,
             my_pw_did,
             send_message,
-        )
-        .await?;
+        ).await?;
         Ok(())
     }
 
@@ -69,8 +68,7 @@ impl Holder {
         self.holder_sm = self.holder_sm.clone().decline_offer(
             comment.map(String::from),
             send_message,
-        )
-        .await?;
+        ).await?;
         Ok(())
     }
 

--- a/aries_vcx/src/handlers/issuance/holder.rs
+++ b/aries_vcx/src/handlers/issuance/holder.rs
@@ -63,14 +63,10 @@ impl Holder {
 
     pub async fn decline_offer<'a>(
         &'a mut self,
-        wallet_handle: WalletHandle,
-        pool_handle: PoolHandle,
         comment: Option<&'a str>,
         send_message: SendClosure,
     ) -> VcxResult<()> {
         self.holder_sm = self.holder_sm.clone().decline_offer(
-            wallet_handle,
-            pool_handle,
             comment.map(String::from),
             send_message,
         )

--- a/aries_vcx/src/handlers/issuance/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer.rs
@@ -142,26 +142,13 @@ impl Issuer {
     }
 
     pub async fn send_credential_offer(&mut self, send_message: SendClosure) -> VcxResult<()> {
-        if self.issuer_sm.get_state() == IssuerState::OfferSet {
-            let cred_offer_msg = self.get_credential_offer_msg()?;
-            send_message(cred_offer_msg).await?;
-            self.issuer_sm = self.issuer_sm.clone().mark_credential_offer_msg_sent()?;
-        } else {
-            return Err(VcxError::from_msg(
-                VcxErrorKind::InvalidState,
-                format!("Can't send credential offer in state {:?}", self.issuer_sm.get_state()),
-            ));
-        }
+        self.issuer_sm = self.issuer_sm.clone().send_credential_offer(send_message).await?;
         Ok(())
     }
 
     pub async fn send_credential(&mut self, wallet_handle: WalletHandle, send_message: SendClosure) -> VcxResult<()> {
-        self.step(
-            wallet_handle,
-            CredentialIssuanceAction::CredentialSend(),
-            Some(send_message),
-        )
-        .await
+        self.issuer_sm = self.issuer_sm.clone().send_credential(wallet_handle, send_message).await?;
+        Ok(())
     }
 
     pub fn get_state(&self) -> IssuerState {

--- a/aries_vcx/src/indy/primitives/credential_definition.rs
+++ b/aries_vcx/src/indy/primitives/credential_definition.rs
@@ -208,7 +208,7 @@ impl CredentialDef {
 
     pub fn get_data_json(&self) -> VcxResult<String> {
         serde_json::to_string(&self)
-            .map_err(|err| VcxError::from_msg(VcxErrorKind::SerializationError, "Failed to serialize credential definition"))
+            .map_err(|_| VcxError::from_msg(VcxErrorKind::SerializationError, "Failed to serialize credential definition"))
     }
 
     pub fn get_source_id(&self) -> &String {

--- a/aries_vcx/src/protocols/issuance/holder/state_machine.rs
+++ b/aries_vcx/src/protocols/issuance/holder/state_machine.rs
@@ -153,14 +153,6 @@ impl HolderSM {
         None
     }
 
-    pub fn step(state: HolderFullState, source_id: String, thread_id: String) -> Self {
-        HolderSM {
-            state,
-            source_id,
-            thread_id,
-        }
-    }
-
     pub async fn handle_message(
         self,
         wallet_handle: WalletHandle,

--- a/aries_vcx/src/protocols/issuance/holder/state_machine.rs
+++ b/aries_vcx/src/protocols/issuance/holder/state_machine.rs
@@ -198,7 +198,7 @@ impl HolderSM {
             CredentialIssuanceAction::ProblemReport(problem_report) => {
                 self.receive_problem_report(problem_report)?
             }
-            _ => { self }
+            _ => self
         };
         Ok(holder_sm)
     }

--- a/aries_vcx/src/protocols/issuance/holder/state_machine.rs
+++ b/aries_vcx/src/protocols/issuance/holder/state_machine.rs
@@ -217,7 +217,7 @@ impl HolderSM {
                         VcxErrorKind::InvalidState,
                         "Attempted to call undefined send_message callback",
                     ))?;
-                    self.decline_offer(wallet_handle, pool_handle, comment, send_message).await?.state
+                    self.decline_offer(comment, send_message).await?.state
                 }
                 _ => {
                     warn!("Unable to process received message in this state");
@@ -289,9 +289,9 @@ impl HolderSM {
         Ok(Self { state, ..self })
     }
 
-    pub async fn decline_offer(self, wallet_handle: WalletHandle, pool_handle: PoolHandle, comment: Option<String>, send_message: SendClosure) -> VcxResult<Self> {
+    pub async fn decline_offer(self, comment: Option<String>, send_message: SendClosure) -> VcxResult<Self> {
         let state = match self.state {
-            HolderFullState::OfferReceived(state_data) => {
+            HolderFullState::OfferReceived(_) => {
                 let problem_report = build_problem_report_msg(comment, &self.thread_id);
                 send_message(problem_report.to_a2a_message()).await?;
                 HolderFullState::Finished(problem_report.into())

--- a/aries_vcx/src/protocols/issuance/issuer/state_machine.rs
+++ b/aries_vcx/src/protocols/issuance/issuer/state_machine.rs
@@ -362,7 +362,10 @@ impl IssuerSM {
                 let state = IssuerFullState::ProposalReceived(ProposalReceivedState::new(proposal, None));
                 (state, self.thread_id.clone())
             }
-            s @ _ => (s, self.thread_id.clone())
+            s @ _ => {
+                warn!("Unable to receive credential proposal in state {}", s);
+                (s, self.thread_id.clone())
+            }
         };
         Ok(Self { state, thread_id, ..self })
     }
@@ -382,7 +385,10 @@ impl IssuerSM {
         verify_thread_id(&self.thread_id, &CredentialIssuanceAction::CredentialRequest(request.clone()))?;
         let state = match self.state {
             IssuerFullState::OfferSent(state_data) => IssuerFullState::RequestReceived((state_data, request).into()),
-            s @ _ => s
+            s @ _ => {
+                warn!("Unable to receive credential request in state {}", s);
+                s
+            }
         };
         Ok(Self { state, ..self })
     }
@@ -421,7 +427,10 @@ impl IssuerSM {
         verify_thread_id(&self.thread_id, &CredentialIssuanceAction::CredentialAck(ack))?;
         let state = match self.state {
             IssuerFullState::CredentialSent(state_data) => IssuerFullState::Finished(state_data.into()),
-            s @ _ => s
+            s @ _ => {
+                warn!("Unable to receive credential ack in state {}", s);
+                s
+            }
         };
         Ok(Self { state, ..self })
     }
@@ -431,7 +440,10 @@ impl IssuerSM {
         let state = match self.state {
             IssuerFullState::OfferSent(state_data) => IssuerFullState::Finished((state_data, problem_report).into()),
             IssuerFullState::CredentialSent(state_data) => IssuerFullState::Finished((state_data).into()),
-            s @ _ => s
+            s @ _ => {
+                warn!("Unable to receive credential ack in state {}", s);
+                s
+            }
         };
         Ok(Self { state, ..self })
     }

--- a/aries_vcx/src/utils/test_logger.rs
+++ b/aries_vcx/src/utils/test_logger.rs
@@ -14,8 +14,6 @@ use chrono::format::{DelayedFormat, StrftimeItems};
 use chrono::Local;
 
 use crate::error::prelude::*;
-use crate::indy;
-
 
 use self::env_logger::fmt::Formatter;
 use self::env_logger::Builder as EnvLoggerBuilder;

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -393,8 +393,6 @@ pub mod test_utils {
         assert_eq!(HolderState::OfferReceived, holder.get_state());
         holder
             .decline_offer(
-                alice.wallet_handle,
-                alice.pool_handle,
                 Some("Have a nice day"),
                 connection.send_message_closure(alice.wallet_handle).await.unwrap(),
             )

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -253,8 +253,6 @@ pub mod test_utils {
         assert_eq!(HolderState::Initial, holder.get_state());
         holder
             .send_proposal(
-                alice.wallet_handle,
-                alice.pool_handle,
                 proposal,
                 connection.send_message_closure(alice.wallet_handle).await.unwrap(),
             )
@@ -291,8 +289,6 @@ pub mod test_utils {
             .add_credential_preview_data(&zip, "42000", MimeType::Plain);
         holder
             .send_proposal(
-                alice.wallet_handle,
-                alice.pool_handle,
                 proposal,
                 connection.send_message_closure(alice.wallet_handle).await.unwrap(),
             )

--- a/libvcx/src/api_lib/api_handle/credential.rs
+++ b/libvcx/src/api_lib/api_handle/credential.rs
@@ -353,7 +353,7 @@ pub async fn decline_offer(handle: u32, connection_handle: u32, comment: Option<
     let mut credential = HANDLE_MAP.get_cloned(handle)?;
     let send_message = connection::send_message_closure(connection_handle).await?;
     credential
-        .decline_offer(get_main_wallet_handle(), get_main_pool_handle()?, comment, send_message)
+        .decline_offer(comment, send_message)
         .await?;
     HANDLE_MAP.insert(handle, credential)?;
     Ok(error::SUCCESS.code_num)

--- a/libvcx/src/api_lib/api_handle/credential.rs
+++ b/libvcx/src/api_lib/api_handle/credential.rs
@@ -352,9 +352,7 @@ pub fn get_thread_id(handle: u32) -> VcxResult<String> {
 pub async fn decline_offer(handle: u32, connection_handle: u32, comment: Option<&str>) -> VcxResult<u32> {
     let mut credential = HANDLE_MAP.get_cloned(handle)?;
     let send_message = connection::send_message_closure(connection_handle).await?;
-    credential
-        .decline_offer(comment, send_message)
-        .await?;
+    credential.decline_offer(comment, send_message).await?;
     HANDLE_MAP.insert(handle, credential)?;
     Ok(error::SUCCESS.code_num)
 }


### PR DESCRIPTION
Holder handler calls specific SM methods instead of relying on a step function. This way, if an explicit "action" is performed in an invalid state, an error is returned, instead of a noop.

Addresses #583 .

Signed-off-by: Miroslav Kovar <miroslav.kovar@absa.africa>