### PR TITLE
Rename connection 'Complete' state to 'Completed'

### DIFF
--- a/aries_vcx/src/protocols/connection/generic/conversions.rs
+++ b/aries_vcx/src/protocols/connection/generic/conversions.rs
@@ -4,12 +4,12 @@ use crate::{
     protocols::connection::{
         initiation_type::{Invitee, Inviter},
         invitee::states::{
-            complete::Complete as InviteeComplete, initial::Initial as InviteeInitial,
+            completed::Completed as InviteeCompleted, initial::Initial as InviteeInitial,
             invited::Invited as InviteeInvited, requested::Requested as InviteeRequested,
             responded::Responded as InviteeResponded,
         },
         inviter::states::{
-            complete::Complete as InviterComplete, initial::Initial as InviterInitial,
+            completed::Completed as InviterCompleted, initial::Initial as InviterInitial,
             invited::Invited as InviterInvited, requested::Requested as InviterRequested,
             responded::Responded as InviterResponded,
         },
@@ -108,13 +108,13 @@ from_concrete_to_vague!(InviterInitial, Initial, InviterState);
 from_concrete_to_vague!(InviterInvited, Invited, InviterState);
 from_concrete_to_vague!(InviterRequested, Requested, InviterState);
 from_concrete_to_vague!(InviterResponded, Responded, InviterState);
-from_concrete_to_vague!(InviterComplete, Complete, InviterState);
+from_concrete_to_vague!(InviterCompleted, Completed, InviterState);
 
 from_concrete_to_vague!(InviteeInitial, Initial, InviteeState);
 from_concrete_to_vague!(InviteeInvited, Invited, InviteeState);
 from_concrete_to_vague!(InviteeRequested, Requested, InviteeState);
 from_concrete_to_vague!(InviteeResponded, Responded, InviteeState);
-from_concrete_to_vague!(InviteeComplete, Complete, InviteeState);
+from_concrete_to_vague!(InviteeCompleted, Completed, InviteeState);
 
 // ---------------------------- Try From Vague State to Concrete State implementations ----------------------------
 impl<I, S> TryFrom<GenericConnection> for Connection<I, S>
@@ -137,10 +137,10 @@ try_from_vague_to_concrete!(InviterState, Initial, InviterInitial);
 try_from_vague_to_concrete!(InviterState, Invited, InviterInvited);
 try_from_vague_to_concrete!(InviterState, Requested, InviterRequested);
 try_from_vague_to_concrete!(InviterState, Responded, InviterResponded);
-try_from_vague_to_concrete!(InviterState, Complete, InviterComplete);
+try_from_vague_to_concrete!(InviterState, Completed, InviterCompleted);
 
 try_from_vague_to_concrete!(InviteeState, Initial, InviteeInitial);
 try_from_vague_to_concrete!(InviteeState, Invited, InviteeInvited);
 try_from_vague_to_concrete!(InviteeState, Requested, InviteeRequested);
 try_from_vague_to_concrete!(InviteeState, Responded, InviteeResponded);
-try_from_vague_to_concrete!(InviteeState, Complete, InviteeComplete);
+try_from_vague_to_concrete!(InviteeState, Completed, InviteeCompleted);

--- a/aries_vcx/src/protocols/connection/generic/mod.rs
+++ b/aries_vcx/src/protocols/connection/generic/mod.rs
@@ -12,12 +12,12 @@ use crate::{
     plugins::wallet::base_wallet::BaseWallet,
     protocols::connection::{
         invitee::states::{
-            complete::Complete as InviteeComplete, initial::Initial as InviteeInitial,
+            completed::Completed as InviteeCompleted, initial::Initial as InviteeInitial,
             invited::Invited as InviteeInvited, requested::Requested as InviteeRequested,
             responded::Responded as InviteeResponded,
         },
         inviter::states::{
-            complete::Complete as InviterComplete, initial::Initial as InviterInitial,
+            completed::Completed as InviterCompleted, initial::Initial as InviterInitial,
             invited::Invited as InviterInvited, requested::Requested as InviterRequested,
             responded::Responded as InviterResponded,
         },
@@ -87,7 +87,7 @@ pub enum InviterState {
     Invited(InviterInvited),
     Requested(InviterRequested),
     Responded(InviterResponded),
-    Complete(InviterComplete),
+    Completed(InviterCompleted),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -96,7 +96,7 @@ pub enum InviteeState {
     Invited(InviteeInvited),
     Requested(InviteeRequested),
     Responded(InviteeResponded),
-    Complete(InviteeComplete),
+    Completed(InviteeCompleted),
 }
 
 impl GenericConnection {
@@ -113,12 +113,12 @@ impl GenericConnection {
             GenericState::Invitee(InviteeState::Invited(s)) => Some(s.thread_id()),
             GenericState::Invitee(InviteeState::Requested(s)) => Some(s.thread_id()),
             GenericState::Invitee(InviteeState::Responded(s)) => Some(s.thread_id()),
-            GenericState::Invitee(InviteeState::Complete(s)) => Some(s.thread_id()),
+            GenericState::Invitee(InviteeState::Completed(s)) => Some(s.thread_id()),
             GenericState::Inviter(InviterState::Initial(_)) => None,
             GenericState::Inviter(InviterState::Invited(s)) => Some(s.thread_id()),
             GenericState::Inviter(InviterState::Requested(s)) => Some(s.thread_id()),
             GenericState::Inviter(InviterState::Responded(s)) => Some(s.thread_id()),
-            GenericState::Inviter(InviterState::Complete(s)) => Some(s.thread_id()),
+            GenericState::Inviter(InviterState::Completed(s)) => Some(s.thread_id()),
         }
     }
 
@@ -132,12 +132,12 @@ impl GenericConnection {
             GenericState::Invitee(InviteeState::Invited(s)) => Some(s.their_did_doc()),
             GenericState::Invitee(InviteeState::Requested(s)) => Some(s.their_did_doc()),
             GenericState::Invitee(InviteeState::Responded(s)) => Some(s.their_did_doc()),
-            GenericState::Invitee(InviteeState::Complete(s)) => Some(s.their_did_doc()),
+            GenericState::Invitee(InviteeState::Completed(s)) => Some(s.their_did_doc()),
             GenericState::Inviter(InviterState::Initial(_)) => None,
             GenericState::Inviter(InviterState::Invited(_)) => None,
             GenericState::Inviter(InviterState::Requested(s)) => Some(s.their_did_doc()),
             GenericState::Inviter(InviterState::Responded(s)) => Some(s.their_did_doc()),
-            GenericState::Inviter(InviterState::Complete(s)) => Some(s.their_did_doc()),
+            GenericState::Inviter(InviterState::Completed(s)) => Some(s.their_did_doc()),
         }
     }
 
@@ -148,7 +148,7 @@ impl GenericConnection {
             GenericState::Invitee(InviteeState::Invited(s)) => Some(s.bootstrap_did_doc()),
             GenericState::Invitee(InviteeState::Requested(s)) => Some(s.bootstrap_did_doc()),
             GenericState::Invitee(InviteeState::Responded(s)) => Some(s.bootstrap_did_doc()),
-            GenericState::Invitee(InviteeState::Complete(s)) => Some(s.bootstrap_did_doc()),
+            GenericState::Invitee(InviteeState::Completed(s)) => Some(s.bootstrap_did_doc()),
         }
     }
 
@@ -225,7 +225,7 @@ mod connection_serde_tests {
                 RefInviteeState::Invited(s) => Self::Invited(s.to_owned()),
                 RefInviteeState::Requested(s) => Self::Requested(s.to_owned()),
                 RefInviteeState::Responded(s) => Self::Responded(s.to_owned()),
-                RefInviteeState::Complete(s) => Self::Complete(s.to_owned()),
+                RefInviteeState::Completed(s) => Self::Completed(s.to_owned()),
             }
         }
     }
@@ -237,7 +237,7 @@ mod connection_serde_tests {
                 RefInviterState::Invited(s) => Self::Invited(s.to_owned()),
                 RefInviterState::Requested(s) => Self::Requested(s.to_owned()),
                 RefInviterState::Responded(s) => Self::Responded(s.to_owned()),
-                RefInviterState::Complete(s) => Self::Complete(s.to_owned()),
+                RefInviterState::Completed(s) => Self::Completed(s.to_owned()),
             }
         }
     }
@@ -274,7 +274,7 @@ mod connection_serde_tests {
                 InviteeState::Invited(s) => Self::Invited(s),
                 InviteeState::Requested(s) => Self::Requested(s),
                 InviteeState::Responded(s) => Self::Responded(s),
-                InviteeState::Complete(s) => Self::Complete(s),
+                InviteeState::Completed(s) => Self::Completed(s),
             }
         }
     }
@@ -286,7 +286,7 @@ mod connection_serde_tests {
                 InviterState::Invited(s) => Self::Invited(s),
                 InviterState::Requested(s) => Self::Requested(s),
                 InviterState::Responded(s) => Self::Responded(s),
-                InviterState::Complete(s) => Self::Complete(s),
+                InviterState::Completed(s) => Self::Completed(s),
             }
         }
     }
@@ -413,7 +413,7 @@ mod connection_serde_tests {
         con.handle_response(&wallet, response, &MockTransport).await.unwrap()
     }
 
-    async fn make_invitee_complete() -> InviteeConnection<InviteeComplete> {
+    async fn make_invitee_completed() -> InviteeConnection<InviteeCompleted> {
         let wallet = make_mock_profile().inject_wallet();
 
         make_invitee_responded()
@@ -460,7 +460,7 @@ mod connection_serde_tests {
             .unwrap()
     }
 
-    async fn make_inviter_complete() -> InviterConnection<InviterComplete> {
+    async fn make_inviter_completed() -> InviterConnection<InviterCompleted> {
         let msg = Request::create().to_a2a_message();
 
         make_inviter_responded().await.acknowledge_connection(&msg).unwrap()
@@ -480,11 +480,11 @@ mod connection_serde_tests {
     generate_test!(invitee_connection_invited, make_invitee_invited);
     generate_test!(invitee_connection_requested, make_invitee_requested);
     generate_test!(invitee_connection_responded, make_invitee_responded);
-    generate_test!(invitee_connection_complete, make_invitee_complete);
+    generate_test!(invitee_connection_complete, make_invitee_completed);
 
     generate_test!(inviter_connection_initial, make_inviter_initial);
     generate_test!(inviter_connection_invited, make_inviter_invited);
     generate_test!(inviter_connection_requested, make_inviter_requested);
     generate_test!(inviter_connection_responded, make_inviter_responded);
-    generate_test!(inviter_connection_complete, make_inviter_complete);
+    generate_test!(inviter_connection_complete, make_inviter_completed);
 }

--- a/aries_vcx/src/protocols/connection/generic/thin_state.rs
+++ b/aries_vcx/src/protocols/connection/generic/thin_state.rs
@@ -16,7 +16,7 @@ pub enum State {
     Invited,
     Requested,
     Responded,
-    Complete,
+    Completed,
 }
 
 impl From<&GenericState> for ThinState {
@@ -35,7 +35,7 @@ impl From<&InviterState> for State {
             InviterState::Invited(_) => Self::Invited,
             InviterState::Requested(_) => Self::Requested,
             InviterState::Responded(_) => Self::Responded,
-            InviterState::Complete(_) => Self::Complete,
+            InviterState::Completed(_) => Self::Completed,
         }
     }
 }
@@ -47,7 +47,7 @@ impl From<&InviteeState> for State {
             InviteeState::Invited(_) => Self::Invited,
             InviteeState::Requested(_) => Self::Requested,
             InviteeState::Responded(_) => Self::Responded,
-            InviteeState::Complete(_) => Self::Complete,
+            InviteeState::Completed(_) => Self::Completed,
         }
     }
 }

--- a/aries_vcx/src/protocols/connection/invitee/mod.rs
+++ b/aries_vcx/src/protocols/connection/invitee/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use self::states::{
-    complete::Complete, initial::Initial, invited::Invited, requested::Requested, responded::Responded,
+    completed::Completed, initial::Initial, invited::Invited, requested::Requested, responded::Responded,
 };
 
 use messages::{
@@ -182,7 +182,7 @@ impl InviteeConnection<Requested> {
 }
 
 impl InviteeConnection<Responded> {
-    /// Sends an acknowledgement message to the inviter and transitions to [`InviteeConnection<Complete>`].
+    /// Sends an acknowledgement message to the inviter and transitions to [`InviteeConnection<Completed>`].
     ///
     /// # Errors
     ///
@@ -191,7 +191,7 @@ impl InviteeConnection<Responded> {
         self,
         wallet: &Arc<dyn BaseWallet>,
         transport: &T,
-    ) -> VcxResult<InviteeConnection<Complete>>
+    ) -> VcxResult<InviteeConnection<Completed>>
     where
         T: Transport,
     {
@@ -202,7 +202,7 @@ impl InviteeConnection<Responded> {
 
         self.send_message(wallet, &msg, transport).await?;
 
-        let state = Complete::new(
+        let state = Completed::new(
             self.state.did_doc,
             self.state.bootstrap_did_doc,
             self.state.thread_id,

--- a/aries_vcx/src/protocols/connection/invitee/states/completed.rs
+++ b/aries_vcx/src/protocols/connection/invitee/states/completed.rs
@@ -3,38 +3,51 @@ use std::clone::Clone;
 use messages::diddoc::aries::diddoc::AriesDidDoc;
 use messages::protocols::discovery::disclose::{Disclose, ProtocolDescriptor};
 
-use crate::protocols::connection::trait_bounds::{CompleteState, TheirDidDoc, ThreadId};
+use crate::protocols::connection::trait_bounds::{BootstrapDidDoc, CompletedState, TheirDidDoc, ThreadId};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Complete {
+pub struct Completed {
     pub(crate) did_doc: AriesDidDoc,
+    pub(crate) bootstrap_did_doc: AriesDidDoc,
     pub(crate) thread_id: String,
     pub(crate) protocols: Option<Vec<ProtocolDescriptor>>,
 }
 
-impl Complete {
-    pub fn new(did_doc: AriesDidDoc, thread_id: String, protocols: Option<Vec<ProtocolDescriptor>>) -> Self {
+impl Completed {
+    pub fn new(
+        did_doc: AriesDidDoc,
+        bootstrap_did_doc: AriesDidDoc,
+        thread_id: String,
+        protocols: Option<Vec<ProtocolDescriptor>>,
+    ) -> Self {
         Self {
             did_doc,
+            bootstrap_did_doc,
             thread_id,
             protocols,
         }
     }
 }
 
-impl TheirDidDoc for Complete {
+impl TheirDidDoc for Completed {
     fn their_did_doc(&self) -> &AriesDidDoc {
         &self.did_doc
     }
 }
 
-impl ThreadId for Complete {
+impl BootstrapDidDoc for Completed {
+    fn bootstrap_did_doc(&self) -> &AriesDidDoc {
+        &self.bootstrap_did_doc
+    }
+}
+
+impl ThreadId for Completed {
     fn thread_id(&self) -> &str {
         &self.thread_id
     }
 }
 
-impl CompleteState for Complete {
+impl CompletedState for Completed {
     fn remote_protocols(&self) -> Option<&[ProtocolDescriptor]> {
         self.protocols.as_deref()
     }

--- a/aries_vcx/src/protocols/connection/invitee/states/mod.rs
+++ b/aries_vcx/src/protocols/connection/invitee/states/mod.rs
@@ -1,4 +1,4 @@
-pub mod complete;
+pub mod completed;
 pub mod initial;
 pub mod invited;
 pub mod requested;

--- a/aries_vcx/src/protocols/connection/inviter/mod.rs
+++ b/aries_vcx/src/protocols/connection/inviter/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 use self::states::{
-    complete::Complete, initial::Initial, invited::Invited, requested::Requested, responded::Responded,
+    completed::Completed, initial::Initial, invited::Invited, requested::Requested, responded::Responded,
 };
 use super::{initiation_type::Inviter, pairwise_info::PairwiseInfo, Connection};
 use messages::a2a::A2AMessage;
@@ -228,15 +228,15 @@ impl InviterConnection<Requested> {
 
 impl InviterConnection<Responded> {
     /// Acknowledges an invitee's connection by processing their first message
-    /// and transitions to [`InviterConnection<Complete>`].
+    /// and transitions to [`InviterConnection<Completed>`].
     ///
     /// # Errors
     ///
     /// Will error out if the message's thread ID does not match
     /// the ID of the thread context used in this connection.
-    pub fn acknowledge_connection(self, msg: &A2AMessage) -> VcxResult<InviterConnection<Complete>> {
+    pub fn acknowledge_connection(self, msg: &A2AMessage) -> VcxResult<InviterConnection<Completed>> {
         verify_thread_id(self.state.thread_id(), msg)?;
-        let state = Complete::new(self.state.did_doc, self.state.thread_id, None);
+        let state = Completed::new(self.state.did_doc, self.state.thread_id, None);
 
         Ok(Connection {
             source_id: self.source_id,

--- a/aries_vcx/src/protocols/connection/inviter/states/completed.rs
+++ b/aries_vcx/src/protocols/connection/inviter/states/completed.rs
@@ -3,51 +3,38 @@ use std::clone::Clone;
 use messages::diddoc::aries::diddoc::AriesDidDoc;
 use messages::protocols::discovery::disclose::{Disclose, ProtocolDescriptor};
 
-use crate::protocols::connection::trait_bounds::{BootstrapDidDoc, CompleteState, TheirDidDoc, ThreadId};
+use crate::protocols::connection::trait_bounds::{CompletedState, TheirDidDoc, ThreadId};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Complete {
+pub struct Completed {
     pub(crate) did_doc: AriesDidDoc,
-    pub(crate) bootstrap_did_doc: AriesDidDoc,
     pub(crate) thread_id: String,
     pub(crate) protocols: Option<Vec<ProtocolDescriptor>>,
 }
 
-impl Complete {
-    pub fn new(
-        did_doc: AriesDidDoc,
-        bootstrap_did_doc: AriesDidDoc,
-        thread_id: String,
-        protocols: Option<Vec<ProtocolDescriptor>>,
-    ) -> Self {
+impl Completed {
+    pub fn new(did_doc: AriesDidDoc, thread_id: String, protocols: Option<Vec<ProtocolDescriptor>>) -> Self {
         Self {
             did_doc,
-            bootstrap_did_doc,
             thread_id,
             protocols,
         }
     }
 }
 
-impl TheirDidDoc for Complete {
+impl TheirDidDoc for Completed {
     fn their_did_doc(&self) -> &AriesDidDoc {
         &self.did_doc
     }
 }
 
-impl BootstrapDidDoc for Complete {
-    fn bootstrap_did_doc(&self) -> &AriesDidDoc {
-        &self.bootstrap_did_doc
-    }
-}
-
-impl ThreadId for Complete {
+impl ThreadId for Completed {
     fn thread_id(&self) -> &str {
         &self.thread_id
     }
 }
 
-impl CompleteState for Complete {
+impl CompletedState for Completed {
     fn remote_protocols(&self) -> Option<&[ProtocolDescriptor]> {
         self.protocols.as_deref()
     }

--- a/aries_vcx/src/protocols/connection/inviter/states/mod.rs
+++ b/aries_vcx/src/protocols/connection/inviter/states/mod.rs
@@ -1,4 +1,4 @@
-pub mod complete;
+pub mod completed;
 pub mod initial;
 pub mod invited;
 pub mod requested;

--- a/aries_vcx/src/protocols/connection/mod.rs
+++ b/aries_vcx/src/protocols/connection/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 use self::{
     generic::GenericState,
     pairwise_info::PairwiseInfo,
-    trait_bounds::{CompleteState, HandleProblem, TheirDidDoc, ThreadId},
+    trait_bounds::{CompletedState, HandleProblem, TheirDidDoc, ThreadId},
 };
 
 pub use self::generic::{GenericConnection, State, ThinState};
@@ -169,7 +169,7 @@ where
 
 impl<I, S> Connection<I, S>
 where
-    S: CompleteState,
+    S: CompletedState,
 {
     pub fn remote_protocols(&self) -> Option<&[ProtocolDescriptor]> {
         self.state.remote_protocols()

--- a/aries_vcx/src/protocols/connection/serializable.rs
+++ b/aries_vcx/src/protocols/connection/serializable.rs
@@ -3,12 +3,14 @@ use serde::Serialize;
 use crate::protocols::connection::{
     initiation_type::{Invitee, Inviter},
     invitee::states::{
-        completed::Completed as InviteeCompleted, initial::Initial as InviteeInitial, invited::Invited as InviteeInvited,
-        requested::Requested as InviteeRequested, responded::Responded as InviteeResponded,
+        completed::Completed as InviteeCompleted, initial::Initial as InviteeInitial,
+        invited::Invited as InviteeInvited, requested::Requested as InviteeRequested,
+        responded::Responded as InviteeResponded,
     },
     inviter::states::{
-        completed::Completed as InviterCompleted, initial::Initial as InviterInitial, invited::Invited as InviterInvited,
-        requested::Requested as InviterRequested, responded::Responded as InviterResponded,
+        completed::Completed as InviterCompleted, initial::Initial as InviterInitial,
+        invited::Invited as InviterInvited, requested::Requested as InviterRequested,
+        responded::Responded as InviterResponded,
     },
     pairwise_info::PairwiseInfo,
     Connection,

--- a/aries_vcx/src/protocols/connection/serializable.rs
+++ b/aries_vcx/src/protocols/connection/serializable.rs
@@ -3,11 +3,11 @@ use serde::Serialize;
 use crate::protocols::connection::{
     initiation_type::{Invitee, Inviter},
     invitee::states::{
-        complete::Complete as InviteeComplete, initial::Initial as InviteeInitial, invited::Invited as InviteeInvited,
+        completed::Completed as InviteeCompleted, initial::Initial as InviteeInitial, invited::Invited as InviteeInvited,
         requested::Requested as InviteeRequested, responded::Responded as InviteeResponded,
     },
     inviter::states::{
-        complete::Complete as InviterComplete, initial::Initial as InviterInitial, invited::Invited as InviterInvited,
+        completed::Completed as InviterCompleted, initial::Initial as InviterInitial, invited::Invited as InviterInvited,
         requested::Requested as InviterRequested, responded::Responded as InviterResponded,
     },
     pairwise_info::PairwiseInfo,
@@ -63,7 +63,7 @@ pub enum RefInviterState<'a> {
     Invited(&'a InviterInvited),
     Requested(&'a InviterRequested),
     Responded(&'a InviterResponded),
-    Complete(&'a InviterComplete),
+    Completed(&'a InviterCompleted),
 }
 
 #[derive(Debug, Serialize)]
@@ -72,7 +72,7 @@ pub enum RefInviteeState<'a> {
     Invited(&'a InviteeInvited),
     Requested(&'a InviteeRequested),
     Responded(&'a InviteeResponded),
-    Complete(&'a InviteeComplete),
+    Completed(&'a InviteeCompleted),
 }
 
 impl<'a, I, S> From<&'a Connection<I, S>> for SerializableConnection<'a>
@@ -94,13 +94,13 @@ from_concrete_to_serializable!(InviterInitial, Initial, RefInviterState);
 from_concrete_to_serializable!(InviterInvited, Invited, RefInviterState);
 from_concrete_to_serializable!(InviterRequested, Requested, RefInviterState);
 from_concrete_to_serializable!(InviterResponded, Responded, RefInviterState);
-from_concrete_to_serializable!(InviterComplete, Complete, RefInviterState);
+from_concrete_to_serializable!(InviterCompleted, Completed, RefInviterState);
 
 from_concrete_to_serializable!(InviteeInitial, Initial, RefInviteeState);
 from_concrete_to_serializable!(InviteeInvited, Invited, RefInviteeState);
 from_concrete_to_serializable!(InviteeRequested, Requested, RefInviteeState);
 from_concrete_to_serializable!(InviteeResponded, Responded, RefInviteeState);
-from_concrete_to_serializable!(InviteeComplete, Complete, RefInviteeState);
+from_concrete_to_serializable!(InviteeCompleted, Completed, RefInviteeState);
 
 impl<'a> SerializableConnection<'a> {
     fn new(source_id: &'a str, pairwise_info: &'a PairwiseInfo, state: RefState<'a>) -> Self {

--- a/aries_vcx/src/protocols/connection/trait_bounds.rs
+++ b/aries_vcx/src/protocols/connection/trait_bounds.rs
@@ -23,8 +23,8 @@ pub trait ThreadId {
     fn thread_id(&self) -> &str;
 }
 
-/// Trait impletement for [`super::Connection`] in complete states.
-pub trait CompleteState {
+/// Trait impletement for [`super::Connection`] in completed states.
+pub trait CompletedState {
     fn remote_protocols(&self) -> Option<&[ProtocolDescriptor]>;
 
     fn handle_disclose(&mut self, disclose: Disclose);

--- a/aries_vcx/src/protocols/mediated_connection/invitee/state_machine.rs
+++ b/aries_vcx/src/protocols/mediated_connection/invitee/state_machine.rs
@@ -6,7 +6,7 @@ use crate::common::signing::decode_signed_connection_response;
 use crate::errors::error::prelude::*;
 use crate::handlers::util::verify_thread_id;
 use crate::plugins::wallet::base_wallet::BaseWallet;
-use crate::protocols::mediated_connection::invitee::states::complete::CompleteState;
+use crate::protocols::mediated_connection::invitee::states::completed::CompletedState;
 use crate::protocols::mediated_connection::invitee::states::initial::InitialState;
 use crate::protocols::mediated_connection::invitee::states::invited::InvitedState;
 use crate::protocols::mediated_connection::invitee::states::requested::RequestedState;
@@ -37,7 +37,7 @@ pub enum InviteeFullState {
     Invited(InvitedState),
     Requested(RequestedState),
     Responded(RespondedState),
-    Completed(CompleteState),
+    Completed(CompletedState),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/aries_vcx/src/protocols/mediated_connection/invitee/states/completed.rs
+++ b/aries_vcx/src/protocols/mediated_connection/invitee/states/completed.rs
@@ -7,16 +7,16 @@ use messages::protocols::connection::response::Response;
 use messages::protocols::discovery::disclose::ProtocolDescriptor;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CompleteState {
+pub struct CompletedState {
     pub did_doc: AriesDidDoc,
     pub bootstrap_did_doc: AriesDidDoc,
     pub protocols: Option<Vec<ProtocolDescriptor>>,
 }
 
-impl From<(CompleteState, Vec<ProtocolDescriptor>)> for CompleteState {
-    fn from((state, protocols): (CompleteState, Vec<ProtocolDescriptor>)) -> CompleteState {
+impl From<(CompletedState, Vec<ProtocolDescriptor>)> for CompletedState {
+    fn from((state, protocols): (CompletedState, Vec<ProtocolDescriptor>)) -> CompletedState {
         trace!("ConnectionInvitee: transit state from CompleteState to CompleteState");
-        CompleteState {
+        CompletedState {
             bootstrap_did_doc: state.bootstrap_did_doc,
             did_doc: state.did_doc,
             protocols: Some(protocols),
@@ -24,10 +24,10 @@ impl From<(CompleteState, Vec<ProtocolDescriptor>)> for CompleteState {
     }
 }
 
-impl From<(RequestedState, Response)> for CompleteState {
-    fn from((state, response): (RequestedState, Response)) -> CompleteState {
+impl From<(RequestedState, Response)> for CompletedState {
+    fn from((state, response): (RequestedState, Response)) -> CompletedState {
         trace!("ConnectionInvitee: transit state from RequestedState to CompleteState");
-        CompleteState {
+        CompletedState {
             bootstrap_did_doc: state.did_doc,
             did_doc: response.connection.did_doc,
             protocols: None,
@@ -35,10 +35,10 @@ impl From<(RequestedState, Response)> for CompleteState {
     }
 }
 
-impl From<RespondedState> for CompleteState {
-    fn from(state: RespondedState) -> CompleteState {
+impl From<RespondedState> for CompletedState {
+    fn from(state: RespondedState) -> CompletedState {
         trace!("ConnectionInvitee: transit state from RespondedState to CompleteState");
-        CompleteState {
+        CompletedState {
             bootstrap_did_doc: state.did_doc,
             did_doc: state.response.connection.did_doc,
             protocols: None,

--- a/aries_vcx/src/protocols/mediated_connection/invitee/states/mod.rs
+++ b/aries_vcx/src/protocols/mediated_connection/invitee/states/mod.rs
@@ -1,4 +1,4 @@
-pub(super) mod complete;
+pub(super) mod completed;
 pub(super) mod initial;
 pub(super) mod invited;
 pub(super) mod requested;

--- a/aries_vcx/src/protocols/mediated_connection/inviter/state_machine.rs
+++ b/aries_vcx/src/protocols/mediated_connection/inviter/state_machine.rs
@@ -15,7 +15,7 @@ use crate::common::signing::sign_connection_response;
 use crate::errors::error::prelude::*;
 use crate::handlers::util::verify_thread_id;
 use crate::plugins::wallet::base_wallet::BaseWallet;
-use crate::protocols::mediated_connection::inviter::states::complete::CompleteState;
+use crate::protocols::mediated_connection::inviter::states::completed::CompletedState;
 use crate::protocols::mediated_connection::inviter::states::initial::InitialState;
 use crate::protocols::mediated_connection::inviter::states::invited::InvitedState;
 use crate::protocols::mediated_connection::inviter::states::requested::RequestedState;
@@ -37,7 +37,7 @@ pub enum InviterFullState {
     Invited(InvitedState),
     Requested(RequestedState),
     Responded(RespondedState),
-    Completed(CompleteState),
+    Completed(CompletedState),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/aries_vcx/src/protocols/mediated_connection/inviter/states/completed.rs
+++ b/aries_vcx/src/protocols/mediated_connection/inviter/states/completed.rs
@@ -4,16 +4,16 @@ use messages::diddoc::aries::diddoc::AriesDidDoc;
 use messages::protocols::discovery::disclose::ProtocolDescriptor;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CompleteState {
+pub struct CompletedState {
     pub did_doc: AriesDidDoc,
     pub protocols: Option<Vec<ProtocolDescriptor>>,
     pub thread_id: Option<String>,
 }
 
-impl From<(CompleteState, Vec<ProtocolDescriptor>)> for CompleteState {
-    fn from((state, protocols): (CompleteState, Vec<ProtocolDescriptor>)) -> CompleteState {
+impl From<(CompletedState, Vec<ProtocolDescriptor>)> for CompletedState {
+    fn from((state, protocols): (CompletedState, Vec<ProtocolDescriptor>)) -> CompletedState {
         trace!("ConnectionInviter: transit state from CompleteState to CompleteState");
-        CompleteState {
+        CompletedState {
             did_doc: state.did_doc,
             thread_id: state.thread_id,
             protocols: Some(protocols),

--- a/aries_vcx/src/protocols/mediated_connection/inviter/states/mod.rs
+++ b/aries_vcx/src/protocols/mediated_connection/inviter/states/mod.rs
@@ -1,4 +1,4 @@
-pub(super) mod complete;
+pub(super) mod completed;
 pub(super) mod initial;
 pub(super) mod invited;
 pub(super) mod requested;

--- a/aries_vcx/src/protocols/mediated_connection/inviter/states/responded.rs
+++ b/aries_vcx/src/protocols/mediated_connection/inviter/states/responded.rs
@@ -5,7 +5,7 @@ use messages::diddoc::aries::diddoc::AriesDidDoc;
 use messages::protocols::connection::problem_report::ProblemReport;
 use messages::protocols::connection::response::SignedResponse;
 
-use crate::protocols::mediated_connection::inviter::states::complete::CompleteState;
+use crate::protocols::mediated_connection::inviter::states::completed::CompletedState;
 use crate::protocols::mediated_connection::inviter::states::initial::InitialState;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -24,10 +24,10 @@ impl From<(RespondedState, ProblemReport)> for InitialState {
     }
 }
 
-impl From<RespondedState> for CompleteState {
-    fn from(state: RespondedState) -> CompleteState {
+impl From<RespondedState> for CompletedState {
+    fn from(state: RespondedState) -> CompletedState {
         trace!("ConnectionInviter: transit state from RespondedState to CompleteState");
-        CompleteState {
+        CompletedState {
             did_doc: state.did_doc,
             thread_id: Some(state.signed_response.get_thread_id()),
             protocols: None,


### PR DESCRIPTION
- We are using past tense form to name protocol states, for example `Requested`, `Finished`, `Sent`, except for Connection's `Complete` state. This PR unifies the naming, renaming `Complete -> Completed`
- Mediated Connection note: although it's discouraged to rely on the serialized form of state machines, note that mediated connection even previously serialized `Complete` state as `"Completed"`, so this does not present any practical change for mediated connection, but purely internal. 

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>