### PR TITLE
Implement Storage trait for agent's ObjectCache

### DIFF
--- a/agents/rust/aries-vcx-agent/src/services/connection.rs
+++ b/agents/rust/aries-vcx-agent/src/services/connection.rs
@@ -39,7 +39,7 @@ impl ServiceConnections {
             .get_invite_details()
             .ok_or_else(|| AgentError::from_kind(AgentErrorKind::InviteDetails))?
             .clone();
-        self.connections.set(&inviter.get_thread_id(), inviter)?;
+        self.connections.insert(&inviter.get_thread_id(), inviter)?;
         Ok(invite)
     }
 
@@ -48,7 +48,7 @@ impl ServiceConnections {
         let invitee = Connection::create_invitee(self.wallet_handle, did_doc)
             .await?
             .process_invite(invite)?;
-        self.connections.set(&invitee.get_thread_id(), invitee)
+        self.connections.insert(&invitee.get_thread_id(), invitee)
     }
 
     pub async fn send_request(&self, thread_id: &str) -> AgentResult<()> {
@@ -57,7 +57,7 @@ impl ServiceConnections {
             .get(thread_id)?
             .send_request(self.wallet_handle, self.service_endpoint.clone(), vec![], None)
             .await?;
-        self.connections.set(thread_id, invitee)?;
+        self.connections.insert(thread_id, invitee)?;
         Ok(())
     }
 
@@ -67,7 +67,7 @@ impl ServiceConnections {
             .get(thread_id)?
             .process_request(self.wallet_handle, request, self.service_endpoint.clone(), vec![], None)
             .await?;
-        self.connections.set(thread_id, inviter)?;
+        self.connections.insert(thread_id, inviter)?;
         Ok(())
     }
 
@@ -77,7 +77,7 @@ impl ServiceConnections {
             .get(thread_id)?
             .send_response(self.wallet_handle, None)
             .await?;
-        self.connections.set(thread_id, inviter)?;
+        self.connections.insert(thread_id, inviter)?;
         Ok(())
     }
 
@@ -87,7 +87,7 @@ impl ServiceConnections {
             .get(thread_id)?
             .process_response(self.wallet_handle, response, None)
             .await?;
-        self.connections.set(thread_id, invitee)?;
+        self.connections.insert(thread_id, invitee)?;
         Ok(())
     }
 
@@ -97,7 +97,7 @@ impl ServiceConnections {
             .get(thread_id)?
             .send_ack(self.wallet_handle, None)
             .await?;
-        self.connections.set(thread_id, invitee)?;
+        self.connections.insert(thread_id, invitee)?;
         Ok(())
     }
 
@@ -107,7 +107,7 @@ impl ServiceConnections {
             .get(thread_id)?
             .process_ack(A2AMessage::Ack(ack))
             .await?;
-        self.connections.set(thread_id, inviter)?;
+        self.connections.insert(thread_id, inviter)?;
         Ok(())
     }
 
@@ -133,6 +133,6 @@ impl ServiceConnections {
 
 
     pub fn exists_by_id(&self, thread_id: &str) -> bool {
-        self.connections.has_id(thread_id)
+        self.connections.contains_key(thread_id)
     }
 }

--- a/agents/rust/aries-vcx-agent/src/services/connection.rs
+++ b/agents/rust/aries-vcx-agent/src/services/connection.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use crate::error::*;
+use crate::storage::Storage;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::handlers::connection::connection::{Connection, ConnectionState};
 use aries_vcx::indy::ledger::transactions::into_did_doc;

--- a/agents/rust/aries-vcx-agent/src/services/credential_definition.rs
+++ b/agents/rust/aries-vcx-agent/src/services/credential_definition.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 
 use crate::error::*;
+use crate::storage::Storage;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::indy::primitives::credential_definition::{CredentialDef, CredentialDefConfig};
 use aries_vcx::vdrtools::{PoolHandle, WalletHandle};

--- a/agents/rust/aries-vcx-agent/src/services/credential_definition.rs
+++ b/agents/rust/aries-vcx-agent/src/services/credential_definition.rs
@@ -29,7 +29,7 @@ impl ServiceCredentialDefinitions {
             true,
         )
         .await?;
-        self.cred_defs.set(&cd.get_cred_def_id(), cd)
+        self.cred_defs.insert(&cd.get_cred_def_id(), cd)
     }
 
     pub async fn publish_cred_def(&self, thread_id: &str) -> AgentResult<()> {
@@ -37,7 +37,7 @@ impl ServiceCredentialDefinitions {
         let cred_def = cred_def
             .publish_cred_def(self.wallet_handle, self.pool_handle)
             .await?;
-        self.cred_defs.set(thread_id, cred_def)?;
+        self.cred_defs.insert(thread_id, cred_def)?;
         Ok(())
     }
 

--- a/agents/rust/aries-vcx-agent/src/services/holder.rs
+++ b/agents/rust/aries-vcx-agent/src/services/holder.rs
@@ -69,7 +69,7 @@ impl ServiceCredentialsHolder {
                 connection.send_message_closure(self.wallet_handle, None).await?,
             )
             .await?;
-        self.creds_holder.set(
+        self.creds_holder.insert(
             &holder.get_thread_id()?,
             HolderWrapper::new(holder, connection_id),
         )
@@ -82,7 +82,7 @@ impl ServiceCredentialsHolder {
     ) -> AgentResult<String> {
         self.service_connections.get_by_id(connection_id)?;
         let holder = Holder::create_from_offer("", offer)?;
-        self.creds_holder.set(
+        self.creds_holder.insert(
             &holder.get_thread_id()?,
             HolderWrapper::new(holder, connection_id),
         )
@@ -108,7 +108,7 @@ impl ServiceCredentialsHolder {
                 connection.send_message_closure(self.wallet_handle, None).await?,
             )
             .await?;
-        self.creds_holder.set(
+        self.creds_holder.insert(
             &holder.get_thread_id()?,
             HolderWrapper::new(holder, &connection_id),
         )
@@ -130,7 +130,7 @@ impl ServiceCredentialsHolder {
                 connection.send_message_closure(self.wallet_handle, None).await?,
             )
             .await?;
-        self.creds_holder.set(
+        self.creds_holder.insert(
             &holder.get_thread_id()?,
             HolderWrapper::new(holder, &connection_id),
         )
@@ -166,6 +166,6 @@ impl ServiceCredentialsHolder {
     }
 
     pub fn exists_by_id(&self, thread_id: &str) -> bool {
-        self.creds_holder.has_id(thread_id)
+        self.creds_holder.contains_key(thread_id)
     }
 }

--- a/agents/rust/aries-vcx-agent/src/services/holder.rs
+++ b/agents/rust/aries-vcx-agent/src/services/holder.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::error::*;
+use crate::storage::Storage;
 use crate::services::connection::ServiceConnections;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::handlers::issuance::holder::Holder;

--- a/agents/rust/aries-vcx-agent/src/services/issuer.rs
+++ b/agents/rust/aries-vcx-agent/src/services/issuer.rs
@@ -60,7 +60,7 @@ impl ServiceCredentialsIssuer {
         proposal: &CredentialProposal,
     ) -> AgentResult<String> {
         let issuer = Issuer::create_from_proposal("", proposal)?;
-        self.creds_issuer.set(
+        self.creds_issuer.insert(
             &issuer.get_thread_id()?,
             IssuerWrapper::new(issuer, connection_id),
         )
@@ -85,7 +85,7 @@ impl ServiceCredentialsIssuer {
         issuer
             .send_credential_offer(connection.send_message_closure(self.wallet_handle, None).await?)
             .await?;
-        self.creds_issuer.set(
+        self.creds_issuer.insert(
             &issuer.get_thread_id()?,
             IssuerWrapper::new(issuer, &connection_id),
         )
@@ -97,7 +97,7 @@ impl ServiceCredentialsIssuer {
             connection_id,
         } = self.creds_issuer.get(thread_id)?;
         issuer.process_credential_request(request)?;
-        self.creds_issuer.set(
+        self.creds_issuer.insert(
             &issuer.get_thread_id()?,
             IssuerWrapper::new(issuer, &connection_id),
         )?;
@@ -110,7 +110,7 @@ impl ServiceCredentialsIssuer {
             connection_id,
         } = self.creds_issuer.get(thread_id)?;
         issuer.process_credential_ack(ack)?;
-        self.creds_issuer.set(
+        self.creds_issuer.insert(
             &issuer.get_thread_id()?,
             IssuerWrapper::new(issuer, &connection_id),
         )?;
@@ -129,7 +129,7 @@ impl ServiceCredentialsIssuer {
                 connection.send_message_closure(self.wallet_handle, None).await?,
             )
             .await?;
-        self.creds_issuer.set(
+        self.creds_issuer.insert(
             &issuer.get_thread_id()?,
             IssuerWrapper::new(issuer, &connection_id),
         )?;
@@ -156,7 +156,7 @@ impl ServiceCredentialsIssuer {
     }
 
     pub fn exists_by_id(&self, thread_id: &str) -> bool {
-        self.creds_issuer.has_id(thread_id)
+        self.creds_issuer.contains_key(thread_id)
     }
 }
 

--- a/agents/rust/aries-vcx-agent/src/services/issuer.rs
+++ b/agents/rust/aries-vcx-agent/src/services/issuer.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::error::*;
 use crate::services::connection::ServiceConnections;
+use crate::storage::Storage;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::handlers::issuance::issuer::Issuer;
 use aries_vcx::messages::issuance::credential_ack::CredentialAck;

--- a/agents/rust/aries-vcx-agent/src/services/mediated_connection.rs
+++ b/agents/rust/aries-vcx-agent/src/services/mediated_connection.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use crate::error::*;
+use crate::storage::Storage;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::messages::connection::invite::Invitation;
 use aries_vcx::messages::connection::request::Request;
 use aries_vcx::messages::issuance::credential_offer::CredentialOffer;
 use aries_vcx::messages::issuance::credential_proposal::CredentialProposal;
 use aries_vcx::messages::proof_presentation::presentation_proposal::PresentationProposal;
-use aries_vcx::messages::proof_presentation::presentation_request::PresentationRequest;
 use aries_vcx::{
     agency_client::{agency_client::AgencyClient, configuration::AgencyClientConfig},
     handlers::connection::mediated_connection::{MediatedConnection, ConnectionState},
@@ -122,23 +122,6 @@ impl ServiceMediatedConnections {
 
     pub fn exists_by_id(&self, thread_id: &str) -> bool {
         self.mediated_connections.contains_key(thread_id)
-    }
-
-    pub async fn get_all_proof_requests(&self) -> AgentResult<Vec<(PresentationRequest, String)>> {
-        let agency_client = self.agency_client()?;
-        let mut requests = Vec::<(PresentationRequest, String)>::new();
-        for connection in self.mediated_connections.get_all()? {
-            for (uid, message) in connection.get_messages(&agency_client).await?.into_iter() {
-                if let A2AMessage::PresentationRequest(request) = message {
-                    connection
-                        .update_message_status(&uid, &agency_client)
-                        .await
-                        .ok();
-                    requests.push((request, connection.get_thread_id()));
-                }
-            }
-        }
-        Ok(requests)
     }
 }
 

--- a/agents/rust/aries-vcx-agent/src/services/mediated_connection.rs
+++ b/agents/rust/aries-vcx-agent/src/services/mediated_connection.rs
@@ -59,7 +59,7 @@ impl ServiceMediatedConnections {
             .ok_or_else(|| AgentError::from_kind(AgentErrorKind::InviteDetails))?
             .clone();
         self.mediated_connections
-            .set(&connection.get_thread_id(), connection)?;
+            .insert(&connection.get_thread_id(), connection)?;
         Ok(invite)
     }
 
@@ -75,7 +75,7 @@ impl ServiceMediatedConnections {
         )
         .await?;
         self.mediated_connections
-            .set(&connection.get_thread_id(), connection)
+            .insert(&connection.get_thread_id(), connection)
     }
 
     pub async fn send_request(&self, thread_id: &str) -> AgentResult<()> {
@@ -86,7 +86,7 @@ impl ServiceMediatedConnections {
         connection
             .find_message_and_update_state(self.wallet_handle, &self.agency_client()?)
             .await?;
-        self.mediated_connections.set(thread_id, connection)?;
+        self.mediated_connections.insert(thread_id, connection)?;
         Ok(())
     }
 
@@ -96,14 +96,14 @@ impl ServiceMediatedConnections {
             .process_request(self.wallet_handle, &self.agency_client()?, request)
             .await?;
         connection.send_response(self.wallet_handle).await?;
-        self.mediated_connections.set(thread_id, connection)?;
+        self.mediated_connections.insert(thread_id, connection)?;
         Ok(())
     }
 
     pub async fn send_ping(&self, thread_id: &str) -> AgentResult<()> {
         let mut connection = self.mediated_connections.get(thread_id)?;
         connection.send_ping(self.wallet_handle, None).await?;
-        self.mediated_connections.set(thread_id, connection)?;
+        self.mediated_connections.insert(thread_id, connection)?;
         Ok(())
     }
 
@@ -116,12 +116,12 @@ impl ServiceMediatedConnections {
         connection
             .find_message_and_update_state(self.wallet_handle, &self.agency_client()?)
             .await?;
-        self.mediated_connections.set(thread_id, connection)?;
+        self.mediated_connections.insert(thread_id, connection)?;
         Ok(self.mediated_connections.get(thread_id)?.get_state())
     }
 
     pub fn exists_by_id(&self, thread_id: &str) -> bool {
-        self.mediated_connections.has_id(thread_id)
+        self.mediated_connections.contains_key(thread_id)
     }
 
     pub async fn get_all_proof_requests(&self) -> AgentResult<Vec<(PresentationRequest, String)>> {

--- a/agents/rust/aries-vcx-agent/src/services/prover.rs
+++ b/agents/rust/aries-vcx-agent/src/services/prover.rs
@@ -86,7 +86,7 @@ impl ServiceProver {
     ) -> AgentResult<String> {
         self.service_connections.get_by_id(connection_id)?;
         let prover = Prover::create_from_request("", request)?;
-        self.provers.set(
+        self.provers.insert(
             &prover.get_thread_id()?,
             ProverWrapper::new(prover, connection_id),
         )
@@ -105,7 +105,7 @@ impl ServiceProver {
                 connection.send_message_closure(self.wallet_handle, None).await?,
             )
             .await?;
-        self.provers.set(
+        self.provers.insert(
             &prover.get_thread_id()?,
             ProverWrapper::new(prover, connection_id),
         )
@@ -138,7 +138,7 @@ impl ServiceProver {
                 connection.send_message_closure(self.wallet_handle, None).await?,
             )
             .await?;
-        self.provers.set(
+        self.provers.insert(
             &prover.get_thread_id()?,
             ProverWrapper::new(prover, &connection_id),
         )?;
@@ -152,7 +152,7 @@ impl ServiceProver {
     ) -> AgentResult<String> {
         let ProverWrapper { mut prover, connection_id } = self.provers.get(thread_id)?;
         prover.process_presentation_ack(ack)?;
-        self.provers.set(
+        self.provers.insert(
             &prover.get_thread_id()?,
             ProverWrapper::new(prover, &connection_id),
         )
@@ -164,6 +164,6 @@ impl ServiceProver {
     }
 
     pub fn exists_by_id(&self, thread_id: &str) -> bool {
-        self.provers.has_id(thread_id)
+        self.provers.contains_key(thread_id)
     }
 }

--- a/agents/rust/aries-vcx-agent/src/services/prover.rs
+++ b/agents/rust/aries-vcx-agent/src/services/prover.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::error::*;
+use crate::storage::Storage;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::handlers::proof_presentation::prover::Prover;
 use aries_vcx::messages::proof_presentation::presentation_ack::PresentationAck;

--- a/agents/rust/aries-vcx-agent/src/services/revocation_registry.rs
+++ b/agents/rust/aries-vcx-agent/src/services/revocation_registry.rs
@@ -43,7 +43,7 @@ impl ServiceRevocationRegistries {
             1,
         )
         .await?;
-        self.rev_regs.set(&rev_reg.get_rev_reg_id(), rev_reg)
+        self.rev_regs.insert(&rev_reg.get_rev_reg_id(), rev_reg)
     }
 
     pub fn tails_file_path(&self, thread_id: &str) -> AgentResult<String> {
@@ -64,7 +64,7 @@ impl ServiceRevocationRegistries {
         rev_reg
             .publish_revocation_primitives(self.wallet_handle, self.pool_handle, tails_url)
             .await?;
-        self.rev_regs.set(thread_id, rev_reg)?;
+        self.rev_regs.insert(thread_id, rev_reg)?;
         Ok(())
     }
 

--- a/agents/rust/aries-vcx-agent/src/services/revocation_registry.rs
+++ b/agents/rust/aries-vcx-agent/src/services/revocation_registry.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use crate::error::*;
+use crate::storage::Storage;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::indy::primitives::revocation_registry::RevocationRegistry;
 use aries_vcx::vdrtools::{PoolHandle, WalletHandle};

--- a/agents/rust/aries-vcx-agent/src/services/schema.rs
+++ b/agents/rust/aries-vcx-agent/src/services/schema.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 
 use crate::error::*;
+use crate::storage::Storage;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::indy::ledger::transactions::get_schema_json;
 use aries_vcx::indy::primitives::credential_schema::Schema;

--- a/agents/rust/aries-vcx-agent/src/services/schema.rs
+++ b/agents/rust/aries-vcx-agent/src/services/schema.rs
@@ -30,7 +30,7 @@ impl ServiceSchemas {
         attributes: &Vec<String>,
     ) -> AgentResult<String> {
         let schema = Schema::create("", &self.issuer_did, name, version, attributes).await?;
-        self.schemas.set(&schema.get_schema_id(), schema)
+        self.schemas.insert(&schema.get_schema_id(), schema)
     }
 
     pub async fn publish_schema(&self, thread_id: &str) -> AgentResult<()> {
@@ -38,7 +38,7 @@ impl ServiceSchemas {
         let schema = schema
             .publish(self.wallet_handle, self.pool_handle, None)
             .await?;
-        self.schemas.set(thread_id, schema)?;
+        self.schemas.insert(thread_id, schema)?;
         Ok(())
     }
 

--- a/agents/rust/aries-vcx-agent/src/services/verifier.rs
+++ b/agents/rust/aries-vcx-agent/src/services/verifier.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::error::*;
+use crate::storage::Storage;
 use crate::storage::object_cache::ObjectCache;
 use aries_vcx::handlers::proof_presentation::verifier::Verifier;
 use aries_vcx::indy::proofs::proof_request::PresentationRequestData;

--- a/agents/rust/aries-vcx-agent/src/services/verifier.rs
+++ b/agents/rust/aries-vcx-agent/src/services/verifier.rs
@@ -63,7 +63,7 @@ impl ServiceVerifier {
         verifier
             .send_presentation_request(connection.send_message_closure(self.wallet_handle, None).await?)
             .await?;
-        self.verifiers.set(
+        self.verifiers.insert(
             &verifier.get_thread_id()?,
             VerifierWrapper::new(verifier, connection_id),
         )
@@ -78,7 +78,7 @@ impl ServiceVerifier {
         let VerifierWrapper { mut verifier, connection_id } = self.verifiers.get(thread_id)?;
         let connection = self.service_connections.get_by_id(&connection_id)?;
         verifier.verify_presentation(self.wallet_handle, self.pool_handle, presentation, connection.send_message_closure(self.wallet_handle, None).await?).await?;
-        self.verifiers.set(
+        self.verifiers.insert(
             thread_id,
             VerifierWrapper::new(verifier, &connection_id),
         )?;
@@ -91,6 +91,6 @@ impl ServiceVerifier {
     }
 
     pub fn exists_by_id(&self, thread_id: &str) -> bool {
-        self.verifiers.has_id(thread_id)
+        self.verifiers.contains_key(thread_id)
     }
 }

--- a/agents/rust/aries-vcx-agent/src/storage/mod.rs
+++ b/agents/rust/aries-vcx-agent/src/storage/mod.rs
@@ -1,1 +1,13 @@
+use crate::AgentResult;
+
 pub(crate) mod object_cache;
+
+pub trait Storage<T> {
+    type Value;
+    fn get(&self, id: &str) -> AgentResult<T>;
+    fn insert(&self, id: &str, obj: T) -> AgentResult<String>;
+    fn contains_key(&self, id: &str) -> bool;
+    fn find_by<F>(&self, closure: F) -> AgentResult<Vec<String>>
+    where
+        F: FnMut((&String, &Self::Value)) -> Option<String>;
+}

--- a/agents/rust/aries-vcx-agent/src/storage/object_cache.rs
+++ b/agents/rust/aries-vcx-agent/src/storage/object_cache.rs
@@ -55,7 +55,7 @@ where
         }
     }
 
-    pub fn has_id(&self, id: &str) -> bool {
+    pub fn contains_key(&self, id: &str) -> bool {
         let store = match self._lock_store_read() {
             Ok(g) => g,
             Err(_) => return false,
@@ -86,7 +86,7 @@ where
         }
     }
 
-    pub fn set(&self, id: &str, obj: T) -> AgentResult<String> {
+    pub fn insert(&self, id: &str, obj: T) -> AgentResult<String> {
         let mut store = self._lock_store_write()?;
 
         match store.insert(id.to_string(), Mutex::new(obj)) {


### PR DESCRIPTION
Adds a Storage trait and implements it for Rust agent's ObjectCache. This may eventually allow for multiple storage implementations.