### PR TITLE
Fix node publishing

### DIFF
--- a/agents/node/vcxagent-core/publish.sh
+++ b/agents/node/vcxagent-core/publish.sh
@@ -18,5 +18,5 @@ cd "$(dirname "$0")" || exit
 echo '//registry.npmjs.org/:_authToken=${NPMJS_TOKEN}' > .npmrc
 npm install --save-exact @hyperledger/node-vcx-wrapper@${PUBLISH_VERSION} || exitWithErrMsg "Failed to install @hyperledger/node-vcx-wrapper@${PUBLISH_VERSION}"
 npm install
-npm version $PUBLISH_VERSION
+npm version --no-git-tag-version $PUBLISH_VERSION
 npm publish

--- a/wrappers/node/publish.sh
+++ b/wrappers/node/publish.sh
@@ -19,5 +19,5 @@ echo '//registry.npmjs.org/:_authToken=${NPMJS_TOKEN}' > .npmrc
 npm install --save-exact @hyperledger/vcx-napi-rs@${PUBLISH_VERSION} || exitWithErrMsg "Failed to install @hyperledger/vcx-napi-rs@${PUBLISH_VERSION}"
 npm install
 npm run compile
-npm version $PUBLISH_VERSION
+npm version --no-git-tag-version $PUBLISH_VERSION
 npm publish


### PR DESCRIPTION
After changes made in #783, `package.json` is modified before running `npm version`, which makes `npm version` error with `Git working directory not clean`, as it attempts to tag HEAD. This fix disables this default behavior.