### PR TITLE
Set indy wallet master secret

### DIFF
--- a/agents/rust/aries-vcx-agent/src/agent/init.rs
+++ b/agents/rust/aries-vcx-agent/src/agent/init.rs
@@ -62,6 +62,7 @@ impl Agent {
             storage_credentials: None,
             rekey: None,
             rekey_derivation_method: None,
+            master_secret: None,
         };
 
         create_wallet_with_master_secret(&config_wallet).await.unwrap();

--- a/aries_vcx/src/global/settings.rs
+++ b/aries_vcx/src/global/settings.rs
@@ -85,18 +85,22 @@ pub fn add_master_secret(wallet_handle: WalletHandle, value: &String) -> VcxResu
 pub fn get_master_secret(wallet_handle: &WalletHandle) -> VcxResult<String> {
     trace!("get_config_value >>> ");
 
-    MASTER_SECRETS
+
+    let ms = MASTER_SECRETS
         .read()
         .or(Err(VcxError::from_msg(
             VcxErrorKind::InvalidConfiguration,
             "Cannot read settings",
         )))?
         .get(wallet_handle)
-        .map(|v| v.to_string())
-        .ok_or(VcxError::from_msg(
-            VcxErrorKind::InvalidConfiguration,
-            format!("Cannot read wallet_handle from settings"),
-        ))
+        .map(|v| v.to_string());
+    match ms {
+        Some(value) => {
+            trace!("get_config_value <<< value: {}", value);
+            Ok(value)
+        }
+        None => Ok(DEFAULT_LINK_SECRET_ALIAS.to_string()),
+    }    
 }
 
 pub fn get_config_value(key: &str) -> VcxResult<String> {

--- a/aries_vcx/src/global/settings.rs
+++ b/aries_vcx/src/global/settings.rs
@@ -70,7 +70,6 @@ pub fn indy_mocks_enabled() -> bool {
 }
 
 pub fn add_master_secret(wallet_handle: WalletHandle, value: &String) -> VcxResult<()> {
-
     trace!("add_master_secret >>> value: {}", value);
     MASTER_SECRETS
         .write()
@@ -83,24 +82,23 @@ pub fn add_master_secret(wallet_handle: WalletHandle, value: &String) -> VcxResu
 }
 
 pub fn get_master_secret(wallet_handle: &WalletHandle) -> VcxResult<String> {
-    trace!("get_config_value >>> ");
-
+    trace!("get_master_secret >>> ");
 
     let ms = MASTER_SECRETS
         .read()
         .or(Err(VcxError::from_msg(
             VcxErrorKind::InvalidConfiguration,
-            "Cannot read settings",
+            "Cannot read master_secret",
         )))?
         .get(wallet_handle)
         .map(|v| v.to_string());
     match ms {
         Some(value) => {
-            trace!("get_config_value <<< value: {}", value);
+            trace!("get_master_secret <<< value: {}", value);
             Ok(value)
         }
         None => Ok(DEFAULT_LINK_SECRET_ALIAS.to_string()),
-    }    
+    }
 }
 
 pub fn get_config_value(key: &str) -> VcxResult<String> {

--- a/aries_vcx/src/indy/credentials/holder/mod.rs
+++ b/aries_vcx/src/indy/credentials/holder/mod.rs
@@ -126,7 +126,7 @@ pub async fn libindy_prover_create_credential_req(
 
     let cred_def = serde_json::from_str::<CredentialDefinition>(credential_def_json)?;
 
-    let master_secret_name = settings::DEFAULT_LINK_SECRET_ALIAS;
+    let master_secret = settings::get_master_secret(&wallet_handle)?;
 
     let res = Locator::instance()
         .prover_controller
@@ -135,7 +135,7 @@ pub async fn libindy_prover_create_credential_req(
             DidValue(prover_did.into()),
             cred_offer,
             cred_def,
-            master_secret_name.into(),
+            master_secret,
         ).await?;
 
     Ok(res)

--- a/aries_vcx/src/indy/proofs/prover/prover.rs
+++ b/aries_vcx/src/indy/proofs/prover/prover.rs
@@ -65,11 +65,13 @@ pub async fn generate_indy_proof(
         build_cred_defs_json_prover(wallet_handle, pool_handle, &credentials_identifiers)
         .await?;
 
+    let master_secret = settings::get_master_secret(&wallet_handle)?;
+
     let proof = libindy_prover_create_proof(
         wallet_handle,
         proof_req_data_json,
         &requested_credentials,
-        settings::DEFAULT_LINK_SECRET_ALIAS,
+        &master_secret,
         &schemas_json,
         &credential_defs_json,
         Some(&revoc_states_json),

--- a/aries_vcx/src/indy/wallet.rs
+++ b/aries_vcx/src/indy/wallet.rs
@@ -33,6 +33,8 @@ pub struct WalletConfig {
     pub rekey: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rekey_derivation_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub master_secret: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Builder, Serialize, Deserialize)]
@@ -565,7 +567,7 @@ pub async fn create_wallet_with_master_secret(config: &WalletConfig) -> VcxResul
     trace!("Created wallet with handle {:?}", wallet_handle);
 
     // If MS is already in wallet then just continue
-    holder::libindy_prover_create_master_secret(wallet_handle, settings::DEFAULT_LINK_SECRET_ALIAS)
+    holder::libindy_prover_create_master_secret(wallet_handle, &config.master_secret.clone().unwrap_or(settings::DEFAULT_LINK_SECRET_ALIAS.to_string()))
         .await
         .ok();
 

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -149,6 +149,7 @@ impl SetupLibraryWallet {
             storage_credentials: None,
             rekey: None,
             rekey_derivation_method: None,
+            master_secret: None,
         };
 
         let wallet_handle = create_and_open_wallet(&wallet_config).await.unwrap();
@@ -196,6 +197,7 @@ impl TestSetupCreateWallet {
             storage_credentials: None,
             rekey: None,
             rekey_derivation_method: None,
+            master_secret: None,
         };
         create_indy_wallet(&wallet_config).await.unwrap();
 
@@ -446,6 +448,7 @@ pub async fn setup_issuer_wallet_and_agency_client() -> (String, WalletHandle, A
         storage_credentials: None,
         rekey: None,
         rekey_derivation_method: None,
+        master_secret: None,
     };
     let config_provision_agent = AgentProvisionConfig {
         agency_did: AGENCY_DID.to_string(),
@@ -476,6 +479,7 @@ pub async fn setup_issuer_wallet() -> (String, WalletHandle) {
         storage_credentials: None,
         rekey: None,
         rekey_derivation_method: None,
+        master_secret: None,
     };
     create_wallet_with_master_secret(&config_wallet).await.unwrap();
     let wallet_handle = open_wallet(&config_wallet).await.unwrap();

--- a/aries_vcx/tests/test_agency.rs
+++ b/aries_vcx/tests/test_agency.rs
@@ -406,6 +406,7 @@ mod integration_tests {
             storage_credentials: None,
             rekey: None,
             rekey_derivation_method: None,
+            master_secret: None,
         };
 
         create_indy_wallet(&wallet_config).await.unwrap();

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -140,6 +140,7 @@ pub mod test_utils {
                 storage_credentials: None,
                 rekey: None,
                 rekey_derivation_method: None,
+                master_secret: None,
             };
             let config_provision_agent = AgentProvisionConfig {
                 agency_did: AGENCY_DID.to_string(),
@@ -444,6 +445,7 @@ pub mod test_utils {
                 storage_credentials: None,
                 rekey: None,
                 rekey_derivation_method: None,
+                master_secret: None,
             };
             let config_provision_agent = AgentProvisionConfig {
                 agency_did: AGENCY_DID.to_string(),

--- a/libvcx/src/api_lib/api_c/vcx.rs
+++ b/libvcx/src/api_lib/api_c/vcx.rs
@@ -340,6 +340,7 @@ pub extern "C" fn vcx_shutdown(delete: bool) -> u32 {
             storage_credentials: None,
             rekey: None,
             rekey_derivation_method: None,
+            master_secret: None,
         };
 
         match futures::executor::block_on(indy::wallet::delete_wallet(&wallet_config)) {
@@ -943,6 +944,7 @@ mod tests {
             storage_credentials: None,
             rekey: None,
             rekey_derivation_method: None,
+            master_secret: None,
         };
 
         let import_config = RestoreWalletConfigs {

--- a/libvcx/src/api_lib/api_c/wallet.rs
+++ b/libvcx/src/api_lib/api_c/wallet.rs
@@ -1363,6 +1363,7 @@ pub mod tests {
             storage_credentials: None,
             rekey: None,
             rekey_derivation_method: None,
+            master_secret: None,
         };
         create_and_open_as_main_wallet(&wallet_config).await.unwrap();
 

--- a/libvcx/src/api_lib/global/wallet.rs
+++ b/libvcx/src/api_lib/global/wallet.rs
@@ -29,12 +29,14 @@ pub async fn export_main_wallet(path: &str, backup_key: &str) -> VcxResult<()> {
 
 pub async fn open_as_main_wallet(wallet_config: &WalletConfig) -> VcxResult<WalletHandle> {
     let handle = indy::wallet::open_wallet(wallet_config).await?;
+    settings::add_master_secret(handle, &wallet_config.master_secret.clone().unwrap_or(settings::DEFAULT_LINK_SECRET_ALIAS.to_string()));
     set_main_wallet_handle(handle);
     Ok(handle)
 }
 
 pub async fn create_and_open_as_main_wallet(wallet_config: &WalletConfig) -> VcxResult<WalletHandle> {
     let handle = indy::wallet::create_and_open_wallet(wallet_config).await?;
+    settings::add_master_secret(handle, &wallet_config.master_secret.clone().unwrap_or(settings::DEFAULT_LINK_SECRET_ALIAS.to_string()));
     set_main_wallet_handle(handle);
     Ok(handle)
 }
@@ -50,7 +52,7 @@ pub async fn create_main_wallet(config: &WalletConfig) -> VcxResult<()> {
     trace!("Created wallet with handle {:?}", wallet_handle);
 
     // If MS is already in wallet then just continue
-    holder::libindy_prover_create_master_secret(wallet_handle, settings::DEFAULT_LINK_SECRET_ALIAS)
+    holder::libindy_prover_create_master_secret(wallet_handle,  &config.master_secret.clone().unwrap_or(settings::DEFAULT_LINK_SECRET_ALIAS.to_string()))
         .await
         .ok();
 

--- a/libvcx/src/api_lib/global/wallet.rs
+++ b/libvcx/src/api_lib/global/wallet.rs
@@ -91,6 +91,7 @@ pub mod test_utils {
             storage_credentials: None,
             rekey: None,
             rekey_derivation_method: None,
+            master_secret: None,
         };
         let wallet_handle = create_and_open_as_main_wallet(&wallet_config).await.unwrap();
         create_and_store_my_did(wallet_handle, None, None).await.unwrap();


### PR DESCRIPTION
Set indy wallet master secret
master_secret parameter has been added to wallet config
Master secret is used in some methods where the wallet config is not there,
then has been added a global access to master secret of each wallet