### PR TITLE
Avoid misusing peer dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ env:
   DOCKER_REPO_LOCAL_ANDROID: android-test
 
   RUST_TOOLCHAIN_VERSON: 1.64.0
-  NODE_VERSION: 18
+  NODE_VERSION: 18.x
 
 jobs:
   verify-code-formatting:
@@ -203,9 +203,9 @@ jobs:
           branch-main: ${{ env.MAIN_BRANCH }}
           docker-repo-local-name: ${{ env.DOCKER_REPO_LOCAL_ANDROID }}
 
-#
-#  #  ##########################################################################################
-#  #  ##############################   DOCKER PUBLISH   ########################################
+
+  ##########################################################################################
+  ##############################   DOCKER PUBLISH   ########################################
 
   publish-docker-libvcx:
     runs-on: ubuntu-20.04
@@ -233,8 +233,8 @@ jobs:
           docker-img: ${{ env.DOCKER_IMG_CACHED }}
           publish-version: ${{ env.PUBLISH_VERSION }}
 
-#  #  ##########################################################################################
-#  #  ###############################    CODECOV    ###########################################
+  ##########################################################################################
+  ###############################    CODECOV    ###########################################
 
   code-coverage-aries-vcx-unit-tests:
     needs: workflow-setup
@@ -326,8 +326,8 @@ jobs:
           name: code-coverage-report-unit-aries-vcx
           path: /tmp/artifacts/coverage
 
-#  #  ##########################################################################################
-#  #  ###############################    TESTING    ###########################################
+  ##########################################################################################
+  ###############################    TESTING    ###########################################
 
   test-unit-workspace:
     needs: workflow-setup
@@ -622,8 +622,8 @@ jobs:
           name: libvcx.dylib
           path: target/release/libvcx.dylib
 
-#  #  ##########################################################################################
-#  #  ############################   NPMJS PUBLISHING   #######################################
+  ##########################################################################################
+  ############################   NPMJS PUBLISHING   #######################################
 
   publish-node-wrapper:
     runs-on: ubuntu-20.04
@@ -635,6 +635,7 @@ jobs:
       - test-integration-aries-vcx-mysql
       - test-node-wrapper
       - test-integration-node-wrapper
+      - publish-napi
     env:
       PUBLISH_VERSION: ${{needs.workflow-setup.outputs.PUBLISH_VERSION}}
     steps:
@@ -643,7 +644,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
       - name: "Run tests"
         run: |
           if [[ "$PUBLISH_VERSION" ]]
@@ -663,18 +664,18 @@ jobs:
       - test-integration-aries-vcx-mysql
       - test-node-wrapper
       - test-integration-node-wrapper
+      - publish-napi
+      - publish-node-wrapper
     env:
       NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
       PUBLISH_VERSION: ${{needs.workflow-setup.outputs.PUBLISH_VERSION}}
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
-      - name: "Docker Login"
-        uses: azure/docker-login@v1
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
         with:
-          login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: $GITHUB_ACTOR
-          password: ${{ secrets.GITHUB_TOKEN }}
+          node-version: ${{ env.NODE_VERSION }}
       - name: "Release agent-core package"
         run: |
           if [[ "$PUBLISH_VERSION" ]]
@@ -763,8 +764,8 @@ jobs:
           npmjs-token: ${{ secrets.NPMJS_TOKEN }}
           node-version: ${{ env.NODE_VERSION }}
 
-  #  ##########################################################################################
-  #  ##############################      RELEASE      #########################################
+  ##########################################################################################
+  ##############################      RELEASE      #########################################
 
   make-release:
     runs-on: ubuntu-20.04

--- a/agents/node/vcxagent-core/package.json
+++ b/agents/node/vcxagent-core/package.json
@@ -48,6 +48,7 @@
     "test:integration:nonmediated-connection": "jest --forceExit --env=node --runInBand test/nonmediated-connection.spec.js"
   },
   "dependencies": {
+    "@hyperledger/node-vcx-wrapper": "file:../../../wrappers/node",
     "axios": "^0.27.2",
     "ffi-napi": "^4.0.3",
     "fs-extra": "^4.0.3",
@@ -58,7 +59,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@hyperledger/node-vcx-wrapper": "file:../../../wrappers/node",
     "body-parser": "^1.19.0",
     "command-line-args": "^5.2.0",
     "command-line-usage": "^5.0.5",
@@ -68,9 +68,5 @@
     "readline-sync": "^1.4.10",
     "standard": "^16.0.4",
     "winston": "^3.3.3"
-  },
-  "peerDependencies": {
-    "@hyperledger/node-vcx-wrapper": "^0.52.0",
-    "@hyperledger/vcx-napi-rs": "^0.52.0"
   }
 }

--- a/agents/node/vcxagent-core/publish.sh
+++ b/agents/node/vcxagent-core/publish.sh
@@ -16,13 +16,7 @@ fi
 
 cd "$(dirname "$0")" || exit
 echo '//registry.npmjs.org/:_authToken=${NPMJS_TOKEN}' > .npmrc
-
-# transpile TS to JS
-cd  ../../../wrappers/node || exit
-npm install
-npm run compile
-
-cd - || exit
+npm install --save-exact @hyperledger/node-vcx-wrapper@${PUBLISH_VERSION} || exitWithErrMsg "Failed to install @hyperledger/node-vcx-wrapper@${PUBLISH_VERSION}"
 npm install
 npm version $PUBLISH_VERSION
 npm publish

--- a/wrappers/node/package-lock.json
+++ b/wrappers/node/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@hyperledger/vcx-napi-rs": "file:../vcx-napi-rs",
         "fs-extra": "^4.0.2",
         "lodash": "^4.17.21",
         "uuid": "^8.3.2",
         "weak-napi": "^2.0.2"
       },
       "devDependencies": {
-        "@hyperledger/vcx-napi-rs": "../vcx-napi-rs",
         "@types/app-module-path": "^2.2.0",
         "@types/chai": "^4.2.22",
         "@types/lodash": "^4.14.177",
@@ -34,14 +34,9 @@
         "prettier": "^2.5.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.4"
-      },
-      "peerDependencies": {
-        "@hyperledger/vcx-napi-rs": "^0.52.0"
       }
     },
     "../vcx-napi-rs": {
-      "name": "@hyperledger/vcx-napi-rs",
-      "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.9.1",
@@ -3174,7 +3169,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -3567,7 +3563,8 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
       "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "3.4.1",

--- a/wrappers/node/package.json
+++ b/wrappers/node/package.json
@@ -34,6 +34,7 @@
     "fs-extra": "^4.0.2",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2",
+    "@hyperledger/vcx-napi-rs": "file:../vcx-napi-rs",
     "weak-napi": "^2.0.2"
   },
   "devDependencies": {
@@ -54,11 +55,7 @@
     "mocha": "^9.2.2",
     "prettier": "^2.5.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.4",
-    "@hyperledger/vcx-napi-rs": "../vcx-napi-rs"
-  },
-  "peerDependencies": {
-    "@hyperledger/vcx-napi-rs": "^0.52.0"
+    "typescript": "^4.8.4"
   },
   "scripts": {
     "tscversion": "tsc --version",

--- a/wrappers/node/publish.sh
+++ b/wrappers/node/publish.sh
@@ -16,6 +16,7 @@ fi
 
 cd "$(dirname "$0")" || exit
 echo '//registry.npmjs.org/:_authToken=${NPMJS_TOKEN}' > .npmrc
+npm install --save-exact @hyperledger/vcx-napi-rs@${PUBLISH_VERSION} || exitWithErrMsg "Failed to install @hyperledger/vcx-napi-rs@${PUBLISH_VERSION}"
 npm install
 npm run compile
 npm version $PUBLISH_VERSION


### PR DESCRIPTION
We have the following local dependency chain of node modules in the project:

`@hyperledger/vcx-napi-rs` -> `@hyperledger/node-vcx-wrapper` -> `@hyperledger/vcxagent-core`

Currently, we are specifying local node dependencies twice:

* as `devDependencies` (via relative path) for local development, and
* as `peerDependencies` (referring to a previously published version) for publishing.

Moreover:
* `vcxagent-core`, unnecessarily specifies both `node-vcx-wrapper` and `vcx-napi-rs` dependency, and
* since all publish CI jobs run in parallel, both `node-vcx-wrapper` and `vcxagent-core` use the version of a previous release of their dependencies for publishing.

The current approach is obviously not ideal and causes version resolution issues when both `node-vcx-wrapper` and `vcxagent-core` (of the same version) are installed in the same package.

This PR eliminates duplicate imports, replaces peer with prod dependencies via a relative path for local development and sets the appropriate version before publishing (which now happens sequentially in the order of dependence).