### PR TITLE
Release 0.51.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agency_client"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "android_logger",
  "async-trait",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "aries-vcx"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "agency_client",
  "android_logger",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "aries-vcx-agent"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "aries-vcx",
  "derive_builder 0.11.2",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "diddoc"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "libvcx"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "android_logger",
  "aries-vcx",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "messages"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "base64 0.10.1",
  "chrono",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "shared_vcx"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "bs58 0.4.0",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.51.0"
+version = "0.51.1"
 authors = ["Absa Group Limited", "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>"]
 description = "Absa's fork of HL LibVCX"
 license = "Apache-2.0"

--- a/agents/node/vcxagent-core/package.json
+++ b/agents/node/vcxagent-core/package.json
@@ -69,6 +69,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@hyperledger/node-vcx-wrapper": "^0.51.0"
+    "@hyperledger/node-vcx-wrapper": "^0.51.1"
   }
 }

--- a/wrappers/node/package-lock.json
+++ b/wrappers/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/node-vcx-wrapper",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/node-vcx-wrapper",
-      "version": "0.51.0",
+      "version": "0.51.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ffi-napi": "^4.0.3",

--- a/wrappers/node/package.json
+++ b/wrappers/node/package.json
@@ -3,7 +3,7 @@
   "name": "@hyperledger/node-vcx-wrapper",
   "description": "NodeJS wrapper Aries Framework",
   "license": "Apache-2.0",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "directories": {
     "test": "test",
     "build": "dist",


### PR DESCRIPTION
Let's include 
- https://github.com/hyperledger/aries-vcx/pull/726

Possibly also
- https://github.com/hyperledger/aries-vcx/pull/723
if we manage to test it today

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>