### PR TITLE
Handle did:sov service omitting routing_keys attribute

### DIFF
--- a/aries_vcx/src/indy/ledger/transactions.rs
+++ b/aries_vcx/src/indy/ledger/transactions.rs
@@ -515,7 +515,7 @@ pub async fn get_service(pool_handle: PoolHandle, did: &Did) -> VcxResult<AriesS
         return Ok(AriesService::create()
             .set_recipient_keys(recipient_keys)
             .set_service_endpoint(endpoint.endpoint)
-            .set_routing_keys(endpoint.routing_keys.unwrap()));
+            .set_routing_keys(endpoint.routing_keys.unwrap_or_default()));
     }
     parse_legacy_endpoint_attrib(pool_handle, &did_raw).await
 }

--- a/aries_vcx/tests/test_pool.rs
+++ b/aries_vcx/tests/test_pool.rs
@@ -106,4 +106,22 @@ mod integration_tests {
             assert_eq!(expect_service, service)
         }).await;
     }
+    #[tokio::test]
+    async fn test_add_get_service_public_none_routing_keys() {
+        SetupWalletPool::run(|setup| async move {
+            let did = setup.institution_did.clone();
+            let create_service = EndpointDidSov::create()
+                .set_service_endpoint("https://example.org".into())
+                .set_routing_keys(None);
+            write_endpoint(setup.wallet_handle, setup.pool_handle, &did, &create_service).await.unwrap();
+            thread::sleep(Duration::from_millis(50));
+            let service = get_service(setup.pool_handle, &Did::new(&did).unwrap()).await.unwrap();
+            let expect_recipient_key = get_verkey_from_ledger(setup.pool_handle, &setup.institution_did).await.unwrap();
+            let expect_service = AriesService::default()
+                .set_service_endpoint("https://example.org".into())
+                .set_recipient_keys(vec![expect_recipient_key])
+                .set_routing_keys(vec![]);
+            assert_eq!(expect_service, service)
+        }).await;
+    }
 }


### PR DESCRIPTION
when performing a test with acapy a routing_keys problem was discovered, it generates an empty ledger.