### PR TITLE
Simplify connection serialization from nodejs

### DIFF
--- a/.github/actions/setup-testing-nodejs/action.yml
+++ b/.github/actions/setup-testing-nodejs/action.yml
@@ -13,10 +13,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js ${{ inputs.node-version }}
+    - name: "Use Node.js ${{ inputs.node-version }}"
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
+    - name: "Install npm 8.19.3"
+      shell: bash
+      run: |
+        npm install -g npm@8.19.3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.64.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,10 +378,10 @@ jobs:
 
   test-node-wrapper:
     needs: workflow-setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [12.x, 18.x]
+        node-version: [18.x]
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -395,10 +395,10 @@ jobs:
 
   test-integration-node-wrapper:
     needs: workflow-setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [12.x, 18.x]
+        node-version: [18.x]
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3

--- a/aries_vcx/README.md
+++ b/aries_vcx/README.md
@@ -67,3 +67,4 @@ cargo test  --features "pool_tests" -- --test-threads=1
 ## Architecture 
 
 <img alt="AriesVCX architecture diagram" src="../docs/architecture/ariesvcx_architecture_040123.png"/>
+

--- a/wrappers/node/src/api/common.ts
+++ b/wrappers/node/src/api/common.ts
@@ -165,10 +165,6 @@ export enum VerifierStateType {
   Failed = 5
 }
 
-export interface IInitVCXOptions {
-  libVCXPath?: string;
-}
-
 export interface ISerializedData<T> {
   version: string;
   data: T;

--- a/wrappers/node/src/api/connection.ts
+++ b/wrappers/node/src/api/connection.ts
@@ -9,15 +9,20 @@ export type INonmediatedConnectionInvite = string;
 export type INonmeditatedConnectionData = string;
 
 export interface IEndpointInfo {
-  serviceEndpoint: string,
-  routingKeys: string[],
+  serviceEndpoint: string;
+  routingKeys: string[];
 }
 
-export class NonmediatedConnection extends VcxBaseWithState<INonmeditatedConnectionData, ConnectionStateType> {
+export class NonmediatedConnection extends VcxBaseWithState<
+  INonmeditatedConnectionData,
+  ConnectionStateType
+> {
   public static async createInviter(pwInfo?: IPwInfo): Promise<NonmediatedConnection> {
     try {
-      const connection = new NonmediatedConnection("");
-      connection._setHandle(await ffiNapi.connectionCreateInviter(pwInfo ? JSON.stringify(pwInfo) : null));
+      const connection = new NonmediatedConnection();
+      connection._setHandle(
+        await ffiNapi.connectionCreateInviter(pwInfo ? JSON.stringify(pwInfo) : null),
+      );
       return connection;
     } catch (err: any) {
       throw new VCXInternalError(err);
@@ -26,7 +31,7 @@ export class NonmediatedConnection extends VcxBaseWithState<INonmeditatedConnect
 
   public static async createInvitee(invite: string): Promise<NonmediatedConnection> {
     try {
-      const connection = new NonmediatedConnection("");
+      const connection = new NonmediatedConnection();
       connection._setHandle(await ffiNapi.connectionCreateInvitee(invite));
       return connection;
     } catch (err: any) {
@@ -175,9 +180,7 @@ export class NonmediatedConnection extends VcxBaseWithState<INonmeditatedConnect
 
   public static deserialize(connectionData: ISerializedData<string>): NonmediatedConnection {
     try {
-      const connection = new NonmediatedConnection("");
-      connection._setHandle(ffiNapi.connectionDeserialize(connectionData.data));
-      return connection;
+      return super._deserialize(NonmediatedConnection, connectionData as any);
     } catch (err: any) {
       throw new VCXInternalError(err);
     }

--- a/wrappers/node/src/api/connection.ts
+++ b/wrappers/node/src/api/connection.ts
@@ -189,10 +189,7 @@ export class NonmediatedConnection extends VcxBaseWithState<INonmeditatedConnect
     throw new Error('_updateStFnV2 cannot be called for a Connection object');
   };
   protected _getStFn = ffiNapi.connectionGetState;
-  protected _serializeFn = (handle: number): string => {
-    const data = JSON.parse(ffiNapi.connectionSerialize(handle));
-    return JSON.stringify({ data, source_id: this.sourceId, version: '1.0' });
-  }
+  protected _serializeFn = ffiNapi.connectionSerialize;
   protected _deserializeFn = ffiNapi.connectionDeserialize;
   protected _inviteDetailFn = ffiNapi.connectionGetInvitation;
 }

--- a/wrappers/node/src/api/credential-def.ts
+++ b/wrappers/node/src/api/credential-def.ts
@@ -50,7 +50,7 @@ export class CredentialDef extends VcxBase<ICredentialDefData> {
     tag,
   }: ICredentialDefCreateDataV2): Promise<CredentialDef> {
     try {
-      const credentialDef = new CredentialDef(sourceId, { schemaId });
+      const credentialDef = new CredentialDef({ schemaId });
       const handle = await ffi.credentialdefCreateV2(sourceId, schemaId, tag, supportRevocation);
       credentialDef._setHandle(handle);
       return credentialDef;
@@ -69,7 +69,7 @@ export class CredentialDef extends VcxBase<ICredentialDefData> {
       name,
       schemaId: null,
     };
-    return super._deserialize(CredentialDef, credentialDef, credentialDefParams);
+    return super._deserialize(CredentialDef, credentialDef as any, credentialDefParams);
   }
 
   protected _serializeFn = ffi.credentialdefSerialize;
@@ -80,8 +80,8 @@ export class CredentialDef extends VcxBase<ICredentialDefData> {
   private _credDefId: string | undefined;
   private _tailsDir: string | undefined;
 
-  constructor(sourceId: string, { name, schemaId, credDefId, tailsDir }: ICredentialDefParams) {
-    super(sourceId);
+  constructor({ name, schemaId, credDefId, tailsDir }: ICredentialDefParams) {
+    super();
     this._name = name;
     this._schemaId = schemaId;
     this._credDefId = credDefId;

--- a/wrappers/node/src/api/credential.ts
+++ b/wrappers/node/src/api/credential.ts
@@ -24,7 +24,7 @@ export interface ICredentialSendData {
 export class Credential extends VcxBaseWithState<ICredentialStructData, HolderStateType> {
   public static create({ sourceId, offer }: ICredentialCreateWithOffer): Credential {
     try {
-      const credential = new Credential(sourceId);
+      const credential = new Credential();
       const handle = ffi.credentialCreateWithOffer(sourceId, offer);
       credential._setHandle(handle);
       return credential;
@@ -36,7 +36,8 @@ export class Credential extends VcxBaseWithState<ICredentialStructData, HolderSt
   public static deserialize(
     credentialData: ISerializedData<ICredentialStructData>,
   ): Credential {
-    const credential = super._deserialize<Credential>(Credential, credentialData);
+    // running into issue https://github.com/microsoft/TypeScript/issues/15300 without using "as any"
+    const credential = super._deserialize<Credential>(Credential, credentialData as any);
     return credential;
   }
 

--- a/wrappers/node/src/api/disclosed-proof.ts
+++ b/wrappers/node/src/api/disclosed-proof.ts
@@ -17,12 +17,6 @@ export interface IDisclosedProofCreateData {
   request: string;
 }
 
-export interface IDisclosedProofCreateWithMsgIdData {
-  connection: Connection;
-  msgId: string;
-  sourceId: string;
-}
-
 export interface IRetrievedCreds {
   attrs: {
     [index: string]: ICredData[];

--- a/wrappers/node/src/api/disclosed-proof.ts
+++ b/wrappers/node/src/api/disclosed-proof.ts
@@ -55,7 +55,7 @@ export interface IDeclinePresentationRequestData {
 export class DisclosedProof extends VcxBaseWithState<IDisclosedProofData, ProverStateType> {
   public static create({ sourceId, request }: IDisclosedProofCreateData): DisclosedProof {
     try {
-      const disclosedProof = new DisclosedProof(sourceId);
+      const disclosedProof = new DisclosedProof();
       disclosedProof._setHandle(ffi.disclosedProofCreateWithRequest(sourceId, request));
       return disclosedProof;
     } catch (err: any) {
@@ -65,7 +65,7 @@ export class DisclosedProof extends VcxBaseWithState<IDisclosedProofData, Prover
 
   public static deserialize(data: ISerializedData<IDisclosedProofData>): DisclosedProof {
     try {
-      return super._deserialize(DisclosedProof, data);
+      return super._deserialize(DisclosedProof, data as any);
     } catch (err: any) {
       throw new VCXInternalError(err);
     }

--- a/wrappers/node/src/api/issuer-credential.ts
+++ b/wrappers/node/src/api/issuer-credential.ts
@@ -32,8 +32,8 @@ export interface IIssuerCredentialData {
 export class IssuerCredential extends VcxBaseWithState<IIssuerCredentialData, IssuerStateType> {
   public static async create(sourceId: string): Promise<IssuerCredential> {
     try {
-      const connection = new IssuerCredential(sourceId);
-      connection._setHandle(await ffi.issuerCredentialCreate(sourceId));
+      const connection = new IssuerCredential();
+      connection._setHandle(ffi.issuerCredentialCreate(sourceId));
       return connection;
     } catch (err: any) {
       throw new VCXInternalError(err);
@@ -44,7 +44,7 @@ export class IssuerCredential extends VcxBaseWithState<IIssuerCredentialData, Is
     serializedData: ISerializedData<IIssuerCredentialData>,
   ): IssuerCredential {
     try {
-      return super._deserialize(IssuerCredential, serializedData);
+      return super._deserialize(IssuerCredential, serializedData as any);
     } catch (err: any) {
       throw new VCXInternalError(err);
     }
@@ -55,10 +55,6 @@ export class IssuerCredential extends VcxBaseWithState<IIssuerCredentialData, Is
   protected _getStFn = ffi.issuerCredentialGetState;
   protected _serializeFn = ffi.issuerCredentialSerialize;
   protected _deserializeFn = ffi.issuerCredentialDeserialize;
-
-  constructor(sourceId: string) {
-    super(sourceId);
-  }
 
   public async updateStateWithMessage(connection: Connection, message: string): Promise<number> {
     try {

--- a/wrappers/node/src/api/mediated-connection.ts
+++ b/wrappers/node/src/api/mediated-connection.ts
@@ -44,15 +44,6 @@ export interface IFromRequestInfoV2 extends IConnectionCreateData {
 }
 
 /**
- * @description Interface that represents the parameters for `Connection.connect` function.
- * @interface
- */
-export interface IConnectOptions {
-  // Provides details indicating if the connection will be established by text or QR Code
-  data: string;
-}
-
-/**
  * @description Interface that represents the parameters for `Connection.sendMessage` function.
  * @interface
  */
@@ -108,10 +99,6 @@ export interface IDownloadMessagesConfigsV2 {
 export interface IConnectionDownloadMessages {
   status: string;
   uids: string;
-}
-
-export interface IConnectionDownloadAllMessages extends IConnectionDownloadMessages {
-  pwdids: string;
 }
 
 export async function downloadMessagesV2({

--- a/wrappers/node/src/api/mediated-connection.ts
+++ b/wrappers/node/src/api/mediated-connection.ts
@@ -138,7 +138,7 @@ export function generatePublicInvite(public_did: string, label: string): string 
 export class Connection extends VcxBaseWithState<IConnectionData, ConnectionStateType> {
   public static async create({ id }: IConnectionCreateData): Promise<Connection> {
     try {
-      const connection = new Connection(id);
+      const connection = new Connection();
       connection._setHandle(await ffiNapi.mediatedConnectionCreate(id));
       return connection;
     } catch (err: any) {
@@ -148,7 +148,7 @@ export class Connection extends VcxBaseWithState<IConnectionData, ConnectionStat
 
   public static async createWithInvite({ id, invite }: IRecipientInviteInfo): Promise<Connection> {
     try {
-      const connection = new Connection(id);
+      const connection = new Connection();
       connection._setHandle(await ffiNapi.mediatedConnectionCreateWithInvite(id, invite));
       return connection;
     } catch (err: any) {
@@ -170,7 +170,7 @@ export class Connection extends VcxBaseWithState<IConnectionData, ConnectionStat
     request,
   }: IFromRequestInfoV2): Promise<Connection> {
     try {
-      const connection = new Connection(id);
+      const connection = new Connection();
       connection._setHandle(
         await ffiNapi.mediatedConnectionCreateWithConnectionRequestV2(
           request,
@@ -185,7 +185,7 @@ export class Connection extends VcxBaseWithState<IConnectionData, ConnectionStat
 
   public static deserialize(connectionData: ISerializedData<IConnectionData>): Connection {
     try {
-      return super._deserialize(Connection, connectionData);
+      return super._deserialize(Connection, connectionData as any);
     } catch (err: any) {
       throw new VCXInternalError(err);
     }

--- a/wrappers/node/src/api/out-of-band-receiver.ts
+++ b/wrappers/node/src/api/out-of-band-receiver.ts
@@ -8,7 +8,7 @@ import { ISerializedData } from './common';
 
 export class OutOfBandReceiver extends VcxBase<IOOBSerializedData> {
   public static createWithMessage(msg: string): OutOfBandReceiver {
-    const oob = new OutOfBandReceiver('');
+    const oob = new OutOfBandReceiver();
     try {
       oob._setHandle(ffi.outOfBandReceiverCreate(msg));
       return oob;

--- a/wrappers/node/src/api/out-of-band-sender.ts
+++ b/wrappers/node/src/api/out-of-band-sender.ts
@@ -36,7 +36,7 @@ export enum HandshakeProtocol {
 
 export class OutOfBandSender extends VcxBase<IOOBSerializedData> {
   public static create(config: IOOBCreateData): OutOfBandSender {
-    const oob = new OutOfBandSender(config.source_id);
+    const oob = new OutOfBandSender();
     try {
       oob._setHandle(ffi.outOfBandSenderCreate(JSON.stringify(config)));
       return oob;

--- a/wrappers/node/src/api/proof.ts
+++ b/wrappers/node/src/api/proof.ts
@@ -88,9 +88,9 @@ export interface IRevocationInterval {
 export class Proof extends VcxBaseWithState<IProofData, VerifierStateType> {
   public static async create({ sourceId, ...createDataRest }: IProofCreateData): Promise<Proof> {
     try {
-      const proof = new Proof(sourceId);
+      const proof = new Proof();
       const handle = await ffi.proofCreate(
-        proof.sourceId,
+        sourceId,
         JSON.stringify(createDataRest.attrs),
         JSON.stringify(createDataRest.preds || []),
         JSON.stringify(createDataRest.revocationInterval),
@@ -105,7 +105,7 @@ export class Proof extends VcxBaseWithState<IProofData, VerifierStateType> {
 
   public static deserialize(proofData: ISerializedData<IProofData>): Proof {
     try {
-      return super._deserialize<Proof, IProofConstructorData>(Proof, proofData);
+      return super._deserialize<Proof, IProofConstructorData>(Proof, proofData as any);
     } catch (err: any) {
       throw new VCXInternalError(err);
     }

--- a/wrappers/node/src/api/revocation-registry.ts
+++ b/wrappers/node/src/api/revocation-registry.ts
@@ -28,7 +28,7 @@ export interface IRevocationRegistryConfig {
 export class RevocationRegistry extends VcxBase<IRevocationRegistryData> {
   public static async create(config: IRevocationRegistryConfig): Promise<RevocationRegistry> {
     try {
-      const revReg = new RevocationRegistry('');
+      const revReg = new RevocationRegistry();
       const _config = {
         issuer_did: config.issuerDid,
         cred_def_id: config.credDefId,

--- a/wrappers/node/src/api/schema.ts
+++ b/wrappers/node/src/api/schema.ts
@@ -77,9 +77,9 @@ export class Schema extends VcxBase<ISchemaSerializedData> {
 
   public static async create({ data, sourceId }: ISchemaCreateData): Promise<Schema> {
     try {
-      const schema = new Schema(sourceId, { name: data.name, schemaId: '', schemaAttrs: data });
+      const schema = new Schema({ name: data.name, schemaId: '', schemaAttrs: data });
       const handle = await ffi.schemaCreate(
-        schema.sourceId,
+        sourceId,
         schema._name,
         data.version,
         JSON.stringify(data.attrNames),
@@ -101,7 +101,7 @@ export class Schema extends VcxBase<ISchemaSerializedData> {
       schemaAttrs: { name, version, attrNames: data },
       schemaId: schema_id,
     };
-    return super._deserialize(Schema, schema, jsConstructorParams);
+    return super._deserialize(Schema, schema as any, jsConstructorParams);
   }
 
   protected _serializeFn = ffi.schemaSerialize;
@@ -111,8 +111,8 @@ export class Schema extends VcxBase<ISchemaSerializedData> {
   protected _schemaId: string;
   protected _schemaAttrs: ISchemaAttrs;
 
-  constructor(sourceId: string, { name, schemaId, schemaAttrs }: ISchemaParams) {
-    super(sourceId);
+  constructor({ name, schemaId, schemaAttrs }: ISchemaParams) {
+    super();
     this._name = name;
     this._schemaId = schemaId;
     this._schemaAttrs = schemaAttrs;

--- a/wrappers/node/src/api/schema.ts
+++ b/wrappers/node/src/api/schema.ts
@@ -52,11 +52,6 @@ export interface ISchemaParams {
   schemaAttrs: ISchemaAttrs;
 }
 
-export interface ISchemaLookupData {
-  sourceId: string;
-  schemaId: string;
-}
-
 export enum SchemaState {
   Built = 0,
   Published = 1,

--- a/wrappers/node/test/helpers/entities.ts
+++ b/wrappers/node/test/helpers/entities.ts
@@ -32,7 +32,6 @@ export const connectionCreateInviterNull = async (
 ): Promise<Connection> => {
   const connection = await Connection.create(data);
   assert.notEqual(connection.handle, undefined);
-  assert.equal(connection.sourceId, data.id);
   return connection;
 };
 
@@ -73,7 +72,6 @@ export const credentialDefCreate = async (
   const credentialDef = await CredentialDef.create(data);
   await credentialDef.publish();
   assert.notEqual(credentialDef.handle, undefined);
-  assert.equal(credentialDef.sourceId, data.sourceId);
   assert.equal(credentialDef.schemaId, data.schemaId);
   return credentialDef;
 };
@@ -106,7 +104,6 @@ export const credentialCreateWithOffer = async (
   }
   const credential = await Credential.create(data);
   assert.notEqual(credential.handle, undefined);
-  assert.equal(credential.sourceId, data.sourceId);
   return credential;
 };
 
@@ -127,7 +124,6 @@ export const disclosedProofCreateWithRequest = async (
   }
   const disclosedProof = DisclosedProof.create(data);
   assert.notEqual(disclosedProof.handle, undefined);
-  assert.equal(disclosedProof.sourceId, data.sourceId);
   return disclosedProof;
 };
 
@@ -165,7 +161,6 @@ export const dataProofCreate = (): IProofCreateData => ({
 export const proofCreate = async (data = dataProofCreate()): Promise<Proof> => {
   const proof = await Proof.create(data);
   assert.notEqual(proof.handle, undefined);
-  assert.equal(proof.sourceId, data.sourceId);
   return proof;
 };
 
@@ -181,7 +176,6 @@ export const dataSchemaCreate = (): ISchemaCreateData => ({
 export const schemaCreate = async (data = dataSchemaCreate()): Promise<Schema> => {
   const schema = await Schema.create(data);
   assert.notEqual(schema.handle, undefined);
-  assert.equal(schema.sourceId, data.sourceId);
   assert.equal(schema.name, data.data.name);
   assert.deepEqual(schema.schemaAttrs, data.data);
   assert.ok(schema.schemaId);

--- a/wrappers/node/test/suite1/ariesvcx-credential-def.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-credential-def.test.ts
@@ -27,7 +27,7 @@ describe('CredentialDef:', () => {
     });
 
     it('throws: not initialized', async () => {
-      const credentialDef = new CredentialDef(null as any, {} as any);
+      const credentialDef = new CredentialDef({} as any);
       const error = await shouldThrow(() => credentialDef.serialize());
       assert.equal(error.napiCode, 'NumberExpected');
     });

--- a/wrappers/node/test/suite1/ariesvcx-credential-def.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-credential-def.test.ts
@@ -24,7 +24,6 @@ describe('CredentialDef:', () => {
       const { data, version } = serialized;
       assert.ok(data);
       assert.ok(version);
-      assert.equal(data.source_id, credentialDef.sourceId);
     });
 
     it('throws: not initialized', async () => {
@@ -39,7 +38,6 @@ describe('CredentialDef:', () => {
       const credentialDef1 = await credentialDefCreate();
       const data1 = await credentialDef1.serialize();
       const credentialDef2 = await CredentialDef.deserialize(data1);
-      assert.equal(credentialDef2.sourceId, credentialDef1.sourceId);
       const data2 = await credentialDef2.serialize();
       assert.deepEqual(data1, data2);
     });

--- a/wrappers/node/test/suite1/ariesvcx-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-credential.test.ts
@@ -46,7 +46,7 @@ describe('Credential:', () => {
     });
 
     it('throws: not initialized', async () => {
-      const credential = new Credential(null as any);
+      const credential = new Credential();
       const error = await shouldThrow(() => credential.serialize());
       assert.equal(error.napiCode, 'NumberExpected');
     });

--- a/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-disclosed-proof.test.ts
@@ -2,13 +2,11 @@ import '../module-resolver-helper';
 
 import { assert } from 'chai';
 import {
-  createConnectionInviterFinished,
   createConnectionInviterRequested,
   dataDisclosedProofCreateWithRequest,
   disclosedProofCreateWithRequest,
 } from 'helpers/entities';
 import { initVcxTestMode, shouldThrow } from 'helpers/utils';
-import { mapValues } from 'lodash';
 import { DisclosedProof, ProverStateType, VCXCode } from 'src';
 
 describe('DisclosedProof', () => {

--- a/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-issuer-credential.test.ts
@@ -32,7 +32,7 @@ describe('IssuerCredential:', () => {
     });
 
     it('throws: not initialized', async () => {
-      const issuerCredential = new IssuerCredential('foo');
+      const issuerCredential = new IssuerCredential();
       const error = await shouldThrow(() => issuerCredential.serialize());
       assert.equal(error.napiCode, 'NumberExpected');
     });
@@ -103,7 +103,7 @@ describe('IssuerCredential:', () => {
 
     it('throws: not initialized', async () => {
       const [, data] = await issuerCredentialCreate();
-      const issuerCredential = new IssuerCredential('');
+      const issuerCredential = new IssuerCredential();
       const error = await shouldThrow(() => issuerCredential.buildCredentialOfferMsgV2(data));
       assert.equal(error.napiCode, 'NumberExpected');
     });

--- a/wrappers/node/test/suite1/ariesvcx-mediated-connection.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-mediated-connection.test.ts
@@ -91,7 +91,6 @@ describe('Connection:', () => {
       assert.ok(data);
       assert.ok(version);
       assert.ok(source_id);
-      assert.equal(source_id, connection.sourceId);
     });
   });
 
@@ -100,7 +99,6 @@ describe('Connection:', () => {
       const connection1 = await connectionCreateInviterNull();
       const data1 = connection1.serialize();
       const connection2 = Connection.deserialize(data1);
-      assert.equal(connection2.sourceId, connection1.sourceId);
       const data2 = connection2.serialize();
       assert.deepEqual(data1, data2);
     });

--- a/wrappers/node/test/suite1/ariesvcx-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-proof.test.ts
@@ -78,7 +78,7 @@ describe('Proof:', () => {
   describe('updateState:', () => {
     it(`throws error when not initialized`, async () => {
       let caught_error;
-      const proof = new Proof(null as any);
+      const proof = new Proof();
       const connection = await createConnectionInviterRequested();
       try {
         await proof.updateStateV2(connection);
@@ -112,7 +112,7 @@ describe('Proof:', () => {
 
     it('throws: not initialized', async () => {
       const connection = await createConnectionInviterRequested();
-      const proof = new Proof(null as any);
+      const proof = new Proof();
       const error = await shouldThrow(() => proof.requestProof(connection));
       assert.equal(error.napiCode, 'NumberExpected');
     });

--- a/wrappers/node/test/suite1/ariesvcx-proof.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-proof.test.ts
@@ -42,7 +42,6 @@ describe('Proof:', () => {
       const proof = await proofCreate();
       const { data } = await proof.serialize();
       assert.ok(data);
-      assert.equal((data as any).verifier_sm.source_id, proof.sourceId);
     });
   });
 

--- a/wrappers/node/test/suite1/ariesvcx-schema.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-schema.test.ts
@@ -80,7 +80,6 @@ describe('Schema:', () => {
       const { data, version } = serialized;
       assert.ok(data);
       assert.ok(version);
-      assert.equal(data.source_id, schema.sourceId);
     });
 
     it('throws: not initialized', async () => {
@@ -95,7 +94,6 @@ describe('Schema:', () => {
       const schema1 = await schemaCreate();
       const data1 = await schema1.serialize();
       const schema2 = await Schema.deserialize(data1);
-      assert.equal(schema2.sourceId, schema1.sourceId);
       const data2 = await schema2.serialize();
       assert.deepEqual(data1, data2);
     });

--- a/wrappers/node/test/suite1/ariesvcx-schema.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-schema.test.ts
@@ -83,7 +83,7 @@ describe('Schema:', () => {
     });
 
     it('throws: not initialized', async () => {
-      const schema = new Schema(null as any, {} as any);
+      const schema = new Schema({} as any);
       const error = await shouldThrow(() => schema.serialize());
       assert.equal(error.napiCode, 'NumberExpected');
     });


### PR DESCRIPTION
- NodeJS wrapper was previously trying to keep value of `source_id` as part of constructed JS objects / TS classes, see changes in class `VcxBase`
```
protected _sourceId: string;
```
- Consequently deserialization constructors requiring `source_id`. That led me to generalizing signature for its static method ` _deserialize` such the serialized data to be deserialized are simply a JSON object (expressed as `Record<string, unknown>` in TS) instead of previous more strict definition `objData: ISerializedData<{ source_id: string }>`  which couldn't acommodate different serialization format of `Connection` state machine.
- Additionally removed some dead code
- Note: More code can be purged and cleaned up, for example given the decision to treat serialized data as opaque, it makes no sense to define `ISerializedData`, as this is expression of certain assumption as to how that serialized data looks like. The only thing which should be held by TS classes is the numeric rust handle
- Simplifies `Connection` serialization such that in serialized to (removing extra `data` level in hierarchy, removes duplicated field `source_id`, removes `version`)
```
{
    "source_id": "",
    "pairwise_info": {
        "pw_did": "FhrSrYtQcw3p9xwf7NYemf",
        "pw_vk": "91qMFrZjXDoi2Vc8Mm14Ys112tEZdDegBZZoembFEATE"
    },
    "state": {
        "Inviter": {
            "Initial": null
        }
    }
}
```



Signed-off-by: Patrik Stas <patrik.stas@absa.africa>