### PR TITLE
Replace gradlew repo jcenter() by mavenCentral()

### DIFF
--- a/wrappers/java/android/build.gradle
+++ b/wrappers/java/android/build.gradle
@@ -180,7 +180,6 @@ dependencies {
     testImplementation group: 'org.json', name: 'json', version:'20160810'
     testImplementation 'net.java.dev.jna:jna:4.5.0'
     testImplementation 'org.awaitility:awaitility-scala:3.1.2'
-    androidTestImplementation 'com.getkeepsafe.relinker:relinker:1.3.1'
     androidTestImplementation('com.facebook.react:react-native:0.59.9') { force = true }
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support:support-annotations:26.1.0'

--- a/wrappers/java/android/build.gradle
+++ b/wrappers/java/android/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.android.library'
 buildscript {
 
     repositories {
-        jcenter()
+        mavenCentral()
         google()
         maven {
             url "https://maven.google.com"
@@ -38,7 +38,7 @@ repositories {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://maven.google.com"
         }

--- a/wrappers/java/build.gradle
+++ b/wrappers/java/build.gradle
@@ -18,7 +18,7 @@ repositories {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://maven.google.com"
         }

--- a/wrappers/java/build.gradle
+++ b/wrappers/java/build.gradle
@@ -74,7 +74,6 @@ dependencies {
     implementation group: 'net.sourceforge.streamsupport', name: 'android-retrostreams', version: '1.6.2'
     implementation group: 'org.json', name: 'json', version: '20180130'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0'
-    testImplementation 'com.getkeepsafe.relinker:relinker:1.3.1'
     testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
     testImplementation group: 'commons-io', name: 'commons-io', version: '2.5'


### PR DESCRIPTION
- jcentre was decomissioned
https://stackoverflow.com/questions/74258160/is-jcenter-down-permanently-31-oct
- the `relinker:relinker` dependency (which was originally being pulled from jcenter) itself, seems like was not being used, so removed

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>