### PR TITLE
Profiles refactoring

### DIFF
--- a/agents/rust/aries-vcx-agent/src/agent/init.rs
+++ b/agents/rust/aries-vcx-agent/src/agent/init.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use aries_vcx::{
     agency_client::{agency_client::AgencyClient, configuration::AgentProvisionConfig},
-    core::profile::{indy_profile::IndySdkProfile, profile::Profile},
+    core::profile::{profile::Profile, vdrtools_profile::VdrtoolsProfile},
     global::settings::init_issuer_config,
     indy::{
         ledger::pool::{create_pool_ledger_config, open_pool_ledger, PoolConfigBuilder},
@@ -86,7 +86,7 @@ impl Agent {
             .await
             .unwrap();
 
-        let indy_profile = IndySdkProfile::new(wallet_handle, pool_handle);
+        let indy_profile = VdrtoolsProfile::new(wallet_handle, pool_handle);
         let profile: Arc<dyn Profile> = Arc::new(indy_profile);
         let wallet = profile.inject_wallet();
 

--- a/aries_vcx/src/common/test_utils.rs
+++ b/aries_vcx/src/common/test_utils.rs
@@ -8,8 +8,8 @@ use crate::common::credentials::encoding::encode_attributes;
 use crate::common::primitives::credential_definition::CredentialDef;
 use crate::common::primitives::credential_definition::CredentialDefConfigBuilder;
 use crate::common::primitives::revocation_registry::RevocationRegistry;
-use crate::core::profile::indy_profile::IndySdkProfile;
 use crate::core::profile::profile::Profile;
+use crate::core::profile::vdrtools_profile::VdrtoolsProfile;
 use crate::global::settings;
 use crate::utils::constants::{DEFAULT_SCHEMA_ATTRS, TAILS_DIR, TEST_TAILS_URL, TRUSTEE_SEED};
 use crate::utils::get_temp_dir_path;
@@ -437,5 +437,5 @@ pub fn mock_profile() -> Arc<dyn Profile> {
 
 // TODO - FUTURE - should only be used for quick mock setups, should be removable after full detachment from vdrtools dep
 pub fn indy_handles_to_profile(wallet_handle: WalletHandle, pool_handle: PoolHandle) -> Arc<dyn Profile> {
-    Arc::new(IndySdkProfile::new(wallet_handle, pool_handle))
+    Arc::new(VdrtoolsProfile::new(wallet_handle, pool_handle))
 }

--- a/aries_vcx/src/core/profile/indy_profile.rs
+++ b/aries_vcx/src/core/profile/indy_profile.rs
@@ -10,34 +10,36 @@ use crate::plugins::{
 
 use super::profile::Profile;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug)]
 pub struct IndySdkProfile {
-    pub indy_wallet_handle: WalletHandle,
-    pub indy_pool_handle: PoolHandle,
+    wallet: Arc<dyn BaseWallet>,
+    ledger: Arc<dyn BaseLedger>,
+    anoncreds: Arc<dyn BaseAnonCreds>,
 }
 
 impl IndySdkProfile {
     pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
+        let wallet = Arc::new(IndySdkWallet::new(indy_wallet_handle));
+        let ledger = Arc::new(IndySdkLedger::new(indy_wallet_handle, indy_pool_handle));
+        let anoncreds = Arc::new(IndySdkAnonCreds::new(indy_wallet_handle, indy_pool_handle));
         IndySdkProfile {
-            indy_wallet_handle,
-            indy_pool_handle,
+            wallet,
+            ledger,
+            anoncreds,
         }
     }
 }
 
 impl Profile for IndySdkProfile {
     fn inject_ledger(self: Arc<Self>) -> Arc<dyn BaseLedger> {
-        // TODO - future -we should lazy eval and avoid creating a new instance each time
-        Arc::new(IndySdkLedger::new(self))
+        Arc::clone(&self.ledger)
     }
 
     fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds> {
-        // TODO - future -we should lazy eval and avoid creating a new instance each time
-        Arc::new(IndySdkAnonCreds::new(self))
+        Arc::clone(&self.anoncreds)
     }
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {
-        // TODO - future -we should lazy eval and avoid creating a new instance each time
-        Arc::new(IndySdkWallet::new(self.indy_wallet_handle))
+        Arc::clone(&self.wallet)
     }
 }

--- a/aries_vcx/src/core/profile/indy_profile.rs
+++ b/aries_vcx/src/core/profile/indy_profile.rs
@@ -31,13 +31,13 @@ impl Profile for IndySdkProfile {
         Arc::new(IndySdkLedger::new(self))
     }
 
-    fn inject_wallet(&self) -> Arc<dyn BaseWallet> {
-        // TODO - future -we should lazy eval and avoid creating a new instance each time
-        Arc::new(IndySdkWallet::new(self.indy_wallet_handle))
-    }
-
     fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds> {
         // TODO - future -we should lazy eval and avoid creating a new instance each time
         Arc::new(IndySdkAnonCreds::new(self))
+    }
+
+    fn inject_wallet(&self) -> Arc<dyn BaseWallet> {
+        // TODO - future -we should lazy eval and avoid creating a new instance each time
+        Arc::new(IndySdkWallet::new(self.indy_wallet_handle))
     }
 }

--- a/aries_vcx/src/core/profile/mod.rs
+++ b/aries_vcx/src/core/profile/mod.rs
@@ -1,3 +1,3 @@
-pub mod indy_profile;
 pub mod modular_libs_profile;
 pub mod profile;
+pub mod vdrtools_profile;

--- a/aries_vcx/src/core/profile/mod.rs
+++ b/aries_vcx/src/core/profile/mod.rs
@@ -1,3 +1,3 @@
 pub mod indy_profile;
-pub mod modular_wallet_profile;
+pub mod modular_libs_profile;
 pub mod profile;

--- a/aries_vcx/src/core/profile/modular_libs_profile.rs
+++ b/aries_vcx/src/core/profile/modular_libs_profile.rs
@@ -38,7 +38,8 @@ impl Profile for ModularLibsProfile {
 
     fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds> {
         // todo - in the future we should lazy eval and avoid creating a new instance each time
-        Arc::new(IndyCredxAnonCreds::new(self))
+        let wallet = Arc::clone(&self.wallet);
+        Arc::new(IndyCredxAnonCreds::new(wallet))
     }
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {

--- a/aries_vcx/src/core/profile/modular_libs_profile.rs
+++ b/aries_vcx/src/core/profile/modular_libs_profile.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::errors::error::VcxResult;
+use crate::plugins::ledger::indy_vdr_ledger::LedgerPoolConfig;
 use crate::plugins::{
     anoncreds::{base_anoncreds::BaseAnonCreds, credx_anoncreds::IndyCredxAnonCreds},
     ledger::{
@@ -9,7 +10,6 @@ use crate::plugins::{
     },
     wallet::base_wallet::BaseWallet,
 };
-use crate::plugins::ledger::indy_vdr_ledger::LedgerPoolConfig;
 
 use super::profile::Profile;
 
@@ -26,7 +26,11 @@ impl ModularLibsProfile {
         let ledger_pool = Arc::new(IndyVdrLedgerPool::new(ledger_pool_config)?);
         let ledger = Arc::new(IndyVdrLedger::new(Arc::clone(&wallet), ledger_pool));
         let anoncreds = Arc::new(IndyCredxAnonCreds::new(Arc::clone(&wallet)));
-        Ok(ModularLibsProfile { wallet, ledger, anoncreds })
+        Ok(ModularLibsProfile {
+            wallet,
+            ledger,
+            anoncreds,
+        })
     }
 }
 

--- a/aries_vcx/src/core/profile/vdrtools_profile.rs
+++ b/aries_vcx/src/core/profile/vdrtools_profile.rs
@@ -11,18 +11,18 @@ use crate::plugins::{
 use super::profile::Profile;
 
 #[derive(Debug)]
-pub struct IndySdkProfile {
+pub struct VdrtoolsProfile {
     wallet: Arc<dyn BaseWallet>,
     ledger: Arc<dyn BaseLedger>,
     anoncreds: Arc<dyn BaseAnonCreds>,
 }
 
-impl IndySdkProfile {
+impl VdrtoolsProfile {
     pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
         let wallet = Arc::new(IndySdkWallet::new(indy_wallet_handle));
         let ledger = Arc::new(IndySdkLedger::new(indy_wallet_handle, indy_pool_handle));
         let anoncreds = Arc::new(IndySdkAnonCreds::new(indy_wallet_handle, indy_pool_handle));
-        IndySdkProfile {
+        VdrtoolsProfile {
             wallet,
             ledger,
             anoncreds,
@@ -30,7 +30,7 @@ impl IndySdkProfile {
     }
 }
 
-impl Profile for IndySdkProfile {
+impl Profile for VdrtoolsProfile {
     fn inject_ledger(self: Arc<Self>) -> Arc<dyn BaseLedger> {
         Arc::clone(&self.ledger)
     }

--- a/aries_vcx/src/handlers/proof_presentation/verifier.rs
+++ b/aries_vcx/src/handlers/proof_presentation/verifier.rs
@@ -221,7 +221,7 @@ impl Verifier {
 #[cfg(test)]
 #[cfg(feature = "general_test")]
 mod unit_tests {
-    use crate::core::profile::indy_profile::IndySdkProfile;
+    use crate::core::profile::vdrtools_profile::VdrtoolsProfile;
     use crate::utils::constants::{REQUESTED_ATTRS, REQUESTED_PREDICATES};
     use crate::utils::devsetup::*;
     use crate::utils::mockdata::mock_settings::MockBuilder;
@@ -232,7 +232,7 @@ mod unit_tests {
     use super::*;
 
     fn _dummy_profile() -> Arc<dyn Profile> {
-        Arc::new(IndySdkProfile::new(WalletHandle(0), 0))
+        Arc::new(VdrtoolsProfile::new(WalletHandle(0), 0))
     }
 
     async fn _verifier() -> Verifier {

--- a/aries_vcx/src/plugins/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx/src/plugins/anoncreds/credx_anoncreds.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult};
+use crate::plugins::wallet::base_wallet::BaseWallet;
 use crate::{
     plugins::wallet::base_wallet::AsyncFnIteratorCollect,
     utils::{
@@ -28,7 +29,6 @@ use credx::{
 };
 use indy_credx as credx;
 use serde_json::Value;
-use crate::plugins::wallet::base_wallet::BaseWallet;
 
 use super::base_anoncreds::BaseAnonCreds;
 
@@ -37,7 +37,7 @@ const CATEGORY_LINK_SECRET: &str = "VCX_LINK_SECRET";
 
 #[derive(Debug)]
 pub struct IndyCredxAnonCreds {
-    wallet: Arc<dyn BaseWallet>
+    wallet: Arc<dyn BaseWallet>,
 }
 
 impl IndyCredxAnonCreds {
@@ -46,7 +46,8 @@ impl IndyCredxAnonCreds {
     }
 
     async fn get_link_secret(&self, link_secret_id: &str) -> VcxResult<MasterSecret> {
-        let record = self.wallet
+        let record = self
+            .wallet
             .get_wallet_record(CATEGORY_LINK_SECRET, link_secret_id, "{}")
             .await?;
 
@@ -66,7 +67,8 @@ impl IndyCredxAnonCreds {
     }
 
     async fn _get_credential(&self, credential_id: &str) -> VcxResult<CredxCredential> {
-        let cred_record = self.wallet
+        let cred_record = self
+            .wallet
             .get_wallet_record(CATEGORY_CREDENTIAL, credential_id, "{}")
             .await?;
         let cred_record: Value = serde_json::from_str(&cred_record)?;
@@ -80,7 +82,10 @@ impl IndyCredxAnonCreds {
     }
 
     async fn _get_credentials(&self, wql: &str) -> VcxResult<Vec<(String, CredxCredential)>> {
-        let mut record_iterator = self.wallet.iterate_wallet_records(CATEGORY_CREDENTIAL, wql, "{}").await?;
+        let mut record_iterator = self
+            .wallet
+            .iterate_wallet_records(CATEGORY_CREDENTIAL, wql, "{}")
+            .await?;
         let records = record_iterator.collect().await?;
 
         let id_cred_tuple_list: VcxResult<Vec<(String, CredxCredential)>> = records
@@ -610,7 +615,8 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
     }
 
     async fn prover_create_link_secret(&self, link_secret_id: &str) -> VcxResult<String> {
-        let existing_record = self.wallet
+        let existing_record = self
+            .wallet
             .get_wallet_record(CATEGORY_LINK_SECRET, link_secret_id, "{}")
             .await
             .ok(); // ignore error, as we only care about whether it exists or not
@@ -654,8 +660,7 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
     }
 
     async fn prover_delete_credential(&self, cred_id: &str) -> VcxResult<()> {
-        self.wallet
-            .delete_wallet_record(CATEGORY_CREDENTIAL, cred_id).await
+        self.wallet.delete_wallet_record(CATEGORY_CREDENTIAL, cred_id).await
     }
 
     async fn issuer_create_schema(

--- a/aries_vcx/src/plugins/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx/src/plugins/anoncreds/credx_anoncreds.rs
@@ -6,7 +6,6 @@ use std::{
 
 use crate::errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult};
 use crate::{
-    core::profile::profile::Profile,
     plugins::wallet::base_wallet::AsyncFnIteratorCollect,
     utils::{
         constants::ATTRS,
@@ -29,6 +28,7 @@ use credx::{
 };
 use indy_credx as credx;
 use serde_json::Value;
+use crate::plugins::wallet::base_wallet::BaseWallet;
 
 use super::base_anoncreds::BaseAnonCreds;
 
@@ -37,18 +37,16 @@ const CATEGORY_LINK_SECRET: &str = "VCX_LINK_SECRET";
 
 #[derive(Debug)]
 pub struct IndyCredxAnonCreds {
-    profile: Arc<dyn Profile>,
+    wallet: Arc<dyn BaseWallet>
 }
 
 impl IndyCredxAnonCreds {
-    pub fn new(profile: Arc<dyn Profile>) -> Self {
-        IndyCredxAnonCreds { profile }
+    pub fn new(wallet: Arc<dyn BaseWallet>) -> Self {
+        IndyCredxAnonCreds { wallet }
     }
 
     async fn get_link_secret(&self, link_secret_id: &str) -> VcxResult<MasterSecret> {
-        let wallet = self.profile.inject_wallet();
-
-        let record = wallet
+        let record = self.wallet
             .get_wallet_record(CATEGORY_LINK_SECRET, link_secret_id, "{}")
             .await?;
 
@@ -68,9 +66,7 @@ impl IndyCredxAnonCreds {
     }
 
     async fn _get_credential(&self, credential_id: &str) -> VcxResult<CredxCredential> {
-        let wallet = self.profile.inject_wallet();
-
-        let cred_record = wallet
+        let cred_record = self.wallet
             .get_wallet_record(CATEGORY_CREDENTIAL, credential_id, "{}")
             .await?;
         let cred_record: Value = serde_json::from_str(&cred_record)?;
@@ -84,9 +80,7 @@ impl IndyCredxAnonCreds {
     }
 
     async fn _get_credentials(&self, wql: &str) -> VcxResult<Vec<(String, CredxCredential)>> {
-        let wallet = self.profile.inject_wallet();
-
-        let mut record_iterator = wallet.iterate_wallet_records(CATEGORY_CREDENTIAL, wql, "{}").await?;
+        let mut record_iterator = self.wallet.iterate_wallet_records(CATEGORY_CREDENTIAL, wql, "{}").await?;
         let records = record_iterator.collect().await?;
 
         let id_cred_tuple_list: VcxResult<Vec<(String, CredxCredential)>> = records
@@ -608,8 +602,7 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
         let record_value = serde_json::to_string(&credential)?;
         let tags_json = serde_json::to_string(&tags)?;
 
-        self.profile
-            .inject_wallet()
+        self.wallet
             .add_wallet_record(CATEGORY_CREDENTIAL, &credential_id, &record_value, Some(&tags_json))
             .await?;
 
@@ -617,9 +610,7 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
     }
 
     async fn prover_create_link_secret(&self, link_secret_id: &str) -> VcxResult<String> {
-        let wallet = self.profile.inject_wallet();
-
-        let existing_record = wallet
+        let existing_record = self.wallet
             .get_wallet_record(CATEGORY_LINK_SECRET, link_secret_id, "{}")
             .await
             .ok(); // ignore error, as we only care about whether it exists or not
@@ -655,7 +646,7 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
                 )
             })?;
 
-        wallet
+        self.wallet
             .add_wallet_record(CATEGORY_LINK_SECRET, link_secret_id, &ms_decimal, None)
             .await?;
 
@@ -663,9 +654,8 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
     }
 
     async fn prover_delete_credential(&self, cred_id: &str) -> VcxResult<()> {
-        let wallet = self.profile.inject_wallet();
-
-        wallet.delete_wallet_record(CATEGORY_CREDENTIAL, cred_id).await
+        self.wallet
+            .delete_wallet_record(CATEGORY_CREDENTIAL, cred_id).await
     }
 
     async fn issuer_create_schema(
@@ -823,7 +813,7 @@ mod unit_tests {
         }
 
         let profile = mock_profile();
-        let anoncreds: Box<dyn BaseAnonCreds> = Box::new(IndyCredxAnonCreds::new(profile));
+        let anoncreds: Box<dyn BaseAnonCreds> = Box::new(IndyCredxAnonCreds::new(profile.inject_wallet()));
 
         assert_unimplemented(anoncreds.issuer_create_and_store_revoc_reg("", "", "", 0, "").await);
         assert_unimplemented(

--- a/aries_vcx/src/plugins/anoncreds/indy_anoncreds.rs
+++ b/aries_vcx/src/plugins/anoncreds/indy_anoncreds.rs
@@ -1,20 +1,25 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use vdrtools::{PoolHandle, WalletHandle};
 
 use crate::errors::error::VcxResult;
-use crate::{core::profile::indy_profile::IndySdkProfile, indy};
+use crate::indy;
 
 use super::base_anoncreds::BaseAnonCreds;
 
 #[derive(Debug)]
 pub struct IndySdkAnonCreds {
-    profile: Arc<IndySdkProfile>,
+    indy_wallet_handle: WalletHandle,
+    indy_pool_handle: PoolHandle,
 }
 
 impl IndySdkAnonCreds {
-    pub fn new(profile: Arc<IndySdkProfile>) -> Self {
-        IndySdkAnonCreds { profile }
+    pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
+        IndySdkAnonCreds {
+            indy_wallet_handle,
+            indy_pool_handle,
+        }
     }
 }
 
@@ -49,7 +54,7 @@ impl BaseAnonCreds for IndySdkAnonCreds {
         tag: &str,
     ) -> VcxResult<(String, String, String)> {
         indy::primitives::revocation_registry::libindy_create_and_store_revoc_reg(
-            self.profile.indy_wallet_handle,
+            self.indy_wallet_handle,
             issuer_did,
             cred_def_id,
             tails_dir,
@@ -68,7 +73,7 @@ impl BaseAnonCreds for IndySdkAnonCreds {
         config_json: &str,
     ) -> VcxResult<(String, String)> {
         indy::primitives::credential_definition::libindy_create_and_store_credential_def(
-            self.profile.indy_wallet_handle,
+            self.indy_wallet_handle,
             issuer_did,
             schema_json,
             tag,
@@ -79,8 +84,7 @@ impl BaseAnonCreds for IndySdkAnonCreds {
     }
 
     async fn issuer_create_credential_offer(&self, cred_def_id: &str) -> VcxResult<String> {
-        indy::credentials::issuer::libindy_issuer_create_credential_offer(self.profile.indy_wallet_handle, cred_def_id)
-            .await
+        indy::credentials::issuer::libindy_issuer_create_credential_offer(self.indy_wallet_handle, cred_def_id).await
     }
 
     async fn issuer_create_credential(
@@ -92,7 +96,7 @@ impl BaseAnonCreds for IndySdkAnonCreds {
         tails_dir: Option<String>,
     ) -> VcxResult<(String, Option<String>, Option<String>)> {
         indy::credentials::issuer::libindy_issuer_create_credential(
-            self.profile.indy_wallet_handle,
+            self.indy_wallet_handle,
             cred_offer_json,
             cred_req_json,
             cred_values_json,
@@ -112,7 +116,7 @@ impl BaseAnonCreds for IndySdkAnonCreds {
         revoc_states_json: Option<&str>,
     ) -> VcxResult<String> {
         indy::proofs::prover::prover::libindy_prover_create_proof(
-            self.profile.indy_wallet_handle,
+            self.indy_wallet_handle,
             proof_req_json,
             requested_credentials_json,
             master_secret_id,
@@ -124,19 +128,16 @@ impl BaseAnonCreds for IndySdkAnonCreds {
     }
 
     async fn prover_get_credential(&self, cred_id: &str) -> VcxResult<String> {
-        indy::credentials::holder::libindy_prover_get_credential(self.profile.indy_wallet_handle, cred_id).await
+        indy::credentials::holder::libindy_prover_get_credential(self.indy_wallet_handle, cred_id).await
     }
 
     async fn prover_get_credentials(&self, filter_json: Option<&str>) -> VcxResult<String> {
-        indy::proofs::prover::prover::libindy_prover_get_credentials(self.profile.indy_wallet_handle, filter_json).await
+        indy::proofs::prover::prover::libindy_prover_get_credentials(self.indy_wallet_handle, filter_json).await
     }
 
     async fn prover_get_credentials_for_proof_req(&self, proof_req: &str) -> VcxResult<String> {
-        indy::proofs::prover::prover::libindy_prover_get_credentials_for_proof_req(
-            self.profile.indy_wallet_handle,
-            proof_req,
-        )
-        .await
+        indy::proofs::prover::prover::libindy_prover_get_credentials_for_proof_req(self.indy_wallet_handle, proof_req)
+            .await
     }
 
     async fn prover_create_credential_req(
@@ -147,7 +148,7 @@ impl BaseAnonCreds for IndySdkAnonCreds {
         master_secret_id: &str,
     ) -> VcxResult<(String, String)> {
         indy::credentials::holder::libindy_prover_create_credential_req(
-            self.profile.indy_wallet_handle,
+            self.indy_wallet_handle,
             prover_did,
             credential_offer_json,
             credential_def_json,
@@ -183,7 +184,7 @@ impl BaseAnonCreds for IndySdkAnonCreds {
         rev_reg_def_json: Option<&str>,
     ) -> VcxResult<String> {
         indy::credentials::holder::libindy_prover_store_credential(
-            self.profile.indy_wallet_handle,
+            self.indy_wallet_handle,
             cred_id,
             cred_req_meta,
             cred_json,
@@ -194,15 +195,11 @@ impl BaseAnonCreds for IndySdkAnonCreds {
     }
 
     async fn prover_delete_credential(&self, cred_id: &str) -> VcxResult<()> {
-        indy::credentials::holder::libindy_prover_delete_credential(self.profile.indy_wallet_handle, cred_id).await
+        indy::credentials::holder::libindy_prover_delete_credential(self.indy_wallet_handle, cred_id).await
     }
 
     async fn prover_create_link_secret(&self, master_secret_id: &str) -> VcxResult<String> {
-        indy::credentials::holder::libindy_prover_create_master_secret(
-            self.profile.indy_wallet_handle,
-            master_secret_id,
-        )
-        .await
+        indy::credentials::holder::libindy_prover_create_master_secret(self.indy_wallet_handle, master_secret_id).await
     }
 
     async fn issuer_create_schema(
@@ -217,7 +214,7 @@ impl BaseAnonCreds for IndySdkAnonCreds {
 
     async fn revoke_credential_local(&self, tails_dir: &str, rev_reg_id: &str, cred_rev_id: &str) -> VcxResult<()> {
         indy::primitives::revocation_registry::revoke_credential_local(
-            self.profile.indy_wallet_handle,
+            self.indy_wallet_handle,
             tails_dir,
             rev_reg_id,
             cred_rev_id,
@@ -227,8 +224,8 @@ impl BaseAnonCreds for IndySdkAnonCreds {
 
     async fn publish_local_revocations(&self, submitter_did: &str, rev_reg_id: &str) -> VcxResult<()> {
         indy::primitives::revocation_registry::publish_local_revocations(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
+            self.indy_wallet_handle,
+            self.indy_pool_handle,
             submitter_did,
             rev_reg_id,
         )

--- a/aries_vcx/src/plugins/ledger/base_ledger.rs
+++ b/aries_vcx/src/plugins/ledger/base_ledger.rs
@@ -5,7 +5,7 @@ use crate::errors::error::VcxResult;
 
 /// Trait defining standard 'ledger' related functionality.
 #[async_trait]
-pub trait BaseLedger: Send + Sync {
+pub trait BaseLedger: std::fmt::Debug + Send + Sync {
     // returns request result as JSON
     async fn sign_and_submit_request(&self, submitter_did: &str, request_json: &str) -> VcxResult<String>;
 

--- a/aries_vcx/src/plugins/ledger/indy_ledger.rs
+++ b/aries_vcx/src/plugins/ledger/indy_ledger.rs
@@ -10,6 +10,7 @@ use crate::indy;
 
 use super::base_ledger::BaseLedger;
 
+#[derive(Debug)]
 pub struct IndySdkLedger {
     profile: Arc<IndySdkProfile>,
 }

--- a/aries_vcx/src/plugins/ledger/indy_ledger.rs
+++ b/aries_vcx/src/plugins/ledger/indy_ledger.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use vdrtools::{PoolHandle, WalletHandle};
 
 use crate::core::profile::indy_profile::IndySdkProfile;
 
@@ -12,12 +13,16 @@ use super::base_ledger::BaseLedger;
 
 #[derive(Debug)]
 pub struct IndySdkLedger {
-    profile: Arc<IndySdkProfile>,
+    indy_wallet_handle: WalletHandle,
+    indy_pool_handle: PoolHandle,
 }
 
 impl IndySdkLedger {
-    pub fn new(profile: Arc<IndySdkProfile>) -> Self {
-        IndySdkLedger { profile }
+    pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
+        IndySdkLedger {
+            indy_wallet_handle,
+            indy_pool_handle,
+        }
     }
 }
 
@@ -25,8 +30,8 @@ impl IndySdkLedger {
 impl BaseLedger for IndySdkLedger {
     async fn sign_and_submit_request(&self, submitter_did: &str, request_json: &str) -> VcxResult<String> {
         indy::ledger::transactions::libindy_sign_and_submit_request(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
+            self.indy_wallet_handle,
+            self.indy_pool_handle,
             submitter_did,
             request_json,
         )
@@ -34,13 +39,13 @@ impl BaseLedger for IndySdkLedger {
     }
 
     async fn submit_request(&self, request_json: &str) -> VcxResult<String> {
-        indy::ledger::transactions::libindy_submit_request(self.profile.indy_pool_handle, request_json).await
+        indy::ledger::transactions::libindy_submit_request(self.indy_pool_handle, request_json).await
     }
 
     async fn endorse_transaction(&self, endorser_did: &str, request_json: &str) -> VcxResult<()> {
         indy::ledger::transactions::endorse_transaction(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
+            self.indy_wallet_handle,
+            self.indy_pool_handle,
             endorser_did,
             request_json,
         )
@@ -48,16 +53,15 @@ impl BaseLedger for IndySdkLedger {
     }
 
     async fn set_endorser(&self, submitter_did: &str, request_json: &str, endorser: &str) -> VcxResult<String> {
-        indy::ledger::transactions::set_endorser(self.profile.indy_wallet_handle, submitter_did, request_json, endorser)
-            .await
+        indy::ledger::transactions::set_endorser(self.indy_wallet_handle, submitter_did, request_json, endorser).await
     }
 
     async fn get_txn_author_agreement(&self) -> VcxResult<String> {
-        indy::ledger::transactions::libindy_get_txn_author_agreement(self.profile.indy_pool_handle).await
+        indy::ledger::transactions::libindy_get_txn_author_agreement(self.indy_pool_handle).await
     }
 
     async fn get_nym(&self, did: &str) -> VcxResult<String> {
-        indy::ledger::transactions::get_nym(self.profile.indy_pool_handle, did).await
+        indy::ledger::transactions::get_nym(self.indy_pool_handle, did).await
     }
 
     // returns request result as JSON
@@ -75,8 +79,8 @@ impl BaseLedger for IndySdkLedger {
         let nym_request = indy::ledger::transactions::append_txn_author_agreement_to_request(&nym_request).await?;
 
         indy::ledger::transactions::libindy_sign_and_submit_request(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
+            self.indy_wallet_handle,
+            self.indy_pool_handle,
             submitter_did,
             &nym_request,
         )
@@ -87,50 +91,37 @@ impl BaseLedger for IndySdkLedger {
         if let Some(submitter_did) = submitter_did {
             // with cache if possible
             indy::ledger::transactions::libindy_get_schema(
-                self.profile.indy_wallet_handle,
-                self.profile.indy_pool_handle,
+                self.indy_wallet_handle,
+                self.indy_pool_handle,
                 submitter_did,
                 schema_id,
             )
             .await
         } else {
             // no cache
-            indy::ledger::transactions::get_schema_json(
-                self.profile.indy_wallet_handle,
-                self.profile.indy_pool_handle,
-                schema_id,
-            )
-            .await
-            .map(|(_, json)| json)
+            indy::ledger::transactions::get_schema_json(self.indy_wallet_handle, self.indy_pool_handle, schema_id)
+                .await
+                .map(|(_, json)| json)
         }
     }
 
     async fn get_cred_def(&self, cred_def_id: &str, _submitter_did: Option<&str>) -> VcxResult<String> {
-        indy::ledger::transactions::get_cred_def_json(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
-            cred_def_id,
-        )
-        .await
-        .map(|(_id, json)| json)
+        indy::ledger::transactions::get_cred_def_json(self.indy_wallet_handle, self.indy_pool_handle, cred_def_id)
+            .await
+            .map(|(_id, json)| json)
     }
 
     async fn get_attr(&self, target_did: &str, attr_name: &str) -> VcxResult<String> {
-        indy::ledger::transactions::get_attr(self.profile.indy_pool_handle, target_did, attr_name).await
+        indy::ledger::transactions::get_attr(self.indy_pool_handle, target_did, attr_name).await
     }
 
     async fn add_attr(&self, target_did: &str, attrib_json: &str) -> VcxResult<String> {
-        indy::ledger::transactions::add_attr(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
-            target_did,
-            attrib_json,
-        )
-        .await
+        indy::ledger::transactions::add_attr(self.indy_wallet_handle, self.indy_pool_handle, target_did, attrib_json)
+            .await
     }
 
     async fn get_rev_reg_def_json(&self, rev_reg_id: &str) -> VcxResult<String> {
-        indy::ledger::transactions::get_rev_reg_def_json(self.profile.indy_pool_handle, rev_reg_id)
+        indy::ledger::transactions::get_rev_reg_def_json(self.indy_pool_handle, rev_reg_id)
             .await
             .map(|(_, json)| json)
     }
@@ -141,17 +132,17 @@ impl BaseLedger for IndySdkLedger {
         from: Option<u64>,
         to: Option<u64>,
     ) -> VcxResult<(String, String, u64)> {
-        indy::ledger::transactions::get_rev_reg_delta_json(self.profile.indy_pool_handle, rev_reg_id, from, to).await
+        indy::ledger::transactions::get_rev_reg_delta_json(self.indy_pool_handle, rev_reg_id, from, to).await
     }
 
     async fn get_rev_reg(&self, rev_reg_id: &str, timestamp: u64) -> VcxResult<(String, String, u64)> {
-        indy::ledger::transactions::get_rev_reg(self.profile.indy_pool_handle, rev_reg_id, timestamp).await
+        indy::ledger::transactions::get_rev_reg(self.indy_pool_handle, rev_reg_id, timestamp).await
     }
 
     async fn get_ledger_txn(&self, seq_no: i32, submitter_did: Option<&str>) -> VcxResult<String> {
         indy::ledger::transactions::get_ledger_txn(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
+            self.indy_wallet_handle,
+            self.indy_pool_handle,
             seq_no,
             submitter_did,
         )
@@ -169,8 +160,8 @@ impl BaseLedger for IndySdkLedger {
         endorser_did: Option<String>,
     ) -> VcxResult<()> {
         indy::primitives::credential_schema::publish_schema(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
+            self.indy_wallet_handle,
+            self.indy_pool_handle,
             submitter_did,
             schema_json,
             endorser_did,
@@ -180,8 +171,8 @@ impl BaseLedger for IndySdkLedger {
 
     async fn publish_cred_def(&self, cred_def_json: &str, submitter_did: &str) -> VcxResult<()> {
         indy::primitives::credential_definition::publish_cred_def(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
+            self.indy_wallet_handle,
+            self.indy_pool_handle,
             submitter_did,
             cred_def_json,
         )
@@ -194,8 +185,8 @@ impl BaseLedger for IndySdkLedger {
         submitter_did: &str,
     ) -> VcxResult<()> {
         indy::primitives::revocation_registry::publish_rev_reg_def(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
+            self.indy_wallet_handle,
+            self.indy_pool_handle,
             submitter_did,
             rev_reg_def,
         )
@@ -209,8 +200,8 @@ impl BaseLedger for IndySdkLedger {
         submitter_did: &str,
     ) -> VcxResult<()> {
         indy::primitives::revocation_registry::publish_rev_reg_delta(
-            self.profile.indy_wallet_handle,
-            self.profile.indy_pool_handle,
+            self.indy_wallet_handle,
+            self.indy_pool_handle,
             submitter_did,
             rev_reg_id,
             rev_reg_entry_json,

--- a/aries_vcx/src/plugins/ledger/indy_ledger.rs
+++ b/aries_vcx/src/plugins/ledger/indy_ledger.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use vdrtools::{PoolHandle, WalletHandle};
 
-use crate::core::profile::indy_profile::IndySdkProfile;
+use crate::core::profile::vdrtools_profile::VdrtoolsProfile;
 
 use crate::common::primitives::revocation_registry::RevocationRegistryDefinition;
 use crate::errors::error::VcxResult;

--- a/aries_vcx/src/plugins/ledger/indy_vdr_ledger.rs
+++ b/aries_vcx/src/plugins/ledger/indy_vdr_ledger.rs
@@ -120,10 +120,7 @@ impl IndyVdrLedger {
 
         let signer_verkey = self.wallet.key_for_local_did(submitter_did).await?;
 
-        let signature = self
-            .wallet
-            .sign(&signer_verkey, to_sign.as_bytes())
-            .await?;
+        let signature = self.wallet.sign(&signer_verkey, to_sign.as_bytes()).await?;
 
         request.set_signature(&signature)?;
 

--- a/aries_vcx/src/plugins/ledger/indy_vdr_ledger.rs
+++ b/aries_vcx/src/plugins/ledger/indy_vdr_ledger.rs
@@ -1,6 +1,7 @@
 use indy_vdr as vdr;
 use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use vdr::ledger::requests::schema::{AttributeNames, Schema, SchemaV1};
 
@@ -51,8 +52,8 @@ impl IndyVdrLedgerPool {
     }
 }
 
-impl std::fmt::Debug for IndyVdrLedgerPool {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for IndyVdrLedgerPool {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IndyVdrLedgerPool")
             .field("runner", &"PoolRunner")
             .finish()
@@ -183,6 +184,12 @@ impl IndyVdrLedger {
         Ok(self
             .request_builder()?
             .build_attrib_request(&identifier, &dest, None, attrib_json.as_ref(), None)?)
+    }
+}
+
+impl Debug for IndyVdrLedger {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IndyVdrLedger instance")
     }
 }
 

--- a/aries_vcx/src/plugins/ledger/indy_vdr_ledger.rs
+++ b/aries_vcx/src/plugins/ledger/indy_vdr_ledger.rs
@@ -538,7 +538,7 @@ mod unit_tests {
 
         let profile = mock_profile();
         let pool = Arc::new(IndyVdrLedgerPool { runner: None });
-        let ledger: Box<dyn BaseLedger> = Box::new(IndyVdrLedger::new(profile, pool));
+        let ledger: Box<dyn BaseLedger> = Box::new(IndyVdrLedger::new(profile.inject_wallet(), pool));
 
         assert_unimplemented(ledger.endorse_transaction("", "").await);
         assert_unimplemented(ledger.set_endorser("", "", "").await);

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -11,9 +11,9 @@ use agency_client::agency_client::AgencyClient;
 use agency_client::configuration::AgentProvisionConfig;
 use agency_client::testing::mocking::{disable_agency_mocks, enable_agency_mocks, AgencyMockDecrypted};
 
-use crate::core::profile::indy_profile::IndySdkProfile;
 use crate::core::profile::modular_libs_profile::ModularLibsProfile;
 use crate::core::profile::profile::Profile;
+use crate::core::profile::vdrtools_profile::VdrtoolsProfile;
 use crate::global::settings;
 use crate::global::settings::init_issuer_config;
 use crate::global::settings::{disable_indy_mocks, enable_indy_mocks, set_test_configs};
@@ -386,7 +386,7 @@ impl SetupProfile {
         .unwrap();
         let pool_handle = open_test_pool().await;
 
-        let profile: Arc<dyn Profile> = Arc::new(IndySdkProfile::new(wallet_handle, pool_handle.clone()));
+        let profile: Arc<dyn Profile> = Arc::new(VdrtoolsProfile::new(wallet_handle, pool_handle.clone()));
 
         async fn indy_teardown(pool_handle: i32) {
             delete_test_pool(pool_handle.clone()).await;

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -12,7 +12,7 @@ use agency_client::configuration::AgentProvisionConfig;
 use agency_client::testing::mocking::{disable_agency_mocks, enable_agency_mocks, AgencyMockDecrypted};
 
 use crate::core::profile::indy_profile::IndySdkProfile;
-use crate::core::profile::modular_libs_profile::{ModularLibsProfile};
+use crate::core::profile::modular_libs_profile::ModularLibsProfile;
 use crate::core::profile::profile::Profile;
 use crate::global::settings;
 use crate::global::settings::init_issuer_config;

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -12,7 +12,7 @@ use agency_client::configuration::AgentProvisionConfig;
 use agency_client::testing::mocking::{disable_agency_mocks, enable_agency_mocks, AgencyMockDecrypted};
 
 use crate::core::profile::indy_profile::IndySdkProfile;
-use crate::core::profile::modular_wallet_profile::{LedgerPoolConfig, ModularWalletProfile};
+use crate::core::profile::modular_libs_profile::{ModularLibsProfile};
 use crate::core::profile::profile::Profile;
 use crate::global::settings;
 use crate::global::settings::init_issuer_config;
@@ -28,6 +28,7 @@ use crate::indy::wallet::{
     close_wallet, create_and_open_wallet, create_indy_wallet, create_wallet_with_master_secret, delete_wallet,
     wallet_configure_issuer, WalletConfig,
 };
+use crate::plugins::ledger::indy_vdr_ledger::LedgerPoolConfig;
 use crate::plugins::wallet::base_wallet::BaseWallet;
 use crate::plugins::wallet::indy_wallet::IndySdkWallet;
 use crate::utils;
@@ -406,7 +407,7 @@ impl SetupProfile {
         let wallet = IndySdkWallet::new(wallet_handle);
 
         let profile: Arc<dyn Profile> =
-            Arc::new(ModularWalletProfile::new(Arc::new(wallet), LedgerPoolConfig { genesis_file_path }).unwrap());
+            Arc::new(ModularLibsProfile::new(Arc::new(wallet), LedgerPoolConfig { genesis_file_path }).unwrap());
 
         Arc::clone(&profile)
             .inject_anoncreds()

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -4,7 +4,7 @@ pub mod test_utils {
     use std::sync::Arc;
 
     use aries_vcx::core::profile::indy_profile::IndySdkProfile;
-    use aries_vcx::core::profile::modular_wallet_profile::{LedgerPoolConfig, ModularWalletProfile};
+    use aries_vcx::core::profile::modular_libs_profile::{ModularLibsProfile};
     use aries_vcx::core::profile::profile::Profile;
     use aries_vcx::handlers::revocation_notification::receiver::RevocationNotificationReceiver;
     use aries_vcx::handlers::revocation_notification::sender::RevocationNotificationSender;
@@ -48,6 +48,7 @@ pub mod test_utils {
     use aries_vcx::messages::protocols::issuance::credential_offer::CredentialOffer;
     use aries_vcx::messages::protocols::issuance::credential_offer::OfferInfo;
     use aries_vcx::messages::protocols::proof_presentation::presentation_request::PresentationRequest;
+    use aries_vcx::plugins::ledger::indy_vdr_ledger::LedgerPoolConfig;
     use aries_vcx::protocols::issuance::holder::state_machine::HolderState;
     use aries_vcx::protocols::issuance::issuer::state_machine::IssuerState;
     use aries_vcx::protocols::mediated_connection::invitee::state_machine::InviteeState;
@@ -481,7 +482,7 @@ pub mod test_utils {
 
             let wallet: Arc<dyn BaseWallet> = Arc::new(IndySdkWallet::new(wallet_handle));
 
-            let profile = Arc::new(ModularWalletProfile::new(wallet, ledger_pool_config).unwrap());
+            let profile = Arc::new(ModularLibsProfile::new(wallet, ledger_pool_config).unwrap());
 
             // set up anoncreds link/master secret
             Arc::clone(&profile)

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -3,9 +3,9 @@
 pub mod test_utils {
     use std::sync::Arc;
 
-    use aries_vcx::core::profile::indy_profile::IndySdkProfile;
     use aries_vcx::core::profile::modular_libs_profile::ModularLibsProfile;
     use aries_vcx::core::profile::profile::Profile;
+    use aries_vcx::core::profile::vdrtools_profile::VdrtoolsProfile;
     use aries_vcx::handlers::revocation_notification::receiver::RevocationNotificationReceiver;
     use aries_vcx::handlers::revocation_notification::sender::RevocationNotificationSender;
     use aries_vcx::plugins::wallet::base_wallet::BaseWallet;
@@ -159,7 +159,7 @@ pub mod test_utils {
             create_wallet_with_master_secret(&config_wallet).await.unwrap();
             let wallet_handle = open_wallet(&config_wallet).await.unwrap();
 
-            let indy_profile = IndySdkProfile::new(wallet_handle, pool_handle);
+            let indy_profile = VdrtoolsProfile::new(wallet_handle, pool_handle);
             let profile: Arc<dyn Profile> = Arc::new(indy_profile);
 
             let config_issuer = wallet_configure_issuer(wallet_handle, enterprise_seed).await.unwrap();
@@ -502,7 +502,7 @@ pub mod test_utils {
         ) -> (Arc<dyn Profile>, Arc<dyn Fn() -> BoxFuture<'static, ()>>) {
             let (wallet_handle, config_wallet) = Alice::setup_indy_wallet().await;
 
-            let indy_profile = IndySdkProfile::new(wallet_handle, pool_handle);
+            let indy_profile = VdrtoolsProfile::new(wallet_handle, pool_handle);
 
             (
                 Arc::new(indy_profile),

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -4,7 +4,7 @@ pub mod test_utils {
     use std::sync::Arc;
 
     use aries_vcx::core::profile::indy_profile::IndySdkProfile;
-    use aries_vcx::core::profile::modular_libs_profile::{ModularLibsProfile};
+    use aries_vcx::core::profile::modular_libs_profile::ModularLibsProfile;
     use aries_vcx::core::profile::profile::Profile;
     use aries_vcx::handlers::revocation_notification::receiver::RevocationNotificationReceiver;
     use aries_vcx::handlers::revocation_notification::sender::RevocationNotificationSender;

--- a/libvcx_core/src/api_vcx/api_global/profile.rs
+++ b/libvcx_core/src/api_vcx/api_global/profile.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::errors::error::LibvcxResult;
 use aries_vcx::{
-    core::profile::{indy_profile::IndySdkProfile, profile::Profile},
+    core::profile::{profile::Profile, vdrtools_profile::VdrtoolsProfile},
     plugins::wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
     vdrtools::{PoolHandle, WalletHandle},
 };
@@ -15,7 +15,7 @@ pub fn indy_wallet_handle_to_wallet(wallet_handle: WalletHandle) -> Arc<dyn Base
 }
 
 pub fn indy_handles_to_profile(wallet_handle: WalletHandle, pool_handle: PoolHandle) -> Arc<dyn Profile> {
-    Arc::new(IndySdkProfile::new(wallet_handle, pool_handle))
+    Arc::new(VdrtoolsProfile::new(wallet_handle, pool_handle))
 }
 
 pub fn get_main_wallet() -> Arc<dyn BaseWallet> {

--- a/uniffi_aries_vcx/core/src/core/profile.rs
+++ b/uniffi_aries_vcx/core/src/core/profile.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use aries_vcx::{
-    core::profile::{indy_profile::IndySdkProfile, profile::Profile},
+    core::profile::{profile::Profile, vdrtools_profile::VdrtoolsProfile},
     indy::wallet::{create_and_open_wallet, WalletConfig},
 };
 
@@ -17,7 +17,7 @@ pub fn new_indy_profile(wallet_config: WalletConfig) -> VcxUniFFIResult<Arc<Prof
     block_on(async {
         let wh = create_and_open_wallet(&wallet_config).await?;
         let ph = 0;
-        let profile = IndySdkProfile::new(wh, ph);
+        let profile = VdrtoolsProfile::new(wh, ph);
 
         Ok(Arc::new(ProfileHolder {
             inner: Arc::new(profile),


### PR DESCRIPTION
- renamed `modular_wallet_profile` to `modular_libs_profile` - it seem confusing to mention "wallet" while the profile encapsulates also credex, ledger client

- Modified `IndyVdrLedger` to store require and store minimal amount of information needed - it doesn't need entire profile, it doesn't need to know about exists of Profiles, it only needs `dyn BaseWallet` for transaction signing
- Similarly modified vdr-tools trait implementations to be unaware of `Profile`, but inject `wallet_handle`, `pool_handle` in them instead


