### PR TITLE
Revocation status "self-check"

### DIFF
--- a/aries_vcx/src/handlers/issuance/holder.rs
+++ b/aries_vcx/src/handlers/issuance/holder.rs
@@ -131,6 +131,10 @@ impl Holder {
         self.holder_sm.is_revokable(wallet_handle, pool_handle).await
     }
 
+    pub async fn is_revoked(&self, wallet_handle: WalletHandle, pool_handle: PoolHandle) -> VcxResult<bool> {
+        self.holder_sm.is_revoked(wallet_handle, pool_handle).await
+    }
+
     pub async fn delete_credential(&self, wallet_handle: WalletHandle) -> VcxResult<()> {
         self.holder_sm.delete_credential(wallet_handle).await
     }

--- a/aries_vcx/src/handlers/issuance/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use messages::ack::please_ack::AckOn;
-use vdrtools_sys::WalletHandle;
+use vdrtools_sys::{WalletHandle, PoolHandle};
 
 use agency_client::agency_client::AgencyClient;
 
@@ -233,6 +233,10 @@ impl Issuer {
 
     pub fn is_revokable(&self) -> bool {
         self.issuer_sm.is_revokable()
+    }
+
+    pub async fn is_revoked(&self, pool_handle: PoolHandle) -> VcxResult<bool> {
+        self.issuer_sm.is_revoked(pool_handle).await
     }
 
     pub async fn step(

--- a/aries_vcx/src/indy/anoncreds.rs
+++ b/aries_vcx/src/indy/anoncreds.rs
@@ -107,7 +107,7 @@ pub mod integration_tests {
             .await;
         assert!(rc.is_err());
 
-        let (_, _, _, _, _, _, _, _, rev_reg_id, cred_rev_id) =
+        let (_, _, _, _, _, _, _, _, rev_reg_id, cred_rev_id, _) =
             create_and_store_credential(
                 setup.wallet_handle,
                 setup.pool_handle,
@@ -130,7 +130,7 @@ pub mod integration_tests {
     async fn test_revoke_credential() {
         let setup = SetupWalletPool::init().await;
 
-        let (_, _, _, _, _, _, _, _, rev_reg_id, cred_rev_id) =
+        let (_, _, _, _, _, _, _, _, rev_reg_id, cred_rev_id, _) =
             create_and_store_credential(
                 setup.wallet_handle,
                 setup.pool_handle,

--- a/aries_vcx/src/indy/credentials/mod.rs
+++ b/aries_vcx/src/indy/credentials/mod.rs
@@ -45,7 +45,7 @@ pub async fn is_cred_revoked(
     let from = None;
     let to = Some(get_time().sec as u64 + 100);
     let rev_reg_delta = RevocationRegistryDelta::create_from_ledger(pool_handle, rev_reg_id, from, to).await?;
-    Ok(rev_reg_delta.revoked().iter().any(|s| s.to_string().eq(&rev_id)))
+    Ok(rev_reg_delta.revoked().iter().any(|s| s.to_string().eq(rev_id)))
 }
 
 #[cfg(test)]
@@ -116,13 +116,12 @@ mod integration_tests {
             DEFAULT_SCHEMA_ATTRS,
         )
         .await;
-        let cred_id = res.7;
         let rev_reg_id = res.8;
         let cred_rev_id = res.9;
         let tails_file = res.10;
 
         assert!(
-            !is_cred_revoked(setup.pool_handle, &rev_reg_id, &cred_id)
+            !is_cred_revoked(setup.pool_handle, &rev_reg_id, &cred_rev_id)
                 .await
                 .unwrap()
         );
@@ -139,8 +138,10 @@ mod integration_tests {
         .await
         .unwrap();
 
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
         assert!(
-            is_cred_revoked(setup.pool_handle, &rev_reg_id, &cred_id)
+            is_cred_revoked(setup.pool_handle, &rev_reg_id, &cred_rev_id)
                 .await
                 .unwrap()
         );

--- a/aries_vcx/src/indy/credentials/mod.rs
+++ b/aries_vcx/src/indy/credentials/mod.rs
@@ -4,11 +4,14 @@ pub mod issuer;
 
 use std::collections::HashMap;
 
-use vdrtools_sys::WalletHandle;
+use time::get_time;
+use vdrtools_sys::{PoolHandle, WalletHandle};
 
 use crate::error::prelude::*;
 
 use self::holder::libindy_prover_get_credential;
+
+use super::primitives::revocation_registry_delta::RevocationRegistryDelta;
 
 #[derive(Serialize, Deserialize)]
 struct ProverCredential {
@@ -17,14 +20,32 @@ struct ProverCredential {
     schema_id: String,
     cred_def_id: String,
     rev_reg_id: Option<String>,
-    cred_rev_id: Option<String>
+    cred_rev_id: Option<String>,
 }
 
 pub async fn get_cred_rev_id(wallet_handle: WalletHandle, cred_id: &str) -> VcxResult<String> {
     let cred_json = libindy_prover_get_credential(wallet_handle, cred_id).await?;
-    let prover_cred = serde_json::from_str::<ProverCredential>(&cred_json)
-        .map_err(|err| VcxError::from_msg(VcxErrorKind::SerializationError, format!("Failed to deserialize anoncreds credential: {}", err)))?;
-    prover_cred.cred_rev_id.ok_or(VcxError::from_msg(VcxErrorKind::InvalidRevocationDetails, "Credenial revocation id missing on credential - is this credential revokable?"))
+    let prover_cred = serde_json::from_str::<ProverCredential>(&cred_json).map_err(|err| {
+        VcxError::from_msg(
+            VcxErrorKind::SerializationError,
+            format!("Failed to deserialize anoncreds credential: {}", err),
+        )
+    })?;
+    prover_cred.cred_rev_id.ok_or(VcxError::from_msg(
+        VcxErrorKind::InvalidRevocationDetails,
+        "Credenial revocation id missing on credential - is this credential revokable?",
+    ))
+}
+
+pub async fn is_cred_revoked(
+    pool_handle: PoolHandle,
+    rev_reg_id: &str,
+    rev_id: &str,
+) -> VcxResult<bool> {
+    let from = None;
+    let to = Some(get_time().sec as u64 + 100);
+    let rev_reg_delta = RevocationRegistryDelta::create_from_ledger(pool_handle, rev_reg_id, from, to).await?;
+    Ok(rev_reg_delta.revoked().iter().any(|s| s.to_string().eq(&rev_id)))
 }
 
 #[cfg(test)]
@@ -32,27 +53,36 @@ pub async fn get_cred_rev_id(wallet_handle: WalletHandle, cred_id: &str) -> VcxR
 mod integration_tests {
     use super::*;
 
+    use crate::indy::primitives::revocation_registry::{self, publish_local_revocations};
     use crate::indy::test_utils::create_and_store_credential;
-    use crate::utils::constants::{DEFAULT_SCHEMA_ATTRS};
+    use crate::utils::constants::DEFAULT_SCHEMA_ATTRS;
     use crate::utils::devsetup::SetupWalletPool;
 
     #[tokio::test]
     async fn test_prover_get_credential() {
         let setup = SetupWalletPool::init().await;
 
-        let res = create_and_store_credential(setup.wallet_handle, setup.pool_handle, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
+        let res = create_and_store_credential(
+            setup.wallet_handle,
+            setup.pool_handle,
+            &setup.institution_did,
+            DEFAULT_SCHEMA_ATTRS,
+        )
+        .await;
         let schema_id = res.0;
         let cred_def_id = res.2;
         let cred_id = res.7;
         let rev_reg_id = res.8;
         let cred_rev_id = res.9;
 
-        let cred_json = libindy_prover_get_credential(setup.wallet_handle, &cred_id).await.unwrap();
+        let cred_json = libindy_prover_get_credential(setup.wallet_handle, &cred_id)
+            .await
+            .unwrap();
         let prover_cred = serde_json::from_str::<ProverCredential>(&cred_json).unwrap();
 
         assert_eq!(prover_cred.schema_id, schema_id);
         assert_eq!(prover_cred.cred_def_id, cred_def_id);
-        assert_eq!(prover_cred.cred_rev_id.unwrap(), cred_rev_id);
+        assert_eq!(prover_cred.cred_rev_id.unwrap().to_string(), cred_rev_id);
         assert_eq!(prover_cred.rev_reg_id.unwrap(), rev_reg_id);
     }
 
@@ -60,12 +90,59 @@ mod integration_tests {
     async fn test_get_cred_rev_id() {
         let setup = SetupWalletPool::init().await;
 
-        let res = create_and_store_credential(setup.wallet_handle, setup.pool_handle, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
+        let res = create_and_store_credential(
+            setup.wallet_handle,
+            setup.pool_handle,
+            &setup.institution_did,
+            DEFAULT_SCHEMA_ATTRS,
+        )
+        .await;
         let cred_id = res.7;
         let cred_rev_id = res.9;
 
         let cred_rev_id_ = get_cred_rev_id(setup.wallet_handle, &cred_id).await.unwrap();
 
-        assert_eq!(cred_rev_id, cred_rev_id_);
+        assert_eq!(cred_rev_id, cred_rev_id_.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_is_cred_revoked() {
+        let setup = SetupWalletPool::init().await;
+
+        let res = create_and_store_credential(
+            setup.wallet_handle,
+            setup.pool_handle,
+            &setup.institution_did,
+            DEFAULT_SCHEMA_ATTRS,
+        )
+        .await;
+        let cred_id = res.7;
+        let rev_reg_id = res.8;
+        let cred_rev_id = res.9;
+        let tails_file = res.10;
+
+        assert!(
+            !is_cred_revoked(setup.pool_handle, &rev_reg_id, &cred_id)
+                .await
+                .unwrap()
+        );
+
+        revocation_registry::revoke_credential_local(setup.wallet_handle, &tails_file, &rev_reg_id, &cred_rev_id)
+            .await
+            .unwrap();
+        publish_local_revocations(
+            setup.wallet_handle,
+            setup.pool_handle,
+            &setup.institution_did,
+            &rev_reg_id,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            is_cred_revoked(setup.pool_handle, &rev_reg_id, &cred_id)
+                .await
+                .unwrap()
+        );
     }
 }

--- a/aries_vcx/src/indy/primitives/mod.rs
+++ b/aries_vcx/src/indy/primitives/mod.rs
@@ -1,4 +1,5 @@
 pub mod revocation_registry;
+pub mod revocation_registry_delta;
 pub mod credential_definition;
 pub mod credential_schema;
 

--- a/aries_vcx/src/indy/primitives/revocation_registry_delta.rs
+++ b/aries_vcx/src/indy/primitives/revocation_registry_delta.rs
@@ -1,0 +1,79 @@
+use vdrtools_sys::PoolHandle;
+
+use crate::{error::prelude::*, indy::ledger::transactions::get_rev_reg_delta_json};
+
+#[derive(Clone, Deserialize, Debug, Serialize, Default)]
+pub struct RevocationRegistryDelta {
+    value: RevocationRegistryDeltaValue,
+    #[serde(rename = "ver")]
+    version: String,
+}
+
+#[derive(Clone, Deserialize, Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RevocationRegistryDeltaValue {
+    prev_accum: Option<String>,
+    accum: String,
+    #[serde(default)]
+    issued: Vec<u32>,
+    #[serde(default)]
+    revoked: Vec<u32>,
+}
+
+impl RevocationRegistryDeltaValue {
+    pub fn issued(&self) -> &[u32] {
+        self.issued.as_ref()
+    }
+
+    pub fn revoked(&self) -> &[u32] {
+        self.revoked.as_ref()
+    }
+}
+
+impl RevocationRegistryDelta {
+    pub async fn create_from_ledger(
+        pool_handle: PoolHandle,
+        rev_reg_id: &str,
+        from: Option<u64>,
+        to: Option<u64>,
+    ) -> VcxResult<Self> {
+        let (_, rev_reg_delta_json, _) = get_rev_reg_delta_json(pool_handle, rev_reg_id, from, to).await?;
+        serde_json::from_str(&rev_reg_delta_json).map_err(|err| {
+            VcxError::from_msg(
+                VcxErrorKind::SerializationError,
+                format!("Failed to deserialize rev_reg_delta_json from ledger, err: {}", err),
+            )
+        })
+    }
+
+    pub fn issued(&self) -> &[u32] {
+        self.value.issued()
+    }
+
+    pub fn revoked(&self) -> &[u32] {
+        self.value.revoked()
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "pool_tests")]
+pub mod integration_tests {
+    use super::*;
+    use crate::{indy::test_utils::create_and_store_credential_def, utils::devsetup::SetupWalletPool};
+
+    #[tokio::test]
+    async fn test_create_rev_reg_delta_from_ledger() {
+        let setup = SetupWalletPool::init().await;
+
+        let attrs = r#"["address1","address2","city","state","zip"]"#;
+        let (_, _, _, _, rev_reg_id, _, _) =
+            create_and_store_credential_def(setup.wallet_handle, setup.pool_handle, &setup.institution_did, attrs)
+                .await;
+
+        assert!(
+            RevocationRegistryDelta::create_from_ledger(setup.pool_handle, &rev_reg_id, None, None)
+                .await
+                .is_ok()
+        );
+    }
+}

--- a/aries_vcx/src/indy/test_utils.rs
+++ b/aries_vcx/src/indy/test_utils.rs
@@ -166,6 +166,7 @@ pub async fn create_and_store_credential(
     String,
     String,
     String,
+    String
 ) {
     let (schema_id, schema_json, cred_def_id, cred_def_json, rev_reg_id, _, _) =
         create_and_store_credential_def(wallet_handle, pool_handle, institution_did, attr_list).await;
@@ -184,7 +185,7 @@ pub async fn create_and_store_credential(
         &req,
         &encoded_attributes,
         Some(rev_reg_id.clone()),
-        Some(tails_file),
+        Some(tails_file.clone()),
     )
         .await
         .unwrap();
@@ -210,6 +211,7 @@ pub async fn create_and_store_credential(
         cred_id,
         rev_reg_id,
         cred_rev_id.unwrap(),
+        tails_file
     )
 }
 

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -825,6 +825,7 @@ pub mod test_utils {
             true,
         )
         .await;
+        assert!(!holder_credential.is_revoked(consumer.wallet_handle, consumer.pool_handle).await.unwrap());
         issuer_credential
     }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
+edition = "2021"
 max_width=120
-


### PR DESCRIPTION
Enables credential revocation status verification for issuer and holder based on revocation registry delta obtained from the ledger, i.e. without generation of a non-revocation proof.

Signed-off-by: Miroslav Kovar <miroslav.kovar@absa.africa>