### PR TITLE
Get connection by remote vk, unpack sender vk, remove async, etc.

### DIFF
--- a/agents/rust/aries-vcx-agent/src/agent/mod.rs
+++ b/agents/rust/aries-vcx-agent/src/agent/mod.rs
@@ -4,4 +4,4 @@ mod init;
 
 pub use agent_config::AgentConfig;
 pub use agent_struct::Agent;
-pub use init::InitConfig;
+pub use init::{AgencyInitConfig, InitConfig, PoolInitConfig, WalletInitConfig};

--- a/agents/rust/aries-vcx-agent/src/services/issuer.rs
+++ b/agents/rust/aries-vcx-agent/src/services/issuer.rs
@@ -4,6 +4,7 @@ use crate::error::*;
 use crate::services::connection::ServiceConnections;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::handlers::issuance::issuer::Issuer;
+use aries_vcx::messages::issuance::credential_ack::CredentialAck;
 use aries_vcx::messages::issuance::credential_offer::OfferInfo;
 use aries_vcx::messages::issuance::credential_proposal::CredentialProposal;
 use aries_vcx::messages::issuance::credential_request::CredentialRequest;
@@ -96,6 +97,19 @@ impl ServiceCredentialsIssuer {
             connection_id,
         } = self.creds_issuer.get(thread_id)?;
         issuer.process_credential_request(request)?;
+        self.creds_issuer.set(
+            &issuer.get_thread_id()?,
+            IssuerWrapper::new(issuer, &connection_id),
+        )?;
+        Ok(())
+    }
+
+    pub fn process_credential_ack(&self, thread_id: &str, ack: CredentialAck) -> AgentResult<()> {
+        let IssuerWrapper {
+            mut issuer,
+            connection_id,
+        } = self.creds_issuer.get(thread_id)?;
+        issuer.process_credential_ack(ack)?;
         self.creds_issuer.set(
             &issuer.get_thread_id()?,
             IssuerWrapper::new(issuer, &connection_id),

--- a/agents/rust/aries-vcx-agent/src/services/issuer.rs
+++ b/agents/rust/aries-vcx-agent/src/services/issuer.rs
@@ -6,6 +6,7 @@ use crate::storage::object_cache::ObjectCache;
 use aries_vcx::handlers::issuance::issuer::Issuer;
 use aries_vcx::messages::issuance::credential_offer::OfferInfo;
 use aries_vcx::messages::issuance::credential_proposal::CredentialProposal;
+use aries_vcx::messages::issuance::credential_request::CredentialRequest;
 use aries_vcx::protocols::issuance::issuer::state_machine::IssuerState;
 use aries_vcx::vdrtools_sys::WalletHandle;
 
@@ -87,6 +88,19 @@ impl ServiceCredentialsIssuer {
             &issuer.get_thread_id()?,
             IssuerWrapper::new(issuer, &connection_id),
         )
+    }
+
+    pub fn process_credential_request(&self, thread_id: &str, request: CredentialRequest) -> AgentResult<()> {
+        let IssuerWrapper {
+            mut issuer,
+            connection_id,
+        } = self.creds_issuer.get(thread_id)?;
+        issuer.process_credential_request(request)?;
+        self.creds_issuer.set(
+            &issuer.get_thread_id()?,
+            IssuerWrapper::new(issuer, &connection_id),
+        )?;
+        Ok(())
     }
 
     pub async fn send_credential(&self, thread_id: &str) -> AgentResult<()> {

--- a/agents/rust/aries-vcx-agent/src/services/issuer.rs
+++ b/agents/rust/aries-vcx-agent/src/services/issuer.rs
@@ -122,7 +122,13 @@ impl ServiceCredentialsIssuer {
         issuer.get_rev_id().map_err(|err| err.into())
     }
 
+    pub fn get_proposal(&self, thread_id: &str) -> AgentResult<CredentialProposal> {
+        let issuer = self.get_issuer(thread_id)?;
+        issuer.get_proposal().map_err(|err| err.into())
+    }
+
     pub fn exists_by_id(&self, thread_id: &str) -> bool {
         self.creds_issuer.has_id(thread_id)
     }
 }
+

--- a/aries_vcx/src/handlers/connection/cloud_agent.rs
+++ b/aries_vcx/src/handlers/connection/cloud_agent.rs
@@ -256,6 +256,6 @@ impl CloudAgentInfo {
         wallet_handle: WalletHandle,
         message: &DownloadedMessageEncrypted,
     ) -> VcxResult<A2AMessage> {
-        EncryptionEnvelope::anon_unpack(wallet_handle, message.payload()?).await
+        Ok(EncryptionEnvelope::anon_unpack(wallet_handle, message.payload()?).await?.0)
     }
 }

--- a/aries_vcx/src/handlers/connection/connection.rs
+++ b/aries_vcx/src/handlers/connection/connection.rs
@@ -81,17 +81,17 @@ impl Connection {
         }
     }
 
-    pub async fn remote_did(&self) -> VcxResult<String> {
+    pub fn remote_did(&self) -> VcxResult<String> {
         match &self.connection_sm {
             SmConnection::Inviter(sm_inviter) => sm_inviter.remote_did(),
-            SmConnection::Invitee(sm_invitee) => sm_invitee.remote_did().await,
+            SmConnection::Invitee(sm_invitee) => sm_invitee.remote_did(),
         }
     }
 
-    pub async fn remote_vk(&self) -> VcxResult<String> {
+    pub fn remote_vk(&self) -> VcxResult<String> {
         match &self.connection_sm {
             SmConnection::Inviter(sm_inviter) => sm_inviter.remote_vk(),
-            SmConnection::Invitee(sm_invitee) => sm_invitee.remote_vk().await,
+            SmConnection::Invitee(sm_invitee) => sm_invitee.remote_vk(),
         }
     }
 
@@ -102,10 +102,10 @@ impl Connection {
         }
     }
 
-    pub async fn their_did_doc(&self) -> Option<DidDoc> {
+    pub fn their_did_doc(&self) -> Option<DidDoc> {
         match &self.connection_sm {
             SmConnection::Inviter(sm_inviter) => sm_inviter.their_did_doc(),
-            SmConnection::Invitee(sm_invitee) => sm_invitee.their_did_doc().await,
+            SmConnection::Invitee(sm_invitee) => sm_invitee.their_did_doc(),
         }
     }
 
@@ -300,7 +300,7 @@ impl Connection {
         send_message: Option<SendClosureConnection>,
     ) -> VcxResult<SendClosure> {
         trace!("send_message_closure >>>");
-        let did_doc = self.their_did_doc().await.ok_or(VcxError::from_msg(
+        let did_doc = self.their_did_doc().ok_or(VcxError::from_msg(
             VcxErrorKind::NotReady,
             "Cannot send message: Remote Connection information is not set",
         ))?;

--- a/aries_vcx/src/handlers/connection/mediated_connection.rs
+++ b/aries_vcx/src/handlers/connection/mediated_connection.rs
@@ -210,17 +210,17 @@ impl MediatedConnection {
         self.cloud_agent_info.clone()
     }
 
-    pub async fn remote_did(&self) -> VcxResult<String> {
+    pub fn remote_did(&self) -> VcxResult<String> {
         match &self.connection_sm {
             SmConnection::Inviter(sm_inviter) => sm_inviter.remote_did(),
-            SmConnection::Invitee(sm_invitee) => sm_invitee.remote_did().await,
+            SmConnection::Invitee(sm_invitee) => sm_invitee.remote_did(),
         }
     }
 
-    pub async fn remote_vk(&self) -> VcxResult<String> {
+    pub fn remote_vk(&self) -> VcxResult<String> {
         match &self.connection_sm {
             SmConnection::Inviter(sm_inviter) => sm_inviter.remote_vk(),
-            SmConnection::Invitee(sm_invitee) => sm_invitee.remote_vk().await,
+            SmConnection::Invitee(sm_invitee) => sm_invitee.remote_vk(),
         }
     }
 
@@ -253,10 +253,10 @@ impl MediatedConnection {
         }
     }
 
-    pub async fn their_did_doc(&self) -> Option<DidDoc> {
+    pub fn their_did_doc(&self) -> Option<DidDoc> {
         match &self.connection_sm {
             SmConnection::Inviter(sm_inviter) => sm_inviter.their_did_doc(),
-            SmConnection::Invitee(sm_invitee) => sm_invitee.their_did_doc().await,
+            SmConnection::Invitee(sm_invitee) => sm_invitee.their_did_doc(),
         }
     }
 
@@ -425,7 +425,7 @@ impl MediatedConnection {
     }
 
     pub async fn handle_message(&mut self, message: A2AMessage, wallet_handle: WalletHandle) -> VcxResult<()> {
-        let did_doc = self.their_did_doc().await.ok_or(VcxError::from_msg(
+        let did_doc = self.their_did_doc().ok_or(VcxError::from_msg(
             VcxErrorKind::NotReady,
             format!(
                 "Can't answer message {:?} because counterparty did doc is not available",
@@ -725,7 +725,7 @@ impl MediatedConnection {
     }
 
     async fn get_expected_sender_vk(&self) -> VcxResult<String> {
-        self.remote_vk().await.map_err(|_err| {
+        self.remote_vk().map_err(|_err| {
             VcxError::from_msg(
                 VcxErrorKind::NotReady,
                 "Verkey of Connection counterparty \
@@ -748,7 +748,7 @@ impl MediatedConnection {
 
     pub async fn send_message_closure(&self, wallet_handle: WalletHandle) -> VcxResult<SendClosure> {
         trace!("send_message_closure >>>");
-        let did_doc = self.their_did_doc().await.ok_or(VcxError::from_msg(
+        let did_doc = self.their_did_doc().ok_or(VcxError::from_msg(
             VcxErrorKind::NotReady,
             "Cannot send message: Remote Connection information is not set",
         ))?;
@@ -847,7 +847,7 @@ impl MediatedConnection {
             query,
             comment
         );
-        let did_doc = self.their_did_doc().await.ok_or(VcxError::from_msg(
+        let did_doc = self.their_did_doc().ok_or(VcxError::from_msg(
             VcxErrorKind::NotReady,
             format!("Can't send handshake-reuse to the counterparty, because their did doc is not available"),
         ))?;
@@ -873,7 +873,7 @@ impl MediatedConnection {
             protocols: Some(self.get_protocols()),
         };
 
-        let remote = match self.their_did_doc().await {
+        let remote = match self.their_did_doc() {
             Some(did_doc) => Some(SideConnectionInfo {
                 did: did_doc.id.clone(),
                 recipient_keys: did_doc.recipient_keys(),
@@ -925,7 +925,7 @@ impl MediatedConnection {
                 Ok(msgs)
             }
             _ => {
-                let expected_sender_vk = self.remote_vk().await?;
+                let expected_sender_vk = self.remote_vk()?;
                 let msgs = futures::stream::iter(
                     self.cloud_agent_info()
                         .ok_or(VcxError::from_msg(

--- a/aries_vcx/src/handlers/issuance/holder.rs
+++ b/aries_vcx/src/handlers/issuance/holder.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use messages::issuance::credential::Credential;
 use messages::revocation_notification::revocation_notification::RevocationNotification;
 use vdrtools_sys::{WalletHandle, PoolHandle};
 
@@ -70,6 +71,22 @@ impl Holder {
     ) -> VcxResult<()> {
         self.holder_sm = self.holder_sm.clone().decline_offer(
             comment.map(String::from),
+            send_message,
+        ).await?;
+        Ok(())
+    }
+
+    pub async fn process_credential(
+        &mut self,
+        wallet_handle: WalletHandle,
+        pool_handle: PoolHandle,
+        credential: Credential,
+        send_message: SendClosure,
+    ) -> VcxResult<()> {
+        self.holder_sm = self.holder_sm.clone().receive_credential(
+            wallet_handle,
+            pool_handle,
+            credential,
             send_message,
         ).await?;
         Ok(())

--- a/aries_vcx/src/handlers/issuance/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use messages::ack::please_ack::AckOn;
+use messages::issuance::credential_ack::CredentialAck;
 use messages::issuance::credential_request::CredentialRequest;
 use vdrtools_sys::{WalletHandle, PoolHandle};
 
@@ -152,6 +153,11 @@ impl Issuer {
 
     pub fn process_credential_request(&mut self, request: CredentialRequest) -> VcxResult<()> {
         self.issuer_sm = self.issuer_sm.clone().receive_request(request)?;
+        Ok(())
+    }
+
+    pub fn process_credential_ack(&mut self, ack: CredentialAck) -> VcxResult<()> {
+        self.issuer_sm = self.issuer_sm.clone().receive_ack(ack)?;
         Ok(())
     }
 

--- a/aries_vcx/src/handlers/issuance/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use messages::ack::please_ack::AckOn;
+use messages::issuance::credential_request::CredentialRequest;
 use vdrtools_sys::{WalletHandle, PoolHandle};
 
 use agency_client::agency_client::AgencyClient;
@@ -146,6 +147,11 @@ impl Issuer {
 
     pub async fn send_credential_offer(&mut self, send_message: SendClosure) -> VcxResult<()> {
         self.issuer_sm = self.issuer_sm.clone().send_credential_offer(send_message).await?;
+        Ok(())
+    }
+
+    pub fn process_credential_request(&mut self, request: CredentialRequest) -> VcxResult<()> {
+        self.issuer_sm = self.issuer_sm.clone().receive_request(request)?;
         Ok(())
     }
 

--- a/aries_vcx/src/handlers/proof_presentation/prover.rs
+++ b/aries_vcx/src/handlers/proof_presentation/prover.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use messages::proof_presentation::presentation_ack::PresentationAck;
 use vdrtools_sys::{PoolHandle, WalletHandle};
 
 use agency_client::agency_client::AgencyClient;
@@ -95,6 +96,12 @@ impl Prover {
     pub async fn send_presentation(&mut self, send_message: SendClosure) -> VcxResult<()> {
         trace!("Prover::send_presentation >>>");
         self.prover_sm = self.prover_sm.clone().send_presentation(send_message).await?;
+        Ok(())
+    }
+
+    pub fn process_presentation_ack(&mut self, ack: PresentationAck) -> VcxResult<()> {
+        trace!("Prover::process_presentation_ack >>>");
+        self.prover_sm = self.prover_sm.clone().receive_presentation_ack(ack)?;
         Ok(())
     }
 

--- a/aries_vcx/src/protocols/connection/invitee/state_machine.rs
+++ b/aries_vcx/src/protocols/connection/invitee/state_machine.rs
@@ -114,7 +114,7 @@ impl SmConnectionInvitee {
         }
     }
 
-    pub async fn their_did_doc(&self) -> Option<DidDoc> {
+    pub fn their_did_doc(&self) -> Option<DidDoc> {
         match self.state {
             InviteeFullState::Initial(ref state) => state.did_doc.clone(),
             InviteeFullState::Invited(ref state) => Some(state.did_doc.clone()),
@@ -161,9 +161,8 @@ impl SmConnectionInvitee {
         }
     }
 
-    pub async fn remote_did(&self) -> VcxResult<String> {
+    pub fn remote_did(&self) -> VcxResult<String> {
         self.their_did_doc()
-            .await
             .map(|did_doc: DidDoc| did_doc.id)
             .ok_or(VcxError::from_msg(
                 VcxErrorKind::NotReady,
@@ -171,9 +170,8 @@ impl SmConnectionInvitee {
             ))
     }
 
-    pub async fn remote_vk(&self) -> VcxResult<String> {
+    pub fn remote_vk(&self) -> VcxResult<String> {
         self.their_did_doc()
-            .await
             .and_then(|did_doc| did_doc.recipient_keys().get(0).cloned())
             .ok_or(VcxError::from_msg(
                 VcxErrorKind::NotReady,
@@ -268,7 +266,7 @@ impl SmConnectionInvitee {
     ) -> VcxResult<Self> {
         let (state, thread_id) = match self.state {
             InviteeFullState::Invited(ref state) => {
-                let ddo = self.their_did_doc().await
+                let ddo = self.their_did_doc()
                     .ok_or(VcxError::from_msg(VcxErrorKind::InvalidState, "Missing did doc"))?;
                 let (request, thread_id) = self.build_connection_request_msg(routing_keys, service_endpoint)?;
                 send_message(request.to_a2a_message(), self.pairwise_info.pw_vk.clone(), ddo.clone()).await?;

--- a/aries_vcx/src/protocols/proof_presentation/prover/state_machine.rs
+++ b/aries_vcx/src/protocols/proof_presentation/prover/state_machine.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use messages::proof_presentation::presentation_ack::PresentationAck;
 use vdrtools_sys::{WalletHandle, PoolHandle};
 
 use crate::error::prelude::*;
@@ -187,6 +188,19 @@ impl ProverSM {
             }
             s @ _ => {
                 warn!("Unable to send set presentation in state {}", s);
+                s
+            }
+        };
+        Ok(Self { state, ..self })
+    }
+
+    pub fn receive_presentation_ack(self, ack: PresentationAck) -> VcxResult<Self> {
+        let state = match self.state {
+            ProverFullState::PresentationSent(state) => {
+                ProverFullState::Finished((state.clone(), ack).into())
+            }
+            s @ _ => {
+                warn!("Unable to process presentation ack in state {}", s);
                 s
             }
         };

--- a/libvcx/src/api_lib/api_c/connection.rs
+++ b/libvcx/src/api_lib/api_c/connection.rs
@@ -1226,7 +1226,7 @@ pub extern "C" fn vcx_connection_verify_signature(
     trace!("vcx_connection_verify_signature: entities >>> connection_handle: {}, data_raw: {:?}, data_len: {}, signature_raw: {:?}, signature_len: {}", connection_handle, data_raw, data_len, signature_raw, signature_len);
 
     execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
-        let vk = match connection::get_their_pw_verkey(connection_handle).await {
+        let vk = match connection::get_their_pw_verkey(connection_handle) {
             Ok(err) => err,
             Err(err) => {
                 error!(
@@ -1530,8 +1530,8 @@ pub extern "C" fn vcx_connection_get_their_pw_did(
         source_id
     );
 
-    execute_async::<BoxFuture<'static, Result<(), ()>>>(Box::pin(async move {
-        match get_their_pw_did(connection_handle).await {
+    execute(move || {
+        match get_their_pw_did(connection_handle) {
             Ok(json) => {
                 trace!("vcx_connection_get_their_pw_did_cb(command_handle: {}, connection_handle: {}, rc: {}, their_pw_did: {}), source_id: {:?}", command_handle, connection_handle, error::SUCCESS.message, json, source_id);
                 let msg = CStringUtils::string_to_cstring(json);
@@ -1545,7 +1545,7 @@ pub extern "C" fn vcx_connection_get_their_pw_did(
         };
 
         Ok(())
-    }));
+    });
 
     error::SUCCESS.code_num
 }

--- a/libvcx/src/api_lib/api_handle/connection.rs
+++ b/libvcx/src/api_lib/api_handle/connection.rs
@@ -74,14 +74,14 @@ pub fn get_pw_verkey(handle: u32) -> VcxResult<String> {
     CONNECTION_MAP.get(handle, |connection| Ok(connection.pairwise_info().pw_vk.clone()))
 }
 
-pub async fn get_their_pw_did(handle: u32) -> VcxResult<String> {
+pub fn get_their_pw_did(handle: u32) -> VcxResult<String> {
     let connection = CONNECTION_MAP.get_cloned(handle)?;
-    connection.remote_did().await.map_err(|err| err.into())
+    connection.remote_did().map_err(|err| err.into())
 }
 
-pub async fn get_their_pw_verkey(handle: u32) -> VcxResult<String> {
+pub fn get_their_pw_verkey(handle: u32) -> VcxResult<String> {
     let connection = CONNECTION_MAP.get_cloned(handle)?;
-    connection.remote_vk().await.map_err(|err| err.into())
+    connection.remote_vk().map_err(|err| err.into())
 }
 
 pub fn get_thread_id(handle: u32) -> VcxResult<String> {


### PR DESCRIPTION
* Expose function to obtain connection id by remote verkey from aries-vcx-agent
* Expose function to process credential request from aries-vcx-agent
* Expose function to process credential from aries-vcx-agent
* Expose function to process presentation and credential ack from aries-vcx-agent
* `anon_unpack` returns besides decrypted message sender verkey as well
* Make functions previously obtaining remote did doc from connection handler synchronous instead of unnecessarily async

Signed-off-by: Miroslav Kovar <miroslav.kovar@absa.africa>