### PR TITLE
Remove proof verifier legacy format deserialization support

### DIFF
--- a/aries_vcx/src/protocols/proof_presentation/verifier/states/finished.rs
+++ b/aries_vcx/src/protocols/proof_presentation/verifier/states/finished.rs
@@ -12,24 +12,7 @@ pub struct FinishedState {
     pub presentation_request: Option<PresentationRequest>,
     pub presentation: Option<Presentation>,
     pub status: Status,
-    #[serde(default = "verification_status_unavailable")] // todo: to be removed in 0.54.0, this supports legacy serialization when the field was undefined
-    #[serde(deserialize_with = "null_to_unavailable")] // todo: to be removed in 0.54.0, this supports legacy serialization when the field was 'null'
-    #[serde(alias = "revocation_status")]
-    // todo: to be removed in 0.54.0, this supports legacy serialization when the field was named 'revocation_status'
     pub verification_status: PresentationVerificationStatus,
-}
-
-fn verification_status_unavailable() -> PresentationVerificationStatus {
-    PresentationVerificationStatus::Unavailable
-}
-
-// todo: to be removed in 0.54.0,  if "revocation_status / verification_status" is null, we deserialize as Unavailable
-fn null_to_unavailable<'de, D>(deserializer: D) -> Result<PresentationVerificationStatus, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or(PresentationVerificationStatus::Unavailable))
 }
 
 impl FinishedState {
@@ -105,85 +88,5 @@ pub mod unit_tests {
         assert_eq!(serialized, expected);
         let deserialized: FinishedState = serde_json::from_str(&serialized).unwrap();
         assert_eq!(state, deserialized)
-    }
-
-    #[test]
-    fn test_verifier_state_finished_deser() {
-        {
-            let serialized =
-                r#"{"presentation":null,"presentation_request":null,"status":"Success","revocation_status":"Invalid"}"#;
-            let deserialized: FinishedState = serde_json::from_str(serialized).unwrap();
-            assert_eq!(
-                deserialized.verification_status,
-                PresentationVerificationStatus::Invalid
-            )
-        }
-        {
-            let serialized =
-                r#"{"presentation":null,"presentation_request":null,"status":"Success","revocation_status":"Valid"}"#;
-            let deserialized: FinishedState = serde_json::from_str(serialized).unwrap();
-            assert_eq!(deserialized.verification_status, PresentationVerificationStatus::Valid)
-        }
-    }
-
-    #[test]
-    fn test_verifier_state_finished_deser_legacy_values_verification_status() {
-        {
-            let serialized = r#"{"presentation":null,"presentation_request":null,"status":"Success"}"#;
-            let deserialized: FinishedState = serde_json::from_str(serialized).unwrap();
-            assert_eq!(
-                deserialized.verification_status,
-                PresentationVerificationStatus::Unavailable
-            )
-        }
-        {
-            let serialized =
-                r#"{"presentation":null,"presentation_request":null,"status":"Success","verification_status":null}"#;
-            let deserialized: FinishedState = serde_json::from_str(serialized).unwrap();
-            assert_eq!(
-                deserialized.verification_status,
-                PresentationVerificationStatus::Unavailable
-            )
-        }
-        {
-            let serialized = r#"{"presentation":null,"presentation_request":null,"status":"Success","verification_status":"Revoked"}"#;
-            let deserialized: FinishedState = serde_json::from_str(serialized).unwrap();
-            assert_eq!(
-                deserialized.verification_status,
-                PresentationVerificationStatus::Invalid
-            )
-        }
-        {
-            let serialized = r#"{"presentation":null,"presentation_request":null,"status":"Success","verification_status":"NonRevoked"}"#;
-            let deserialized: FinishedState = serde_json::from_str(serialized).unwrap();
-            assert_eq!(deserialized.verification_status, PresentationVerificationStatus::Valid)
-        }
-    }
-
-    #[test]
-    fn test_verifier_state_finished_deser_legacy_values_revocation_status() {
-        {
-            let serialized =
-                r#"{"presentation":null,"presentation_request":null,"status":"Success","revocation_status":null}"#;
-            let deserialized: FinishedState = serde_json::from_str(serialized).unwrap();
-            assert_eq!(
-                deserialized.verification_status,
-                PresentationVerificationStatus::Unavailable
-            )
-        }
-        {
-            let serialized =
-                r#"{"presentation":null,"presentation_request":null,"status":"Success","revocation_status":"Revoked"}"#;
-            let deserialized: FinishedState = serde_json::from_str(serialized).unwrap();
-            assert_eq!(
-                deserialized.verification_status,
-                PresentationVerificationStatus::Invalid
-            )
-        }
-        {
-            let serialized = r#"{"presentation":null,"presentation_request":null,"status":"Success","revocation_status":"NonRevoked"}"#;
-            let deserialized: FinishedState = serde_json::from_str(serialized).unwrap();
-            assert_eq!(deserialized.verification_status, PresentationVerificationStatus::Valid)
-        }
     }
 }

--- a/aries_vcx/src/protocols/proof_presentation/verifier/verification_status.rs
+++ b/aries_vcx/src/protocols/proof_presentation/verifier/verification_status.rs
@@ -1,9 +1,6 @@
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum PresentationVerificationStatus {
-    #[serde(alias = "NonRevoked")]
-    // todo: to be removed in 0.54.0, supports legacy serialization when the enum had values "Revoked" and "NotRevoked"
     Valid,
-    #[serde(alias = "Revoked")]
     Invalid,
     Unavailable,
 }
@@ -31,16 +28,8 @@ pub mod unit_tests {
             serde_json::from_str("\"Valid\"").unwrap()
         );
         assert_eq!(
-            PresentationVerificationStatus::Valid,
-            serde_json::from_str("\"NonRevoked\"").unwrap()
-        );
-        assert_eq!(
             PresentationVerificationStatus::Invalid,
             serde_json::from_str("\"Invalid\"").unwrap()
-        );
-        assert_eq!(
-            PresentationVerificationStatus::Invalid,
-            serde_json::from_str("\"Revoked\"").unwrap()
         );
         assert_eq!(
             PresentationVerificationStatus::Unavailable,


### PR DESCRIPTION
- As planned in https://github.com/hyperledger/aries-vcx/pull/770 next release won't support legacy format of serialized verifier proofs. 

- Follow migration guide in the PR linked above using aries-vcx `0.53.0` to reserialize your verifier proofs to the new format. The next `aries-vcx` release `0.54.0` will not support non-migrated verifier proofs created by `aries-vcx` `0.52.x` or older.
