### PR TITLE
Revert hiding mocking behind test_utils feature flag

### DIFF
--- a/.github/actions/setup-testing-nodejs/action.yml
+++ b/.github/actions/setup-testing-nodejs/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: "Build libvcx"
       shell: bash
       run: |
-        cargo build -F "test_utils" --manifest-path="libvcx/Cargo.toml"
+        cargo build --manifest-path="libvcx/Cargo.toml"
         sudo cp "target/debug/libvcx.so" /usr/lib
     - name: "Start indypool, mysql, agency"
       if: ${{ inputs.skip-docker-setup != 'true' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -2144,7 +2143,6 @@ dependencies = [
  "byteorder",
  "cfg-if 1.0.0",
  "convert_case",
- "env_logger 0.9.3",
  "etcommon-rlp",
  "failure",
  "futures",
@@ -2159,7 +2157,6 @@ dependencies = [
  "log-panics",
  "num-derive",
  "num-traits",
- "num_cpus",
  "rand 0.8.5",
  "regex",
  "rmp-serde",

--- a/aries_vcx/src/common/proofs/prover/prover.rs
+++ b/aries_vcx/src/common/proofs/prover/prover.rs
@@ -8,6 +8,7 @@ use crate::common::proofs::prover::prover_internal::{
 use crate::core::profile::profile::Profile;
 use crate::errors::error::prelude::*;
 use crate::global::settings;
+use crate::utils::mockdata::mock_settings::get_mock_generate_indy_proof;
 
 pub async fn generate_indy_proof(
     profile: &Arc<dyn Profile>,
@@ -21,15 +22,11 @@ pub async fn generate_indy_proof(
         secret!(&self_attested_attrs)
     );
 
-    #[cfg(feature = "test_utils")]
-    {
-        use crate::utils::mockdata::mock_settings::get_mock_generate_indy_proof;
-        match get_mock_generate_indy_proof() {
-            None => {}
-            Some(mocked_indy_proof) => {
-                warn!("generate_indy_proof :: returning mocked response");
-                return Ok(mocked_indy_proof);
-            }
+    match get_mock_generate_indy_proof() {
+        None => {}
+        Some(mocked_indy_proof) => {
+            warn!("generate_indy_proof :: returning mocked response");
+            return Ok(mocked_indy_proof);
         }
     }
     let anoncreds = Arc::clone(profile).inject_anoncreds();

--- a/aries_vcx/src/common/proofs/verifier/verifier.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier.rs
@@ -6,18 +6,15 @@ use crate::common::proofs::verifier::verifier_internal::{
 };
 use crate::core::profile::profile::Profile;
 use crate::errors::error::prelude::*;
+use crate::utils::mockdata::mock_settings::get_mock_result_for_validate_indy_proof;
 
 pub async fn validate_indy_proof(
     profile: &Arc<dyn Profile>,
     proof_json: &str,
     proof_req_json: &str,
 ) -> VcxResult<bool> {
-    #[cfg(feature = "test_utils")]
-    {
-        use crate::utils::mockdata::mock_settings::get_mock_result_for_validate_indy_proof;
-        if let Some(mock_result) = get_mock_result_for_validate_indy_proof() {
-            return mock_result;
-        }
+    if let Some(mock_result) = get_mock_result_for_validate_indy_proof() {
+        return mock_result;
     }
 
     let anoncreds = Arc::clone(profile).inject_anoncreds();

--- a/aries_vcx/src/indy/anoncreds.rs
+++ b/aries_vcx/src/indy/anoncreds.rs
@@ -1,4 +1,4 @@
-use vdrtools::{AnoncredsHelpers, Locator, SearchHandle};
+use vdrtools::{Locator, SearchHandle};
 
 use crate::errors::error::prelude::*;
 

--- a/aries_vcx/src/plugins/ledger/indy_vdr_ledger.rs
+++ b/aries_vcx/src/plugins/ledger/indy_vdr_ledger.rs
@@ -10,7 +10,7 @@ use tokio::sync::oneshot;
 use vdr::common::error::VdrError;
 use vdr::config::PoolConfig as IndyVdrPoolConfig;
 use vdr::ledger::identifiers::{CredentialDefinitionId, RevocationRegistryId, SchemaId};
-use vdr::ledger::requests::author_agreement::{GetTxnAuthorAgreementData, TxnAuthrAgrmtAcceptanceData};
+use vdr::ledger::requests::author_agreement::TxnAuthrAgrmtAcceptanceData;
 use vdr::ledger::RequestBuilder;
 use vdr::pool::{PoolBuilder, PoolTransactions};
 use vdr::pool::{PoolRunner, PreparedRequest, ProtocolVersion, RequestResult};
@@ -127,12 +127,6 @@ impl IndyVdrLedger {
         request.set_signature(&signature)?;
 
         self._submit_request(request).await
-    }
-
-    fn build_get_txn_author_agreement_request(&self) -> VcxResult<PreparedRequest> {
-        Ok(self
-            .request_builder()?
-            .build_get_txn_author_agreement_request(None, None)?)
     }
 
     async fn _build_get_cred_def_request(

--- a/aries_vcx/src/utils/mod.rs
+++ b/aries_vcx/src/utils/mod.rs
@@ -50,7 +50,6 @@ pub mod constants;
 pub mod async_fn_iterator;
 pub mod file;
 pub mod json;
-#[cfg(feature = "test_utils")]
 pub mod mockdata;
 pub mod openssl;
 pub mod provision;

--- a/aries_vcx/tests/test_pool.rs
+++ b/aries_vcx/tests/test_pool.rs
@@ -15,7 +15,7 @@ mod integration_tests {
     };
     use aries_vcx::common::test_utils::create_and_store_nonrevocable_credential_def;
     use aries_vcx::messages::protocols::connection::did::Did;
-    use aries_vcx::utils::constants::{DEFAULT_SCHEMA_ATTRS, SCHEMA_DATA};
+    use aries_vcx::utils::constants::DEFAULT_SCHEMA_ATTRS;
     use aries_vcx::utils::devsetup::{SetupProfile, SetupWalletPool};
     use messages::diddoc::aries::service::AriesService;
     use std::sync::Arc;

--- a/libvcx/src/api_vcx/api_global/profile.rs
+++ b/libvcx/src/api_vcx/api_global/profile.rs
@@ -6,7 +6,6 @@ use aries_vcx::{
     plugins::wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
     vdrtools::{PoolHandle, WalletHandle},
 };
-#[cfg(feature = "test_utils")]
 use aries_vcx::{global::settings::indy_mocks_enabled, utils::mockdata::profile::mock_profile::MockProfile};
 
 use super::{pool::get_main_pool_handle, wallet::get_main_wallet_handle};
@@ -24,7 +23,6 @@ pub fn get_main_wallet() -> Arc<dyn BaseWallet> {
 }
 
 pub fn get_main_profile() -> LibvcxResult<Arc<dyn Profile>> {
-    #[cfg(feature = "test_utils")]
     if indy_mocks_enabled() {
         return Ok(Arc::new(MockProfile {}));
     }
@@ -37,7 +35,6 @@ pub fn get_main_profile() -> LibvcxResult<Arc<dyn Profile>> {
 // constructs an indy profile under the condition where a pool_handle is NOT required
 // - e.g. where only a Wallet is used (no ledger interactions). Should be used sparingly.
 pub fn get_main_profile_optional_pool() -> Arc<dyn Profile> {
-    #[cfg(feature = "test_utils")]
     if indy_mocks_enabled() {
         return Arc::new(MockProfile {});
     }

--- a/libvcx/src/api_vcx/api_handle/credential.rs
+++ b/libvcx/src/api_vcx/api_handle/credential.rs
@@ -5,8 +5,6 @@ use aries_vcx::handlers::issuance::holder::Holder;
 use aries_vcx::messages::a2a::A2AMessage;
 use aries_vcx::messages::protocols::issuance::credential_offer::CredentialOffer;
 use aries_vcx::utils::constants::GET_MESSAGES_DECRYPTED_RESPONSE;
-
-#[cfg(feature = "test_utils")]
 use aries_vcx::{global::settings::indy_mocks_enabled, utils::mockdata::mockdata_credex::ARIES_CREDENTIAL_OFFER};
 
 use crate::api_vcx::api_global::profile::{get_main_profile, get_main_profile_optional_pool};
@@ -227,7 +225,6 @@ async fn get_credential_offer_msg(connection_handle: u32, msg_id: &str) -> Libvc
         msg_id
     );
 
-    #[cfg(feature = "test_utils")]
     if indy_mocks_enabled() {
         AgencyMockDecrypted::set_next_decrypted_response(GET_MESSAGES_DECRYPTED_RESPONSE);
         AgencyMockDecrypted::set_next_decrypted_message(ARIES_CREDENTIAL_OFFER);
@@ -259,11 +256,8 @@ pub async fn get_credential_offer_messages_with_conn_handle(connection_handle: u
         connection_handle
     );
 
-    #[cfg(feature = "test_utils")]
-    {
-        AgencyMockDecrypted::set_next_decrypted_response(GET_MESSAGES_DECRYPTED_RESPONSE);
-        AgencyMockDecrypted::set_next_decrypted_message(ARIES_CREDENTIAL_OFFER);
-    }
+    AgencyMockDecrypted::set_next_decrypted_response(GET_MESSAGES_DECRYPTED_RESPONSE);
+    AgencyMockDecrypted::set_next_decrypted_message(ARIES_CREDENTIAL_OFFER);
 
     let credential_offers: Vec<A2AMessage> = mediated_connection::get_messages(connection_handle)
         .await?

--- a/libvcx/src/api_vcx/api_handle/disclosed_proof.rs
+++ b/libvcx/src/api_vcx/api_handle/disclosed_proof.rs
@@ -5,8 +5,6 @@ use aries_vcx::handlers::proof_presentation::prover::Prover;
 use aries_vcx::messages::a2a::A2AMessage;
 use aries_vcx::messages::protocols::proof_presentation::presentation_request::PresentationRequest;
 use aries_vcx::utils::constants::GET_MESSAGES_DECRYPTED_RESPONSE;
-
-#[cfg(feature = "test_utils")]
 use aries_vcx::{
     global::settings::indy_mocks_enabled, utils::mockdata::mockdata_proof::ARIES_PROOF_REQUEST_PRESENTATION,
 };
@@ -224,7 +222,6 @@ pub fn get_thread_id(handle: u32) -> LibvcxResult<String> {
 }
 
 async fn get_proof_request(connection_handle: u32, msg_id: &str) -> LibvcxResult<String> {
-    #[cfg(feature = "test_utils")]
     if indy_mocks_enabled() {
         AgencyMockDecrypted::set_next_decrypted_response(GET_MESSAGES_DECRYPTED_RESPONSE);
         AgencyMockDecrypted::set_next_decrypted_message(ARIES_PROOF_REQUEST_PRESENTATION);


### PR DESCRIPTION
Currently, our tests rely on `test_utils` feature flag indicating whether `MessageId` should be generated randomly or mock value `testid` should be used. Without other changes, setting `test_utils` feature flag without running in test mode causes `MessageId`s to have the same value, which is undesirable. For now, mocking should be exposed without feature flags and work should be done to exclude static mockdata from release builds.

Signed-off-by: Miroslav Kovar <miroslav.kovar@absa.africa>