### PR TITLE
Fix the signature VcxAPI.credentialGetOffers

### DIFF
--- a/wrappers/ios/vcx/VcxAPI.m
+++ b/wrappers/ios/vcx/VcxAPI.m
@@ -1766,12 +1766,12 @@ void checkErrorAndComplete(vcx_error_t ret, vcx_command_handle_t cmdHandle, void
     });
 }
 
-- (void)credentialGetOffers:(VcxHandle)connectionHandle
+- (void)credentialGetOffers:(NSNumber *)connectionHandle
                  completion:(void (^)(NSError *, NSString *))completion {
 
     vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
 
-    vcx_error_t ret = vcx_credential_get_offers(handle, connectionHandle, &VcxWrapperCbResponseString);
+    vcx_error_t ret = vcx_credential_get_offers(handle, connectionHandle.unsignedIntValue, &VcxWrapperCbResponseString);
 
     checkErrorAndComplete(ret, handle, ^{
         completion([NSError errorFromVcxError:ret], ERROR_RESPONSE_STRING);


### PR DESCRIPTION
Fixing the signature of the implementation to match the one from the header to avoid a crash when calling the function.

[VcxAPI.h](https://github.com/hyperledger/aries-vcx/blob/66ee076fb4abd479dd6bbd05eb42270bdca1643b/wrappers/ios/vcx/VcxAPI.h#L444):
<img src="https://user-images.githubusercontent.com/1267845/217582709-fc554dcd-70c2-47b3-9eb0-b7f447d5990a.png" width="600"/>

[VcxAPI.m](https://github.com/hyperledger/aries-vcx/blob/66ee076fb4abd479dd6bbd05eb42270bdca1643b/wrappers/ios/vcx/VcxAPI.m#L1769):
<img src="https://user-images.githubusercontent.com/1267845/217582753-659aace9-816f-4f59-bed2-2c9b48bb5438.png" width="600"/>
