### PR TITLE
create prefix did:sov

### DIFF
--- a/aries_vcx/src/indy/ledger/transactions.rs
+++ b/aries_vcx/src/indy/ledger/transactions.rs
@@ -338,7 +338,12 @@ pub async fn get_attr(pool_handle: PoolHandle, did: &str, attr_name: &str) -> Vc
 }
 
 pub async fn get_service(pool_handle: PoolHandle, did: &Did) -> VcxResult<AriesService> {
-    let attr_resp = get_attr(pool_handle, &did.to_string(), "service").await?;
+    let did_raw = did.to_string();
+    let  did_raw = match  did_raw.rsplit_once(':'){
+        None => {did_raw}
+        Some((_,value)) => {value.to_string()}
+    };
+    let attr_resp = get_attr(pool_handle, &did_raw, "service").await?;
     let data = get_data_from_response(&attr_resp)?;
     let ser_service = match data["service"].as_str() {
         Some(ser_service) => ser_service.to_string(),

--- a/libvcx/src/api_lib/api_handle/out_of_band.rs
+++ b/libvcx/src/api_lib/api_handle/out_of_band.rs
@@ -102,7 +102,9 @@ pub fn append_service(handle: u32, service: &str) -> VcxResult<()> {
 pub fn append_service_did(handle: u32, did: &str) -> VcxResult<()> {
     trace!("append_service_did >>> handle: {}, did: {}", handle, did);
     let mut oob = OUT_OF_BAND_SENDER_MAP.get_cloned(handle)?;
-    oob = oob.clone().append_service(&ServiceResolvable::Did(Did::new(did)?));
+    let mut did_sov = "did:sov:".to_owned();
+    did_sov.push_str(&did);
+    oob = oob.clone().append_service(&ServiceResolvable::Did(Did::new(&did_sov)?));
     OUT_OF_BAND_SENDER_MAP.insert(handle, oob)
 }
 
@@ -246,7 +248,7 @@ pub mod tests {
         assert_eq!(resolved_service.len(), 2);
         assert_eq!(service, resolved_service[0]);
         assert_eq!(
-            ServiceResolvable::Did(Did::new("V4SGRU86Z58d6TV7PBUe6f").unwrap()),
+            ServiceResolvable::Did(Did::new("did:sov:V4SGRU86Z58d6TV7PBUe6f").unwrap()),
             resolved_service[1]
         );
     }


### PR DESCRIPTION

this task was performed implementing did:sov in out-of-band message generation, now every time generating a public out-of-band invite will contain did:sov, it also managed to process messages without the did:sov prefix