### PR TITLE
Allow obtaining cred rev id from the wallet

### DIFF
--- a/aries_vcx/src/handlers/issuance/holder.rs
+++ b/aries_vcx/src/handlers/issuance/holder.rs
@@ -127,6 +127,10 @@ impl Holder {
         self.holder_sm.get_rev_reg_id()
     }
 
+    pub fn get_cred_id(&self) -> VcxResult<String> {
+        self.holder_sm.get_cred_id()
+    }
+
     pub fn get_thread_id(&self) -> VcxResult<String> {
         self.holder_sm.get_thread_id()
     }

--- a/aries_vcx/src/indy/credentials/holder/mod.rs
+++ b/aries_vcx/src/indy/credentials/holder/mod.rs
@@ -4,6 +4,8 @@ use crate::error::{VcxError, VcxResult};
 use crate::global::settings;
 use crate::utils;
 
+
+
 pub async fn libindy_prover_store_credential(
     wallet_handle: WalletHandle,
     cred_id: Option<&str>,
@@ -32,6 +34,23 @@ pub async fn libindy_prover_store_credential(
         cred_json,
         cred_def_json,
         rev_reg_def_json,
+    )
+        .await
+        .map_err(VcxError::from)
+}
+
+pub async fn libindy_prover_get_credential(
+    wallet_handle: WalletHandle,
+    cred_id: &str,
+) -> VcxResult<String> {
+    trace!("libindy_prover_get_credential >>> \
+            cred_id: {:?}",
+           cred_id,
+    );
+
+    anoncreds::prover_get_credential(
+        wallet_handle,
+        cred_id,
     )
         .await
         .map_err(VcxError::from)

--- a/aries_vcx/src/indy/credentials/holder/mod.rs
+++ b/aries_vcx/src/indy/credentials/holder/mod.rs
@@ -4,8 +4,6 @@ use crate::error::{VcxError, VcxResult};
 use crate::global::settings;
 use crate::utils;
 
-
-
 pub async fn libindy_prover_store_credential(
     wallet_handle: WalletHandle,
     cred_id: Option<&str>,

--- a/aries_vcx/src/indy/credentials/mod.rs
+++ b/aries_vcx/src/indy/credentials/mod.rs
@@ -26,3 +26,31 @@ pub async fn get_cred_rev_id(wallet_handle: WalletHandle, cred_id: &str) -> VcxR
         .map_err(|err| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to deserialize anoncreds credential: {}", err)))?;
     prover_cred.cred_rev_id.ok_or(VcxError::from_msg(VcxErrorKind::InvalidRevocationDetails, "Credenial revocation id missing on credential - is this credential revokable?"))
 }
+
+#[cfg(test)]
+#[cfg(feature = "pool_tests")]
+mod integration_tests {
+    use super::*;
+
+    use crate::indy::test_utils::create_and_store_credential;
+    use crate::utils::constants::{DEFAULT_SCHEMA_ATTRS};
+    use crate::utils::devsetup::SetupWalletPool;
+
+    #[tokio::test]
+    async fn test_prover_get_credential() {
+        let setup = SetupWalletPool::init().await;
+
+        let res = create_and_store_credential(setup.wallet_handle, setup.pool_handle, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
+        let schema_id = res.0;
+        let cred_def_id = res.2;
+        let cred_id = res.7;
+        let rev_reg_id = res.8;
+
+        let cred_json = libindy_prover_get_credential(setup.wallet_handle, &cred_id).await.unwrap();
+        let prover_cred = serde_json::from_str::<ProverCredential>(&cred_json).unwrap();
+
+        assert_eq!(prover_cred.schema_id, schema_id);
+        assert_eq!(prover_cred.cred_def_id, cred_def_id);
+        assert_eq!(prover_cred.rev_reg_id.unwrap(), rev_reg_id);
+    }
+}

--- a/aries_vcx/src/indy/credentials/mod.rs
+++ b/aries_vcx/src/indy/credentials/mod.rs
@@ -1,3 +1,28 @@
 pub mod encoding;
 pub mod holder;
 pub mod issuer;
+
+use std::collections::HashMap;
+
+use vdrtools_sys::WalletHandle;
+
+use crate::error::prelude::*;
+
+use self::holder::libindy_prover_get_credential;
+
+#[derive(Serialize, Deserialize)]
+struct ProverCredential {
+    referent: String,
+    attrs: HashMap<String, String>,
+    schema_id: String,
+    cred_def_id: String,
+    rev_reg_id: Option<String>,
+    cred_rev_id: Option<String>
+}
+
+pub async fn get_cred_rev_id(wallet_handle: WalletHandle, cred_id: &str) -> VcxResult<String> {
+    let cred_json = libindy_prover_get_credential(wallet_handle, cred_id).await?;
+    let prover_cred = serde_json::from_str::<ProverCredential>(&cred_json)
+        .map_err(|err| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to deserialize anoncreds credential: {}", err)))?;
+    prover_cred.cred_rev_id.ok_or(VcxError::from_msg(VcxErrorKind::InvalidRevocationDetails, "Credenial revocation id missing on credential - is this credential revokable?"))
+}

--- a/aries_vcx/src/indy/credentials/mod.rs
+++ b/aries_vcx/src/indy/credentials/mod.rs
@@ -45,12 +45,27 @@ mod integration_tests {
         let cred_def_id = res.2;
         let cred_id = res.7;
         let rev_reg_id = res.8;
+        let cred_rev_id = res.9;
 
         let cred_json = libindy_prover_get_credential(setup.wallet_handle, &cred_id).await.unwrap();
         let prover_cred = serde_json::from_str::<ProverCredential>(&cred_json).unwrap();
 
         assert_eq!(prover_cred.schema_id, schema_id);
         assert_eq!(prover_cred.cred_def_id, cred_def_id);
+        assert_eq!(prover_cred.cred_rev_id.unwrap(), cred_rev_id);
         assert_eq!(prover_cred.rev_reg_id.unwrap(), rev_reg_id);
+    }
+
+    #[tokio::test]
+    async fn test_get_cred_rev_id() {
+        let setup = SetupWalletPool::init().await;
+
+        let res = create_and_store_credential(setup.wallet_handle, setup.pool_handle, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
+        let cred_id = res.7;
+        let cred_rev_id = res.9;
+
+        let cred_rev_id_ = get_cred_rev_id(setup.wallet_handle, &cred_id).await.unwrap();
+
+        assert_eq!(cred_rev_id, cred_rev_id_);
     }
 }

--- a/aries_vcx/src/protocols/issuance/holder/state_machine.rs
+++ b/aries_vcx/src/protocols/issuance/holder/state_machine.rs
@@ -382,6 +382,16 @@ impl HolderSM {
         }
     }
 
+    pub fn get_cred_id(&self) -> VcxResult<String> {
+        match self.state {
+            HolderFullState::Finished(ref state) => state.get_cred_id(),
+            _ => Err(VcxError::from_msg(
+                VcxErrorKind::NotReady,
+                "Cannot get credential id: credential exchange not finished yet",
+            )),
+        }
+    }
+
     pub fn get_offer(&self) -> VcxResult<CredentialOffer> {
         match self.state {
             HolderFullState::OfferReceived(ref state) => Ok(state.offer.clone()),

--- a/aries_vcx/src/protocols/issuance/holder/states/finished.rs
+++ b/aries_vcx/src/protocols/issuance/holder/states/finished.rs
@@ -128,6 +128,13 @@ impl FinishedHolderState {
         Ok(rev_reg_def_id.to_string())
     }
 
+    pub fn get_cred_id(&self) -> VcxResult<String> {
+        self.cred_id.clone().ok_or(VcxError::from_msg(
+            VcxErrorKind::InvalidJson,
+            format!("The field 'cred_id' not found on FinishedHolderState")
+        ))
+    }
+
     pub fn is_revokable(&self) -> VcxResult<bool> {
         Ok(self.rev_reg_def_json.is_some())
     }


### PR DESCRIPTION
This will eventually allow checking revocation status against ledger and finding the corresponding `Holder` based on received revocation notification.

Signed-off-by: Miroslav Kovar <miroslav.kovar@absa.africa>