### PR TITLE
Fix NodeJS testing CI

### DIFF
--- a/.github/actions/setup-testing-nodejs/action.yml
+++ b/.github/actions/setup-testing-nodejs/action.yml
@@ -13,10 +13,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js ${{ inputs.node-version }}
+    - name: "Use Node.js ${{ inputs.node-version }}"
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
+    - name: "Install npm 8.19.3"
+      shell: bash
+      run: |
+        npm install -g npm@8.19.3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.64.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,10 +378,10 @@ jobs:
 
   test-node-wrapper:
     needs: workflow-setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [12.x, 18.x]
+        node-version: [18.x]
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -395,10 +395,10 @@ jobs:
 
   test-integration-node-wrapper:
     needs: workflow-setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [12.x, 18.x]
+        node-version: [18.x]
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3


### PR DESCRIPTION
NodeJS CI testing changes:
- upgrade host machines to ubuntu 22.04
- run only against nodejs 18, drop 12
- downgrade npm from default `9.x` to `8.x` instead (on 9x, npm can't resolve `@hyperledger/vcx-napi-rs-linux-x64-gnu` from `node-wrapper`; for example: https://github.com/hyperledger/aries-vcx/actions/runs/4166607529/jobs/7211161331)

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>