### PR TITLE
Tweak u32 handle releasing handling

### DIFF
--- a/libvcx/src/api_c/ledger/credential_def.rs
+++ b/libvcx/src/api_c/ledger/credential_def.rs
@@ -557,32 +557,6 @@ mod tests {
 
     #[test]
     #[cfg(feature = "general_test")]
-    fn test_vcx_credentialdef_release() {
-        let _setup = SetupMocks::init();
-
-        let cb = return_types_u32::Return_U32_U32::new().unwrap();
-        assert_eq!(
-            vcx_credentialdef_create_v2(
-                cb.command_handle,
-                CString::new("Test Source ID Release Test").unwrap().into_raw(),
-                CString::new(SCHEMA_ID).unwrap().into_raw(),
-                CString::new("tag").unwrap().into_raw(),
-                true,
-                Some(cb.get_callback()),
-            ),
-            error::SUCCESS_ERR_CODE
-        );
-
-        let handle = cb.receive(TimeoutUtils::some_medium()).unwrap();
-        let unknown_handle = handle + 1;
-        assert_eq!(
-            vcx_credentialdef_release(unknown_handle),
-            u32::from(LibvcxErrorKind::InvalidCredDefHandle)
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "general_test")]
     fn test_vcx_creddef_get_id() {
         let _setup = SetupMocks::init();
 

--- a/libvcx/src/api_c/ledger/schema.rs
+++ b/libvcx/src/api_c/ledger/schema.rs
@@ -681,21 +681,6 @@ mod tests {
 
     #[test]
     #[cfg(feature = "general_test")]
-    fn test_vcx_schema_release() {
-        let _setup = SetupMocks::init();
-
-        let (_, schema_name, schema_version, data) = prepare_schema_data();
-        let handle = vcx_schema_create_c_closure(&schema_name, &schema_version, &data).unwrap();
-
-        let unknown_handle = handle + 1;
-        assert_eq!(
-            vcx_schema_release(unknown_handle),
-            u32::from(LibvcxErrorKind::InvalidSchemaHandle)
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "general_test")]
     fn test_vcx_prepare_schema_success() {
         let _setup = SetupMocks::init();
 

--- a/libvcx/src/api_c/protocols/credential.rs
+++ b/libvcx/src/api_c/protocols/credential.rs
@@ -1397,24 +1397,4 @@ mod tests {
             error::SUCCESS_ERR_CODE
         );
     }
-
-    #[test]
-    #[cfg(feature = "general_test")]
-    fn test_vcx_credential_release() {
-        let _setup = SetupMocks::init();
-
-        let handle = _vcx_credential_create_with_offer_c_closure(ARIES_CREDENTIAL_OFFER).unwrap();
-
-        assert_eq!(
-            vcx_credential_release(handle + 1),
-            u32::from(LibvcxErrorKind::InvalidCredentialHandle)
-        );
-
-        assert_eq!(vcx_credential_release(handle), error::SUCCESS_ERR_CODE);
-
-        assert_eq!(
-            vcx_credential_release(handle),
-            u32::from(LibvcxErrorKind::InvalidCredentialHandle)
-        );
-    }
 }

--- a/libvcx/src/api_c/protocols/disclosed_proof.rs
+++ b/libvcx/src/api_c/protocols/disclosed_proof.rs
@@ -1213,23 +1213,6 @@ mod tests {
 
     #[test]
     #[cfg(feature = "general_test")]
-    fn test_vcx_disclosed_proof_release() {
-        let _setup = SetupMocks::init();
-
-        let handle = _vcx_disclosed_proof_create_with_request_c_closure(ARIES_PROOF_REQUEST_PRESENTATION).unwrap();
-        assert_eq!(
-            vcx_disclosed_proof_release(handle + 1),
-            u32::from(LibvcxErrorKind::InvalidDisclosedProofHandle)
-        );
-        assert_eq!(vcx_disclosed_proof_release(handle), error::SUCCESS_ERR_CODE);
-        assert_eq!(
-            vcx_disclosed_proof_release(handle),
-            u32::from(LibvcxErrorKind::InvalidDisclosedProofHandle)
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "general_test")]
     fn test_vcx_disclosed_proof_serialize_and_deserialize() {
         let _setup = SetupMocks::init();
 

--- a/libvcx/src/api_c/protocols/issuer_credential.rs
+++ b/libvcx/src/api_c/protocols/issuer_credential.rs
@@ -1060,23 +1060,4 @@ pub mod tests {
         );
         cb.receive(TimeoutUtils::some_medium()).unwrap();
     }
-
-    #[test]
-    #[cfg(feature = "general_test")]
-    fn test_vcx_issuer_credential_release() {
-        let _setup = SetupMocks::init();
-
-        let handle = _vcx_issuer_create_credential_c_closure().unwrap();
-        assert_eq!(
-            vcx_issuer_credential_release(handle + 1),
-            u32::from(LibvcxErrorKind::InvalidIssuerCredentialHandle)
-        );
-
-        assert_eq!(vcx_issuer_credential_release(handle), error::SUCCESS_ERR_CODE);
-
-        assert_eq!(
-            vcx_issuer_credential_release(handle),
-            u32::from(LibvcxErrorKind::InvalidIssuerCredentialHandle)
-        );
-    }
 }

--- a/libvcx/src/api_c/protocols/mediated_connection.rs
+++ b/libvcx/src/api_c/protocols/mediated_connection.rs
@@ -1807,33 +1807,6 @@ mod tests {
         cb.receive(TimeoutUtils::some_medium()).unwrap().unwrap();
     }
 
-    #[tokio::test]
-    #[cfg(feature = "general_test")]
-    async fn test_vcx_connection_release() {
-        let _setup = SetupMocks::init();
-
-        let handle = build_test_connection_inviter_requested().await;
-
-        let rc = vcx_connection_release(handle);
-        assert_eq!(rc, SUCCESS_ERR_CODE);
-
-        let unknown_handle = handle + 1;
-        assert_eq!(
-            vcx_connection_release(unknown_handle),
-            u32::from(LibvcxErrorKind::InvalidConnectionHandle)
-        );
-
-        let cb = return_types_u32::Return_U32_STR::new().unwrap();
-        let rc = vcx_connection_connect(
-            0,
-            handle,
-            CString::new("{}").unwrap().into_raw(),
-            Some(cb.get_callback()),
-        );
-        assert!(cb.receive(TimeoutUtils::some_custom(1)).is_err());
-        assert_eq!(rc, SUCCESS_ERR_CODE);
-    }
-
     #[test]
     #[cfg(feature = "general_test")]
     fn test_vcx_connection_deserialize_succeeds() {

--- a/libvcx/src/api_c/protocols/proof.rs
+++ b/libvcx/src/api_c/protocols/proof.rs
@@ -993,28 +993,6 @@ mod tests {
 
     #[tokio::test]
     #[cfg(feature = "general_test")]
-    async fn test_get_proof_returns_proof_with_proof_state_invalid() {
-        let _setup = SetupMocks::init();
-
-        let proof_handle = proof::from_string(mockdata_proof::SERIALIZIED_PROOF_REVOKED).unwrap();
-
-        let cb = return_types_u32::Return_U32_U32_STR::new().unwrap();
-        assert_eq!(
-            vcx_get_proof_msg(cb.command_handle, proof_handle, Some(cb.get_callback())),
-            error::SUCCESS_ERR_CODE
-        );
-        let (state, _) = cb.receive(TimeoutUtils::some_medium()).unwrap();
-        assert_eq!(state, ProofStateType::ProofInvalid as u32);
-
-        vcx_proof_release(proof_handle);
-        assert_eq!(
-            vcx_proof_release(proof_handle),
-            u32::from(LibvcxErrorKind::InvalidProofHandle)
-        );
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "general_test")]
     async fn test_vcx_connection_get_state() {
         let _setup = SetupMocks::init();
 

--- a/libvcx/src/api_c/vcx.rs
+++ b/libvcx/src/api_c/vcx.rs
@@ -971,34 +971,13 @@ mod tests {
         let credential = credential::credential_create_with_offer("name", ARIES_CREDENTIAL_OFFER).unwrap();
 
         vcx_shutdown(true);
-        assert_eq!(
-            mediated_connection::release(connection).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidConnectionHandle
-        );
-        assert_eq!(
-            issuer_credential::release(issuer_credential).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidIssuerCredentialHandle
-        );
-        assert_eq!(
-            schema::release(schema).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidSchemaHandle
-        );
-        assert_eq!(
-            proof::release(proof).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidProofHandle
-        );
-        assert_eq!(
-            credential_def::release(credentialdef).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidCredDefHandle
-        );
-        assert_eq!(
-            credential::release(credential).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidCredentialHandle
-        );
-        assert_eq!(
-            disclosed_proof::release(disclosed_proof).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidDisclosedProofHandle
-        );
+        assert_eq!(mediated_connection::is_valid_handle(connection), false);
+        assert_eq!(issuer_credential::is_valid_handle(issuer_credential), false);
+        assert_eq!(schema::is_valid_handle(schema), false);
+        assert_eq!(proof::is_valid_handle(proof), false);
+        assert_eq!(credential_def::is_valid_handle(credentialdef), false);
+        assert_eq!(credential::is_valid_handle(credential), false);
+        assert_eq!(disclosed_proof::is_valid_handle(disclosed_proof), false);
         assert_eq!(get_main_wallet_handle(), INVALID_WALLET_HANDLE);
     }
 

--- a/libvcx/src/api_vcx/api_handle/credential.rs
+++ b/libvcx/src/api_vcx/api_handle/credential.rs
@@ -365,6 +365,15 @@ pub mod tests {
         offer
     }
 
+    #[test]
+    #[cfg(feature = "general_test")]
+    fn test_vcx_credential_release() {
+        let _setup = SetupDefaults::init();
+        let handle = credential_create_with_offer("test_credential_create_with_offer", ARIES_CREDENTIAL_OFFER).unwrap();
+        release(handle).unwrap();
+        assert_eq!(to_string(handle).unwrap_err().kind, LibvcxErrorKind::InvalidHandle);
+    }
+
     #[tokio::test]
     #[cfg(feature = "general_test")]
     async fn test_credential_create_with_offer() {

--- a/libvcx/src/api_vcx/api_handle/credential_def.rs
+++ b/libvcx/src/api_vcx/api_handle/credential_def.rs
@@ -131,7 +131,10 @@ pub mod tests {
             .await
             .unwrap();
         release(cred_def_handle).unwrap();
-        assert_eq!(to_string(cred_def_handle).unwrap_err().kind, LibvcxErrorKind::InvalidHandle)
+        assert_eq!(
+            to_string(cred_def_handle).unwrap_err().kind,
+            LibvcxErrorKind::InvalidHandle
+        )
     }
 
     pub async fn create_and_publish_nonrevocable_creddef() -> (u32, u32) {

--- a/libvcx/src/api_vcx/api_handle/credential_def.rs
+++ b/libvcx/src/api_vcx/api_handle/credential_def.rs
@@ -118,6 +118,22 @@ pub mod tests {
 
     use super::*;
 
+    #[tokio::test]
+    #[cfg(feature = "general_test")]
+    async fn test_vcx_credentialdef_release() {
+        let _setup = SetupMocks::init();
+        let schema_handle = schema::tests::create_schema_real().await;
+        sleep(Duration::from_secs(1));
+
+        let schema_id = schema::get_schema_id(schema_handle).unwrap();
+        let issuer_did = get_config_value(CONFIG_INSTITUTION_DID).unwrap();
+        let cred_def_handle = create("1".to_string(), schema_id, "tag_1".to_string(), false)
+            .await
+            .unwrap();
+        release(cred_def_handle).unwrap();
+        assert_eq!(to_string(cred_def_handle).unwrap_err().kind, LibvcxErrorKind::InvalidHandle)
+    }
+
     pub async fn create_and_publish_nonrevocable_creddef() -> (u32, u32) {
         let schema_handle = schema::tests::create_schema_real().await;
         sleep(Duration::from_secs(1));
@@ -238,8 +254,10 @@ pub mod tests {
         let h2 = create("SourceId".to_string(), SCHEMA_ID.to_string(), "tag".to_string(), false)
             .await
             .unwrap();
+
         release_all();
-        assert_eq!(release(h1).unwrap_err().kind(), LibvcxErrorKind::InvalidCredDefHandle);
-        assert_eq!(release(h2).unwrap_err().kind(), LibvcxErrorKind::InvalidCredDefHandle);
+
+        assert_eq!(is_valid_handle(h1), false);
+        assert_eq!(is_valid_handle(h2), false);
     }
 }

--- a/libvcx/src/api_vcx/api_handle/disclosed_proof.rs
+++ b/libvcx/src/api_vcx/api_handle/disclosed_proof.rs
@@ -310,6 +310,15 @@ mod tests {
 
     #[tokio::test]
     #[cfg(feature = "general_test")]
+    async fn test_vcx_disclosed_proof_release() {
+        let _setup = SetupMocks::init();
+        let handle = create_with_proof_request("TEST_CREDENTIAL", ARIES_PROOF_REQUEST_PRESENTATION).unwrap();
+        release(handle).unwrap();
+        assert_eq!(to_string(handle).unwrap_err().kind, LibvcxErrorKind::InvalidHandle)
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "general_test")]
     async fn test_create_proof() {
         let _setup = SetupMocks::init();
 

--- a/libvcx/src/api_vcx/api_handle/issuer_credential.rs
+++ b/libvcx/src/api_vcx/api_handle/issuer_credential.rs
@@ -231,6 +231,15 @@ pub mod tests {
         "{\"attr\":\"value\"}"
     }
 
+    #[test]
+    #[cfg(feature = "general_test")]
+    fn test_vcx_issuer_credential_release() {
+        let _setup = SetupMocks::init();
+        let handle = _issuer_credential_create();
+        release(handle).unwrap();
+        assert_eq!(to_string(handle).unwrap_err().kind, LibvcxErrorKind::InvalidHandle)
+    }
+
     #[tokio::test]
     #[cfg(feature = "general_test")]
     async fn test_issuer_credential_create_succeeds() {
@@ -368,40 +377,9 @@ pub mod tests {
         let h1 = _issuer_credential_create();
         let h2 = _issuer_credential_create();
         let h3 = _issuer_credential_create();
-        let h4 = _issuer_credential_create();
-        let h5 = _issuer_credential_create();
         release_all();
-        assert_eq!(
-            release(h1).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidIssuerCredentialHandle
-        );
-        assert_eq!(
-            release(h2).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidIssuerCredentialHandle
-        );
-        assert_eq!(
-            release(h3).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidIssuerCredentialHandle
-        );
-        assert_eq!(
-            release(h4).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidIssuerCredentialHandle
-        );
-        assert_eq!(
-            release(h5).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidIssuerCredentialHandle
-        );
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "general_test")]
-    async fn test_errors() {
-        let _setup = SetupEmpty::init();
-
-        assert_eq!(to_string(0).unwrap_err().kind(), LibvcxErrorKind::InvalidHandle);
-        assert_eq!(
-            release(0).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidIssuerCredentialHandle
-        );
+        assert_eq!(is_valid_handle(h1), false);
+        assert_eq!(is_valid_handle(h2), false);
+        assert_eq!(is_valid_handle(h3), false);
     }
 }

--- a/libvcx/src/api_vcx/api_handle/mediated_connection.rs
+++ b/libvcx/src/api_vcx/api_handle/mediated_connection.rs
@@ -487,6 +487,15 @@ pub mod tests {
 
     #[tokio::test]
     #[cfg(feature = "general_test")]
+    async fn test_vcx_connection_release() {
+        let _setup = SetupMocks::init();
+        let handle = mediated_connection::create_connection(_source_id()).await.unwrap();
+        release(handle).unwrap();
+        assert_eq!(to_string(handle).unwrap_err().kind, LibvcxErrorKind::InvalidHandle)
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "general_test")]
     async fn test_create_connection_works() {
         let _setup = SetupMocks::init();
         let connection_handle = mediated_connection::create_connection(_source_id()).await.unwrap();
@@ -626,15 +635,6 @@ pub mod tests {
 
     #[tokio::test]
     #[cfg(feature = "general_test")]
-    async fn test_connection_release_fails() {
-        let _setup = SetupEmpty::init();
-
-        let rc = release(1);
-        assert_eq!(rc.unwrap_err().kind(), LibvcxErrorKind::InvalidConnectionHandle);
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "general_test")]
     async fn test_get_state_fails() {
         let _setup = SetupEmpty::init();
 
@@ -690,29 +690,10 @@ pub mod tests {
         let h1 = create_connection("rel1").await.unwrap();
         let h2 = create_connection("rel2").await.unwrap();
         let h3 = create_connection("rel3").await.unwrap();
-        let h4 = create_connection("rel4").await.unwrap();
-        let h5 = create_connection("rel5").await.unwrap();
         release_all();
-        assert_eq!(
-            release(h1).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidConnectionHandle
-        );
-        assert_eq!(
-            release(h2).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidConnectionHandle
-        );
-        assert_eq!(
-            release(h3).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidConnectionHandle
-        );
-        assert_eq!(
-            release(h4).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidConnectionHandle
-        );
-        assert_eq!(
-            release(h5).unwrap_err().kind(),
-            LibvcxErrorKind::InvalidConnectionHandle
-        );
+        assert_eq!(is_valid_handle(h1), false);
+        assert_eq!(is_valid_handle(h2), false);
+        assert_eq!(is_valid_handle(h3), false);
     }
 
     #[tokio::test]

--- a/libvcx/src/api_vcx/api_handle/object_cache/mod.rs
+++ b/libvcx/src/api_vcx/api_handle/object_cache/mod.rs
@@ -211,15 +211,15 @@ where
     pub fn release(&self, handle: u32) -> LibvcxResult<()> {
         let mut store = self._lock_store_write()?;
         match store.remove(&handle) {
-            Some(_) => Ok(()),
-            None => Err(LibvcxError::from_msg(
-                LibvcxErrorKind::InvalidHandle,
-                format!(
-                    "[ObjectCache: {}] release >> Object not found for handle: {}",
+            Some(_) => {}
+            None => {
+                warn!(
+                    "[ObjectCache: {}] release >> Object not found for handle: {}. Perhaps already released?",
                     self.cache_name, handle
-                ),
-            )),
-        }
+                );
+            }
+        };
+        Ok(())
     }
 
     pub fn drain(&self) -> LibvcxResult<()> {

--- a/libvcx/src/api_vcx/api_handle/proof.rs
+++ b/libvcx/src/api_vcx/api_handle/proof.rs
@@ -192,6 +192,15 @@ pub mod tests {
 
     #[tokio::test]
     #[cfg(feature = "general_test")]
+    async fn test_get_proof_returns_proof_with_proof_state_invalid() {
+        let _setup = SetupMocks::init();
+        let handle = create_default_proof().await;
+        release(handle).unwrap();
+        assert_eq!(to_string(handle).unwrap_err().kind, LibvcxErrorKind::InvalidHandle)
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "general_test")]
     async fn test_create_proof_succeeds() {
         let _setup = SetupMocks::init();
         create_default_proof().await;
@@ -455,30 +464,10 @@ pub mod tests {
         )
         .await
         .unwrap();
-        let h4 = create_proof(
-            "1".to_string(),
-            REQUESTED_ATTRS.to_owned(),
-            REQUESTED_PREDICATES.to_owned(),
-            r#"{"support_revocation":false}"#.to_string(),
-            "Optional".to_owned(),
-        )
-        .await
-        .unwrap();
-        let h5 = create_proof(
-            "1".to_string(),
-            REQUESTED_ATTRS.to_owned(),
-            REQUESTED_PREDICATES.to_owned(),
-            r#"{"support_revocation":false}"#.to_string(),
-            "Optional".to_owned(),
-        )
-        .await
-        .unwrap();
         release_all();
-        assert_eq!(release(h1).unwrap_err().kind(), LibvcxErrorKind::InvalidProofHandle);
-        assert_eq!(release(h2).unwrap_err().kind(), LibvcxErrorKind::InvalidProofHandle);
-        assert_eq!(release(h3).unwrap_err().kind(), LibvcxErrorKind::InvalidProofHandle);
-        assert_eq!(release(h4).unwrap_err().kind(), LibvcxErrorKind::InvalidProofHandle);
-        assert_eq!(release(h5).unwrap_err().kind(), LibvcxErrorKind::InvalidProofHandle);
+        assert_eq!(is_valid_handle(h1), false);
+        assert_eq!(is_valid_handle(h2), false);
+        assert_eq!(is_valid_handle(h3), false);
     }
 
     #[tokio::test]

--- a/libvcx/src/api_vcx/api_handle/schema.rs
+++ b/libvcx/src/api_vcx/api_handle/schema.rs
@@ -227,6 +227,19 @@ pub mod tests {
 
     #[tokio::test]
     #[cfg(feature = "general_test")]
+    async fn test_vcx_schema_release() {
+        let _setup = SetupMocks::init();
+
+        let (did, schema_name, schema_version, data) = prepare_schema_data();
+        let handle = create_and_publish_schema("test_create_schema_success", schema_name, schema_version, data.clone())
+            .await
+            .unwrap();
+        release(handle).unwrap();
+        assert_eq!(to_string(handle).unwrap_err().kind, LibvcxErrorKind::InvalidHandle)
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "general_test")]
     async fn test_create_schema_to_string() {
         let _setup = SetupMocks::init();
 
@@ -372,20 +385,12 @@ pub mod tests {
         let h3 = create_and_publish_schema("3", schema_name.clone(), version.clone(), data.clone())
             .await
             .unwrap();
-        let h4 = create_and_publish_schema("4", schema_name.clone(), version.clone(), data.clone())
-            .await
-            .unwrap();
-        let h5 = create_and_publish_schema("5", schema_name.clone(), version.clone(), data.clone())
-            .await
-            .unwrap();
 
         release_all();
 
-        assert_eq!(release(h1).unwrap_err().kind(), LibvcxErrorKind::InvalidSchemaHandle);
-        assert_eq!(release(h2).unwrap_err().kind(), LibvcxErrorKind::InvalidSchemaHandle);
-        assert_eq!(release(h3).unwrap_err().kind(), LibvcxErrorKind::InvalidSchemaHandle);
-        assert_eq!(release(h4).unwrap_err().kind(), LibvcxErrorKind::InvalidSchemaHandle);
-        assert_eq!(release(h5).unwrap_err().kind(), LibvcxErrorKind::InvalidSchemaHandle);
+        assert_eq!(is_valid_handle(h1), false);
+        assert_eq!(is_valid_handle(h2), false);
+        assert_eq!(is_valid_handle(h3), false);
     }
 
     #[test]


### PR DESCRIPTION
Came up as desired change while working on https://github.com/hyperledger/aries-vcx/pull/665

- Change behaviour of releasing to be more forgiving - in tests of `vcx-napi-rs` where we frequently initialize and deinitialize happens often, it happens that garbage collector calls `release` on handle which we have freed manually via `shutdown` function
- Additionally: move some tests from `api_c` to `api_vcx`