### PR TITLE
Ci/improvements

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -50,7 +50,7 @@ runs:
       run: |
         set -x
         GITHUB_REPOSITORY_LOWERCASE=`echo $GITHUB_REPOSITORY | awk '{print tolower($0)}'`
-        REMOTE_DOCKER_REPOSITORY="docker.pkg.github.com/${GITHUB_REPOSITORY_LOWERCASE}/${{ inputs.docker-repo-local-name }}"
+        REMOTE_DOCKER_REPOSITORY="${URL_DOCKER_REGISTRY}/${GITHUB_REPOSITORY_LOWERCASE}/${{ inputs.docker-repo-local-name }}"
         
         LAST_BRANCH_BUILD="$REMOTE_DOCKER_REPOSITORY:${{ inputs.branch-name }}"
         if ! docker pull "$LAST_BRANCH_BUILD"; then

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -73,3 +73,9 @@ runs:
           docker build -t "${{ inputs.docker-img }}" --build-arg ${{ inputs.build-arg }} -f ${{ inputs.dockerfile-path }} .
         fi;
         docker save "${{ inputs.docker-img }}" > "${{ steps.setup.outputs.cache-file-path }}"
+    - name: "Publish branch image"
+      if: steps.loadcachedimg.outputs.cache-hit != 'true'
+      uses: ./.github/actions/publish-image
+      with:
+        docker-img: ${{ inputs.docker-img }}
+        publish-version: ${{ inputs.branch-name }}

--- a/.github/actions/construct-run-info/action.yml
+++ b/.github/actions/construct-run-info/action.yml
@@ -62,10 +62,11 @@ runs:
         if [[ "$IS_FORK" == "false" ]]; then
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             if [[ "${{ contains(github.event.pull_request.labels.*.name, 'pre-release') }}" == "true" ]]; then
+              echo "This CI run will create pre-release!"
               PRERELEASE="true"
             fi;
           elif [[ "${{ github.event_name }}" == "push" ]]; then
-            if [[ "$BRANCH_NAME" == "main" && "$REPO_VERSION_DESIRED" != "$REPO_VERSION_MOST_RECENT" ]]; then
+            if [[ "$BRANCH_NAME" == "$MAIN_BRANCH" && "$REPO_VERSION_DESIRED" != "$REPO_VERSION_MOST_RECENT" ]]; then
               PUBLISH_VERSION="$REPO_VERSION_DESIRED"
               RELEASE="true"
               echo "This is push to main, and version was bumped from $REPO_VERSION_MOST_RECENT to $REPO_VERSION_DESIRED. Will publish a release of $REPO_VERSION_DESIRED."
@@ -74,6 +75,7 @@ runs:
         
           if [[ -z "$PUBLISH_VERSION" ]]; then
             PUBLISH_VERSION="$REPO_VERSION_MOST_RECENT-$BRANCH_NAME-${{ github.run_number }}"
+            echo "Setting PUBLISH_VERSION to ${PUBLISH_VERSION} based on branch name and CI run number."
           fi;
         
           echo "CI will publish artifacts at version: $PUBLISH_VERSION"
@@ -86,3 +88,5 @@ runs:
         echo "pre-release=$(echo $PRERELEASE)" >> $GITHUB_OUTPUT
         echo "publish-version=$(echo $PUBLISH_VERSION)" >> $GITHUB_OUTPUT
         echo "branch-name=$(echo $BRANCH_NAME)" >> $GITHUB_OUTPUT
+        
+        echo "Finished, GITHUB_OUTPUT:\n`cat $GITHUB_OUTPUT`"

--- a/.github/actions/derive-cache-info/action.yml
+++ b/.github/actions/derive-cache-info/action.yml
@@ -1,5 +1,5 @@
 name: "derive-cache-info"
-description: "Given image <docker-img> derive cache-key and caching location on file system. This can be used for caching the image."
+description: "Produces output useful for caching docker images"
 
 inputs:
   docker-img:
@@ -28,6 +28,6 @@ runs:
         CACHE_KEY=`as_docker_cache_key $DOCKER_IMG`
         CACHE_DIR="/tmp/cachedir-$CACHE_KEY"
         CACHE_FILE_PATH="$CACHE_DIR/$CACHE_KEY.rar"
-        echo "::set-output name=cache-key::$CACHE_KEY"
-        echo "::set-output name=cache-dir::$CACHE_DIR"
-        echo "::set-output name=cache-file-path::$CACHE_FILE_PATH"
+        echo "cache-key=$CACHE_KEY" >> $GITHUB_OUTPUT
+        echo "cache-dir=$CACHE_DIR" >> $GITHUB_OUTPUT
+        echo "cache-file-path=$CACHE_FILE_PATH" >> $GITHUB_OUTPUT

--- a/.github/actions/detect-skip-info/action.yml
+++ b/.github/actions/detect-skip-info/action.yml
@@ -13,8 +13,13 @@ runs:
       id: 'main'
       shell: bash
       run: |
-        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-tests-e2e') }}" == "true" ]]; then
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-ios') }}" == "true" ]]; then
           echo "Detected tag to skip E2E tests"
-          echo "skip-tests-e2e=true" >> $GITHUB_OUTPUT
+          echo "skip-ios=true" >> $GITHUB_OUTPUT
         fi;
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-android') }}" == "true" ]]; then
+          echo "Detected tag to skip E2E tests"
+          echo "skip-android=true" >> $GITHUB_OUTPUT
+        fi;
+        
         echo "Finished, GITHUB_OUTPUT:\n`cat $GITHUB_OUTPUT`"

--- a/.github/actions/detect-skip-info/action.yml
+++ b/.github/actions/detect-skip-info/action.yml
@@ -2,9 +2,12 @@ name: 'detect-skip-info'
 description: Determine parts of CI to be skipped
 
 outputs:
-  skip-tests-e2e:
-    description: "True if CI should skip E2E testing"
-    value: ${{ steps.main.outputs.skip-tests-e2e }}
+  skip-ios:
+    description: "True if CI should skip IOS build/testing"
+    value: ${{ steps.main.outputs.skip-ios }}
+  skip-android:
+    description: "True if CI should skip Android build/testing"
+    value: ${{ steps.main.outputs.skip-android }}
 
 runs:
   using: "composite"
@@ -16,10 +19,15 @@ runs:
         if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-ios') }}" == "true" ]]; then
           echo "Detected tag to skip E2E tests"
           echo "skip-ios=true" >> $GITHUB_OUTPUT
-        fi;
+        else
+          echo "skip-ios=false" >> $GITHUB_OUTPUT
+        fi
+        
         if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-android') }}" == "true" ]]; then
           echo "Detected tag to skip E2E tests"
           echo "skip-android=true" >> $GITHUB_OUTPUT
+        else 
+          echo "skip-android=false" >> $GITHUB_OUTPUT
         fi;
         
         echo "Finished, GITHUB_OUTPUT:\n`cat $GITHUB_OUTPUT`"

--- a/.github/actions/detect-skip-info/action.yml
+++ b/.github/actions/detect-skip-info/action.yml
@@ -1,0 +1,20 @@
+name: 'detect-skip-info'
+description: Determine parts of CI to be skipped
+
+outputs:
+  skip-tests-e2e:
+    description: "True if CI should skip E2E testing"
+    value: ${{ steps.main.outputs.skip-tests-e2e }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Detect skip job tags"
+      id: 'main'
+      shell: bash
+      run: |
+        if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-tests-e2e') }}" == "true" ]]; then
+          echo "Detected tag to skip E2E tests"
+          echo "skip-tests-e2e=true" >> $GITHUB_OUTPUT
+        fi;
+        echo "Finished, GITHUB_OUTPUT:\n`cat $GITHUB_OUTPUT`"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,9 +85,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Build and cache image"
         uses: ./.github/actions/build-image
         with:
@@ -110,9 +110,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load alpine core image"
         uses: ./.github/actions/load-image
         with:
@@ -139,9 +139,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load alpine core image"
         uses: ./.github/actions/load-image
         with:
@@ -167,9 +167,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Build and cache image"
         uses: ./.github/actions/build-image
         with:
@@ -190,9 +190,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Build and cache image"
         uses: ./.github/actions/build-image
         with:
@@ -217,9 +217,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -238,9 +238,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -259,9 +259,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -280,9 +280,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -301,9 +301,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -324,9 +324,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load codecov image"
         uses: ./.github/actions/load-image
         with:
@@ -364,9 +364,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
         with:
@@ -402,9 +402,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load codecov image"
         uses: ./.github/actions/load-image
         with:
@@ -442,9 +442,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load libvcx tester image"
         uses: ./.github/actions/load-image
         with:
@@ -471,9 +471,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
         with:
@@ -504,9 +504,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
         with:
@@ -536,9 +536,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
         with:
@@ -567,9 +567,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
         with:
@@ -599,9 +599,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load android image"
         uses: ./.github/actions/load-image
         with:
@@ -624,9 +624,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load libvcx tester image"
         uses: ./.github/actions/load-image
         with:
@@ -654,9 +654,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
         with:
@@ -743,9 +743,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load android image"
         uses: ./.github/actions/load-image
         with:
@@ -774,9 +774,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load android image"
         uses: ./.github/actions/load-image
         with:
@@ -815,9 +815,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load image"
         uses: ./.github/actions/load-image
         with:
@@ -855,9 +855,9 @@ jobs:
       - name: "Docker Login"
         uses: azure/docker-login@v1
         with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
+          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load image"
         uses: ./.github/actions/load-image
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,29 +210,7 @@ jobs:
     needs: [ workflow-setup, build-docker-alpine-core ]
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_ALPINE_CORE }}
-      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
-    steps:
-      - name: "Git checkout"
-        uses: actions/checkout@v3
-      - name: "Docker Login"
-        uses: azure/docker-login@v1
-        with:
-          login-server: env.URL_DOCKER_REGISTRY
-          username: env.GITHUB_ACTOR
-          password: secrets.GITHUB_TOKEN
-      - name: "Publish branch image"
-        uses: ./.github/actions/publish-image
-        with:
-          docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
-
-  publish-docker-libvcx:
-    runs-on: ubuntu-20.04
-    needs: [ workflow-setup, build-docker-libvcx ]
-    env:
-      DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_LIBVCX }}
       PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
-      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -247,18 +225,34 @@ jobs:
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED }}
           publish-version: ${{ env.PUBLISH_VERSION }}
-      - name: "Publish branch image"
+
+  publish-docker-libvcx:
+    runs-on: ubuntu-20.04
+    needs: [ workflow-setup, build-docker-libvcx ]
+    env:
+      DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_LIBVCX }}
+      PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
+    steps:
+      - name: "Git checkout"
+        uses: actions/checkout@v3
+      - name: "Docker Login"
+        uses: azure/docker-login@v1
+        with:
+          login-server: env.URL_DOCKER_REGISTRY
+          username: env.GITHUB_ACTOR
+          password: secrets.GITHUB_TOKEN
+      - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
+          publish-version: ${{ env.PUBLISH_VERSION }}
 
   publish-docker-libvcx-tester:
     runs-on: ubuntu-20.04
     needs: [ workflow-setup, build-docker-libvcx-tester ]
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_LIBVCX_TESTER }}
-      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
+      PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -268,18 +262,18 @@ jobs:
           login-server: env.URL_DOCKER_REGISTRY
           username: env.GITHUB_ACTOR
           password: secrets.GITHUB_TOKEN
-      - name: "Publish branch image"
+      - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
+          publish-version: ${{ env.PUBLISH_VERSION }}
 
   publish-docker-codecov:
     runs-on: ubuntu-20.04
     needs: [ workflow-setup, build-docker-codecov ]
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_CODECOV }}
-      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
+      PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -289,18 +283,18 @@ jobs:
           login-server: env.URL_DOCKER_REGISTRY
           username: env.GITHUB_ACTOR
           password: secrets.GITHUB_TOKEN
-      - name: "Publish branch image"
+      - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
+          publish-version: ${{ env.PUBLISH_VERSION }}
 
   publish-docker-android:
     runs-on: ubuntu-20.04
     needs: [ workflow-setup, build-docker-android ]
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_ANDROID }}
-      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
+      PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -310,11 +304,11 @@ jobs:
           login-server: env.URL_DOCKER_REGISTRY
           username: env.GITHUB_ACTOR
           password: secrets.GITHUB_TOKEN
-      - name: "Publish branch image"
+      - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
+          publish-version: ${{ env.PUBLISH_VERSION }}
 
   #  ##########################################################################################
   #  ###############################    TESTING    ###########################################

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           HASH_SRC_AGENCYCLIENT=${{ hashFiles('agency_client') }}
           HASH_SRC_MESSAGES=${{ hashFiles('messages') }}
           HASH_SRC_WRAPPER_JAVA=${{ hashFiles('wrappers/java') }}
-          HASH_SRC_WRAPPER_NODEJS=${{ hashFiles('wrappers/node') }}
+          HASH_SRC_WRAPPER_NODEJS=triggerbuild1-${{ hashFiles('wrappers/node') }}
           HASH_SRC_AGENT_NODEJS=${{ hashFiles('agents/node') }}
 
           HASH_DOCKER_LIBVCX=${HASH_DOCKERFILE_LIBVCX:0:11}-${HASH_SRC_LIBVCX:0:11}-${HASH_SRC_ARIESVCX:0:11}-${HASH_SRC_AGENCYCLIENT:0:11}-${HASH_SRC_MESSAGES:0:11}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           HASH_SRC_AGENCYCLIENT=${{ hashFiles('agency_client') }}
           HASH_SRC_MESSAGES=${{ hashFiles('messages') }}
           HASH_SRC_WRAPPER_JAVA=${{ hashFiles('wrappers/java') }}
-          HASH_SRC_WRAPPER_NODEJS=triggerbuild2-${{ hashFiles('wrappers/node') }}
+          HASH_SRC_WRAPPER_NODEJS=triggerbuild3-${{ hashFiles('wrappers/node') }}
           HASH_SRC_AGENT_NODEJS=${{ hashFiles('agents/node') }}
 
           HASH_DOCKER_LIBVCX=${HASH_DOCKERFILE_LIBVCX:0:11}-${HASH_SRC_LIBVCX:0:11}-${HASH_SRC_ARIESVCX:0:11}-${HASH_SRC_AGENCYCLIENT:0:11}-${HASH_SRC_MESSAGES:0:11}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Build and cache image"
         uses: ./.github/actions/build-image
@@ -111,7 +111,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load alpine core image"
         uses: ./.github/actions/load-image
@@ -140,7 +140,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load alpine core image"
         uses: ./.github/actions/load-image
@@ -168,7 +168,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Build and cache image"
         uses: ./.github/actions/build-image
@@ -191,7 +191,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Build and cache image"
         uses: ./.github/actions/build-image
@@ -218,7 +218,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
@@ -239,7 +239,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
@@ -260,7 +260,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
@@ -281,7 +281,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
@@ -302,7 +302,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
@@ -325,7 +325,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load codecov image"
         uses: ./.github/actions/load-image
@@ -365,7 +365,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
@@ -403,7 +403,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load codecov image"
         uses: ./.github/actions/load-image
@@ -443,7 +443,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load libvcx tester image"
         uses: ./.github/actions/load-image
@@ -472,7 +472,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
@@ -505,7 +505,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
@@ -537,7 +537,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
@@ -568,7 +568,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
@@ -600,7 +600,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load android image"
         uses: ./.github/actions/load-image
@@ -625,7 +625,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load libvcx tester image"
         uses: ./.github/actions/load-image
@@ -655,7 +655,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup for testing"
         uses: ./.github/actions/setup-testing
@@ -744,7 +744,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load android image"
         uses: ./.github/actions/load-image
@@ -775,7 +775,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load android image"
         uses: ./.github/actions/load-image
@@ -816,7 +816,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load image"
         uses: ./.github/actions/load-image
@@ -856,7 +856,7 @@ jobs:
         uses: azure/docker-login@v1
         with:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: ${{ env.GITHUB_ACTOR }}
+          username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load image"
         uses: ./.github/actions/load-image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,6 +211,7 @@ jobs:
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_ALPINE_CORE }}
       PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
+      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -220,6 +221,11 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Publish branch image"
+        uses: ./.github/actions/publish-image
+        with:
+          docker-img: ${{ env.DOCKER_IMG_CACHED }}
+          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -232,6 +238,7 @@ jobs:
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_LIBVCX }}
       PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
+      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -241,6 +248,11 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Publish branch image"
+        uses: ./.github/actions/publish-image
+        with:
+          docker-img: ${{ env.DOCKER_IMG_CACHED }}
+          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -253,6 +265,7 @@ jobs:
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_LIBVCX_TESTER }}
       PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
+      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -262,6 +275,11 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Publish branch image"
+        uses: ./.github/actions/publish-image
+        with:
+          docker-img: ${{ env.DOCKER_IMG_CACHED }}
+          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -274,6 +292,7 @@ jobs:
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_CODECOV }}
       PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
+      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -283,6 +302,11 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Publish branch image"
+        uses: ./.github/actions/publish-image
+        with:
+          docker-img: ${{ env.DOCKER_IMG_CACHED }}
+          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -295,6 +319,7 @@ jobs:
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_ANDROID }}
       PUBLISH_VERSION: ${{ needs.workflow-setup.outputs.PUBLISH_VERSION }}
+      BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -304,6 +329,11 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Publish branch image"
+        uses: ./.github/actions/publish-image
+        with:
+          docker-img: ${{ env.DOCKER_IMG_CACHED }}
+          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           HASH_SRC_AGENCYCLIENT=${{ hashFiles('agency_client') }}
           HASH_SRC_MESSAGES=${{ hashFiles('messages') }}
           HASH_SRC_WRAPPER_JAVA=${{ hashFiles('wrappers/java') }}
-          HASH_SRC_WRAPPER_NODEJS=triggerbuild3-${{ hashFiles('wrappers/node') }}
+          HASH_SRC_WRAPPER_NODEJS=rbld1-${{ hashFiles('wrappers/node') }}
           HASH_SRC_AGENT_NODEJS=${{ hashFiles('agents/node') }}
 
           HASH_DOCKER_LIBVCX=${HASH_DOCKERFILE_LIBVCX:0:11}-${HASH_SRC_LIBVCX:0:11}-${HASH_SRC_ARIESVCX:0:11}-${HASH_SRC_AGENCYCLIENT:0:11}-${HASH_SRC_MESSAGES:0:11}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           HASH_SRC_AGENCYCLIENT=${{ hashFiles('agency_client') }}
           HASH_SRC_MESSAGES=${{ hashFiles('messages') }}
           HASH_SRC_WRAPPER_JAVA=${{ hashFiles('wrappers/java') }}
-          HASH_SRC_WRAPPER_NODEJS=triggerbuild1-${{ hashFiles('wrappers/node') }}
+          HASH_SRC_WRAPPER_NODEJS=triggerbuild2-${{ hashFiles('wrappers/node') }}
           HASH_SRC_AGENT_NODEJS=${{ hashFiles('agents/node') }}
 
           HASH_DOCKER_LIBVCX=${HASH_DOCKERFILE_LIBVCX:0:11}-${HASH_SRC_LIBVCX:0:11}-${HASH_SRC_ARIESVCX:0:11}-${HASH_SRC_AGENCYCLIENT:0:11}-${HASH_SRC_MESSAGES:0:11}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
       PRERELEASE: ${{ steps.run-info.outputs.pre-release }}
       BRANCH_NAME: ${{ steps.run-info.outputs.branch-name }}
 
+      SKIP_IOS: ${{ steps.skip-info.outputs.skip-ios }}
+      SKIP_ANDROID: ${{ steps.skip-info.outputs.skip-android }}
+
       DOCKER_IMG_CACHED_ALPINE_CORE: ${{ steps.docker-imgs.outputs.DOCKER_IMG_CACHED_ALPINE_CORE }}
       DOCKER_IMG_CACHED_LIBVCX: ${{ steps.docker-imgs.outputs.DOCKER_IMG_CACHED_LIBVCX }}
       DOCKER_IMG_CACHED_LIBVCX_TESTER: ${{ steps.docker-imgs.outputs.DOCKER_IMG_CACHED_LIBVCX_TESTER }}
@@ -43,6 +46,9 @@ jobs:
       - name: "Construct CI run-info"
         id: run-info
         uses: ./.github/actions/construct-run-info
+      - name: "Detect CI skip steps"
+        id: skip-info
+        uses: ./.github/actions/detect-skip-info
       - name: "Set outputs"
         id: docker-imgs
         run: |
@@ -56,7 +62,7 @@ jobs:
           HASH_SRC_AGENCYCLIENT=${{ hashFiles('agency_client') }}
           HASH_SRC_MESSAGES=${{ hashFiles('messages') }}
           HASH_SRC_WRAPPER_JAVA=${{ hashFiles('wrappers/java') }}
-          HASH_SRC_WRAPPER_NODEJS=rbld1-${{ hashFiles('wrappers/node') }}
+          HASH_SRC_WRAPPER_NODEJS=${{ hashFiles('wrappers/node') }}
           HASH_SRC_AGENT_NODEJS=${{ hashFiles('agents/node') }}
 
           HASH_DOCKER_LIBVCX=${HASH_DOCKERFILE_LIBVCX:0:11}-${HASH_SRC_LIBVCX:0:11}-${HASH_SRC_ARIESVCX:0:11}-${HASH_SRC_AGENCYCLIENT:0:11}-${HASH_SRC_MESSAGES:0:11}
@@ -194,6 +200,7 @@ jobs:
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Build and cache image"
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         uses: ./.github/actions/build-image
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED }}
@@ -221,11 +228,6 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Publish branch image"
-        uses: ./.github/actions/publish-image
-        with:
-          docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -248,11 +250,6 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Publish branch image"
-        uses: ./.github/actions/publish-image
-        with:
-          docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -275,11 +272,6 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Publish branch image"
-        uses: ./.github/actions/publish-image
-        with:
-          docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -302,11 +294,6 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Publish branch image"
-        uses: ./.github/actions/publish-image
-        with:
-          docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
         uses: ./.github/actions/publish-image
         with:
@@ -329,12 +316,8 @@ jobs:
           login-server: ${{ env.URL_DOCKER_REGISTRY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Publish branch image"
-        uses: ./.github/actions/publish-image
-        with:
-          docker-img: ${{ env.DOCKER_IMG_CACHED }}
-          publish-version: ${{ env.BRANCH_NAME }}
       - name: "Publish versioned image"
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         uses: ./.github/actions/publish-image
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED }}
@@ -633,10 +616,12 @@ jobs:
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load android image"
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         uses: ./.github/actions/load-image
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED_ANDROID }}
       - name: "Run android tests"
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         run: |
           rm -rf /tmp/imgcache
           docker run --rm -i  $DOCKER_IMG_CACHED_ANDROID \
@@ -746,17 +731,21 @@ jobs:
       - name: "Git checkout"
         uses: actions/checkout@v2
       - name: Switch to xcode version 12.4
+        if: ${{ needs.workflow-setup.outputs.SKIP_IOS != 'true' }}
         run: |
           sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
           xcodebuild -version
       - name: "Build iOS wrapper"
+        if: ${{ needs.workflow-setup.outputs.SKIP_IOS != 'true' }}
         run: |
           ./wrappers/ios/ci/build.sh
       - uses: actions/upload-artifact@v2
+        if: ${{ needs.workflow-setup.outputs.SKIP_IOS != 'true' }}
         with:
           name: libvcx-ios-${{ env.PUBLISH_VERSION }}-device
           path: /tmp/artifacts/libvcx-ios-${{ env.PUBLISH_VERSION }}-device.zip
       - uses: actions/upload-artifact@v2
+        if: ${{ needs.workflow-setup.outputs.SKIP_IOS != 'true' }}
         with:
           name: libvcx-ios-${{ env.PUBLISH_VERSION }}-universal
           path: /tmp/artifacts/libvcx-ios-${{ env.PUBLISH_VERSION }}-universal.zip
@@ -777,16 +766,19 @@ jobs:
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load android image"
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         uses: ./.github/actions/load-image
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED_ANDROID }}
       - name: "Build, run android wrapper tests, and publish artifacts"
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         uses: ./.github/actions/publish-android
         with:
           abis: "arm arm64"
           docker-img-name: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_ANDROID }}
           full-version-name: ${{ env.FULL_VERSION_NAME }}
       - name: "Publish aar artifact"
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ env.FULL_VERSION_NAME }}
@@ -808,16 +800,19 @@ jobs:
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Load android image"
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         uses: ./.github/actions/load-image
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED_ANDROID }}
       - name: "Build, run android wrapper tests, and publish artifacts"
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         uses: ./.github/actions/publish-android
         with:
           abis: "x86 x86_64"
           docker-img-name: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_ANDROID }}
           full-version-name: ${{ env.FULL_VERSION_NAME }}
       - uses: actions/upload-artifact@v2
+        if: ${{ needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
         with:
           name: ${{ env.FULL_VERSION_NAME }}
           path: /tmp/artifacts/aar/${{ env.FULL_VERSION_NAME }}.aar


### PR DESCRIPTION
- Fix CI warnings (usage of set-output)
- As `build-image` action was trying to pull images from `docker.pkg.github.com`, it never worked because that's not docker registry we are logged into - so we didn't reuse previously built docker layer
- Generalized `construct-run-info` to refer to on `$MAIN_BRANCH` instead of hardcoding `main`
- Added action template for detecting skip PR tags (currently supports opt-in PR tags `skip-android` and `skip-ios`)
- Fixed information passing into `azure/docker-login@v1`
- Fixed publishing jobs - images are published under tag`$PUBLISH_VERSION` 
- Modified `build-image` such that it publishes image `<docker-img>:<branch>` to docker registry for caching purposes
- Adjusted publish-image more robust so it doesn't try to load image from cache if it already exist in local docker repo
