### PR TITLE
Experiment - Vdrtools as a feature flag

### DIFF
--- a/agents/rust/aries-vcx-agent/src/agent/init.rs
+++ b/agents/rust/aries-vcx-agent/src/agent/init.rs
@@ -71,7 +71,7 @@ impl Agent {
         let config_issuer = wallet_configure_issuer(wallet_handle, &init_config.enterprise_seed)
             .await
             .unwrap();
-        init_issuer_config(&config_issuer).unwrap();
+        init_issuer_config(&config_issuer.institution_did).unwrap();
 
         let pool_config = PoolConfigBuilder::default()
             .genesis_path(&init_config.pool_config.genesis_path)

--- a/aries_vcx/Cargo.toml
+++ b/aries_vcx/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/lib.rs"
 doctest = false
 
 [features]
+default = ["vdrtools"]
+vdrtools = ["dep:libvdrtools"]
 test_utils = [ "messages/test_utils" ]
 pool_tests = [ "test_utils" ]
 agency_pool_tests = [ "test_utils" ]
@@ -35,7 +37,7 @@ serde_derive = "1.0.97"
 regex = "1.1.0"
 base64 = "0.10"
 openssl = { version = "0.10.35" }
-libvdrtools = { path = "../libvdrtools" }
+libvdrtools = { path = "../libvdrtools", optional = true }
 # vdrtools alternatives ----
 indy-vdr = { version = "0.3.4", default-features = false, features = ["ffi", "log"] }
 # PATCH (TO MONITOR IN FUTURE): The following patch changes the `indy-data-types` (within indy-shared-rs) to depend on

--- a/aries_vcx/src/common/primitives/credential_definition.rs
+++ b/aries_vcx/src/common/primitives/credential_definition.rs
@@ -1,9 +1,10 @@
 use crate::core::profile::profile::Profile;
 use crate::errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult};
-use crate::indy::utils::LibindyMock;
 use crate::plugins::ledger::base_ledger::BaseLedger;
 use crate::utils::constants::{CRED_DEF_ID, CRED_DEF_JSON, DEFAULT_SERIALIZE_VERSION};
 use crate::utils::serialization::ObjectWithVersion;
+#[cfg(feature = "vdrtools")]
+use crate::indy::utils::LibindyMock;
 
 use crate::global::settings::{self, indy_mocks_enabled};
 use std::fmt;
@@ -110,6 +111,7 @@ async fn _try_get_cred_def_from_ledger(
     // TODO - future - may require more customized logic. We set the rc to 309, as the mock for ledger.get_cred_def will return a valid
     // mock cred def unless it reads an rc of 309. Returning a valid mock cred def will result in this method returning an error.
     if indy_mocks_enabled() {
+        #[cfg(feature = "vdrtools")]
         LibindyMock::set_next_result(309)
     }
     match ledger.get_cred_def(cred_def_id, Some(issuer_did)).await {

--- a/aries_vcx/src/core/profile/mod.rs
+++ b/aries_vcx/src/core/profile/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "vdrtools")]
 pub mod indy_profile;
 pub mod modular_wallet_profile;
 pub mod profile;

--- a/aries_vcx/src/errors/mod.rs
+++ b/aries_vcx/src/errors/mod.rs
@@ -5,4 +5,5 @@ mod mapping_diddoc;
 mod mapping_indyvdr;
 mod mapping_messages;
 mod mapping_others;
+#[cfg(feature = "vdrtools")]
 mod mapping_vdrtools;

--- a/aries_vcx/src/global/settings.rs
+++ b/aries_vcx/src/global/settings.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use crate::errors::error::prelude::*;
-use crate::indy::wallet::IssuerConfig;
 
 pub static CONFIG_POOL_NAME: &str = "pool_name";
 pub static CONFIG_SDK_TO_REMOTE_ROLE: &str = "sdk_to_remote_role";
@@ -185,7 +184,7 @@ pub mod unit_tests {
     }
 }
 
-pub fn init_issuer_config(config: &IssuerConfig) -> VcxResult<()> {
-    set_config_value(CONFIG_INSTITUTION_DID, &config.institution_did)?;
+pub fn init_issuer_config(institution_did: &str) -> VcxResult<()> {
+    set_config_value(CONFIG_INSTITUTION_DID, institution_did)?;
     Ok(())
 }

--- a/aries_vcx/src/lib.rs
+++ b/aries_vcx/src/lib.rs
@@ -13,6 +13,7 @@
 pub extern crate agency_client;
 
 // TODO: remove reexports
+#[cfg(feature = "vdrtools")]
 pub extern crate vdrtools;
 
 #[macro_use]
@@ -42,6 +43,7 @@ pub mod utils;
 pub mod handlers;
 
 pub mod global;
+#[cfg(feature = "vdrtools")]
 pub mod indy;
 pub mod protocols;
 

--- a/aries_vcx/src/plugins/anoncreds/mod.rs
+++ b/aries_vcx/src/plugins/anoncreds/mod.rs
@@ -1,3 +1,4 @@
 pub mod base_anoncreds;
 pub mod credx_anoncreds;
+#[cfg(feature = "vdrtools")]
 pub mod indy_anoncreds;

--- a/aries_vcx/src/plugins/ledger/mod.rs
+++ b/aries_vcx/src/plugins/ledger/mod.rs
@@ -1,3 +1,4 @@
 pub mod base_ledger;
+#[cfg(feature = "vdrtools")]
 pub mod indy_ledger;
 pub mod indy_vdr_ledger;

--- a/aries_vcx/src/plugins/wallet/mod.rs
+++ b/aries_vcx/src/plugins/wallet/mod.rs
@@ -1,3 +1,4 @@
 pub mod agency_client_wallet;
 pub mod base_wallet;
+#[cfg(feature = "vdrtools")]
 pub mod indy_wallet;

--- a/aries_vcx/src/utils/mockdata/profile/mock_anoncreds.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_anoncreds.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use crate::errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult};
 use crate::{
     global::settings,
-    indy::utils::LibindyMock,
     plugins::anoncreds::base_anoncreds::BaseAnonCreds,
     utils::{
         self,
@@ -11,6 +10,8 @@ use crate::{
         mockdata::mock_settings::get_mock_creds_retrieved_for_proof_request,
     },
 };
+#[cfg(feature = "vdrtools")]
+use crate::indy::utils::LibindyMock;
 
 #[derive(Debug)]
 pub(crate) struct MockAnoncreds;
@@ -65,8 +66,8 @@ impl BaseAnonCreds for MockAnoncreds {
     }
 
     async fn issuer_create_credential_offer(&self, _cred_def_id: &str) -> VcxResult<String> {
-        let rc = LibindyMock::get_result();
-        if rc != 0 {
+        #[cfg(feature = "vdrtools")]
+        if LibindyMock::get_result() != 0 {
             return Err(AriesVcxError::from_msg(
                 AriesVcxErrorKind::InvalidState,
                 "Mocked error result of issuer_create_credential_offer",

--- a/aries_vcx/src/utils/mockdata/profile/mock_ledger.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_ledger.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use crate::errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult};
 use crate::{
     common::primitives::revocation_registry::RevocationRegistryDefinition,
-    indy::utils::LibindyMock,
     plugins::ledger::base_ledger::BaseLedger,
     utils::{
         self,
@@ -12,6 +11,8 @@ use crate::{
         },
     },
 };
+#[cfg(feature = "vdrtools")]
+use crate::indy::utils::LibindyMock;
 
 #[derive(Debug)]
 pub(crate) struct MockLedger;
@@ -71,8 +72,8 @@ impl BaseLedger for MockLedger {
     async fn get_cred_def(&self, cred_def_id: &str, submitter_did: Option<&str>) -> VcxResult<String> {
         // TODO - FUTURE - below error is required for tests to pass which require a cred def to not exist (libvcx)
         // ideally we can migrate away from it
-        let rc = LibindyMock::get_result();
-        if rc == 309 {
+        #[cfg(feature = "vdrtools")]
+        if  LibindyMock::get_result() == 309 {
             return Err(AriesVcxError::from_msg(
                 AriesVcxErrorKind::LedgerItemNotFound,
                 "Mocked error".to_string(),

--- a/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
@@ -2,10 +2,11 @@ use async_trait::async_trait;
 
 use crate::errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult};
 use crate::{
-    indy::utils::mocks::did_mocks::DidMocks,
     plugins::wallet::base_wallet::BaseWallet,
     utils::{self, async_fn_iterator::AsyncFnIterator},
 };
+#[cfg(feature = "vdrtools")]
+use crate::indy::utils::mocks::did_mocks::DidMocks;
 
 #[derive(Debug)]
 pub(crate) struct MockWallet;
@@ -94,13 +95,13 @@ impl BaseWallet for MockWallet {
 }
 
 fn get_next_mock_did_response_or_fail() -> VcxResult<String> {
+    #[cfg(feature = "vdrtools")]
     if DidMocks::has_did_mock_responses() {
         warn!("key_for_local_did >> retrieving did mock response");
-        Ok(DidMocks::get_next_did_response())
-    } else {
-        Err(AriesVcxError::from_msg(
-            AriesVcxErrorKind::UnimplementedFeature,
-            "DidMocks data for must be set",
-        ))
-    }
+        return Ok(DidMocks::get_next_did_response())
+    };
+    Err(AriesVcxError::from_msg(
+        AriesVcxErrorKind::UnimplementedFeature,
+        "DidMocks data for must be set",
+    ))
 }

--- a/aries_vcx/src/utils/mod.rs
+++ b/aries_vcx/src/utils/mod.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
-
+#[cfg(feature = "vdrtools")]
 use vdrtools::types::validation::Validatable;
 
 use messages::a2a::A2AMessage;
@@ -101,6 +101,7 @@ pub async fn send_message_anonymously(
     Ok(())
 }
 
+#[cfg(feature = "vdrtools")]
 pub fn parse_and_validate<'a, T>(s: &'a str) -> VcxResult<T>
 where
     T: Validatable,

--- a/libvcx_core/src/api_vcx/api_global/settings.rs
+++ b/libvcx_core/src/api_vcx/api_global/settings.rs
@@ -18,5 +18,5 @@ pub fn get_config_value(key: &str) -> LibvcxResult<String> {
 }
 
 pub fn settings_init_issuer_config(issuer_config: &IssuerConfig) -> LibvcxResult<()> {
-    map_ariesvcx_result(init_issuer_config(issuer_config))
+    map_ariesvcx_result(init_issuer_config(&issuer_config.institution_did))
 }


### PR DESCRIPTION
This is mostly just an experimental proof of concept to put all aries-vcx usages of libvdrtools under a feature flag (which aries-vcx has as a default flag).

The idea is that consumers who do not want to use vdrtools dependencies (e.g. using modular deps or their even own deps instead), can override the default flag and use their own `Profile`. This way the consumer does not have to pull in the heavy-weight deps of libvdrtools

I imagine once the modular deps (i.e. issuer&verifer & askar-wallet) implementations are fleshed out, we would have a feature flag for those implementations as well, and then importing consumers can toggle between what they wish to use.