### PR TITLE
Remove deps in `aries-vcx`: `env_logger`, `android_logger`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,6 @@ dependencies = [
 name = "agency_client"
 version = "0.55.0"
 dependencies = [
- "android_logger",
  "async-trait",
  "env_logger 0.9.3",
  "lazy_static",
@@ -186,7 +185,6 @@ name = "aries-vcx"
 version = "0.55.0"
 dependencies = [
  "agency_client",
- "android_logger",
  "aries_vcx_core",
  "async-channel",
  "async-trait",
@@ -197,7 +195,10 @@ dependencies = [
  "diddoc",
  "env_logger 0.9.3",
  "futures",
+ "indy-credx",
+ "indy-vdr",
  "lazy_static",
+ "libvdrtools",
  "log",
  "messages",
  "openssl",
@@ -4718,6 +4719,7 @@ name = "vcx-napi-rs"
 version = "0.55.0"
 dependencies = [
  "chrono",
+ "env_logger 0.9.3",
  "libvcx_core",
  "log",
  "napi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agency_client"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "android_logger",
  "async-trait",
@@ -183,7 +183,7 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "aries-vcx"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "agency_client",
  "android_logger",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "aries-vcx-agent"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "aries-vcx",
  "aries_vcx_core",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "diddoc"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "libvcx"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "agency_client",
  "android_logger",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "libvcx_core"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "agency_client",
  "aries-vcx",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "messages"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "chrono",
  "derive_more",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "shared_vcx"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "bs58 0.4.0",
  "lazy_static",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi_aries_vcx"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "aries-vcx",
  "async-trait",
@@ -4715,7 +4715,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vcx-napi-rs"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "chrono",
  "libvcx_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.54.1"
+version = "0.55.0"
 authors = ["Absa Group Limited", "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>"]
 description = "Absa's fork of HL LibVCX"
 license = "Apache-2.0"

--- a/agency_client/Cargo.toml
+++ b/agency_client/Cargo.toml
@@ -9,12 +9,12 @@ edition.workspace = true
 doctest = false
 
 [features]
-test_utils = []
+test_utils = [ "dep:env_logger" ]
 general_test = ["test_utils"]
 
 [dependencies]
 async-trait = "0.1.53"
-env_logger = "0.9.0"
+env_logger = { version = "0.9.0", optional = true } # Only for testing
 log = "0.4.16"
 lazy_static = "1.3"
 serde = "1.0.97"
@@ -26,9 +26,6 @@ url = { version = "2.3", features = ["serde"] }
 uuid = { version = "0.8", default-features = false, features = ["v4"]}
 thiserror = "1.0.37"
 shared_vcx = { path = "../shared_vcx" }
-
-[target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.5"
 
 [dev-dependencies]
 tokio = { version = "1.20", features = [ "rt", "macros" ] }

--- a/aries_vcx/Cargo.toml
+++ b/aries_vcx/Cargo.toml
@@ -24,7 +24,7 @@ diddoc = { path = "../diddoc" }
 aries_vcx_core = { path  = "../aries_vcx_core" }
 bs58 = "0.4.0"
 async-trait = "0.1.53"
-env_logger = "0.9.0"
+env_logger = { version = "0.9.0", optional = true } # Only for testing
 log = "0.4.16"
 chrono = "0.4.23"
 time = "0.1.44"
@@ -36,6 +36,23 @@ serde_derive = "1.0.97"
 regex = "1.1.0"
 base64 = "0.10"
 openssl = { version = "0.10.48" }
+libvdrtools = { path = "../libvdrtools", optional = true }
+# vdrtools alternatives ----
+indy-vdr = { version = "0.3.4", default-features = false, features = ["ffi", "log"], optional = true }
+# PATCH (TO MONITOR IN FUTURE): The following patch changes the `indy-data-types` (within indy-shared-rs) to depend on
+# `ursa "0.3.6"` rather than `ursa "=0.3.6"`. Currently, `libvdrtools` depends on `ursa "0.3.7"`, which causes a mismatch of
+# `indy-utils` versions, which causes some types within credx to fail. Details about the issue can be found here: https://github.com/hyperledger/indy-shared-rs/issues/20
+# `indy-data-types` depends on `ursa =0.3.6` due to a 'broken cl feature', see commmit: https://github.com/hyperledger/indy-shared-rs/commit/2403eed6449a3b5e347697b215a732fc33c014c0
+# however using ursa 0.3.7 does not seem to affect our usage of indy-credx currently. More testing would be ideal.
+# various combinations of indy-vdr and indy-credx have been tried to resolve the dependency mismatches, however this patch appears
+# to be the only quick solution.
+# Potential resolutions:
+# - wait for ursa 0.3.8+ to resolve the CL issue and update indy-shared-rs,
+# - monitor anoncred-rs (which will replace indy-credx) as the fix will likely go in here,
+# - monitor the issue for other fixes from the maintainers: https://github.com/hyperledger/indy-shared-rs/issues/20
+# - update libvdrtools to use =0.3.6 ursa
+indy-credx = { git = "https://github.com/anonyome/indy-shared-rs.git", rev = "7342bc624d23ece8845d1a701cd2cdc9cd401bb0", optional = true }
+# ----------------------
 futures = { version = "0.3", default-features = false }
 uuid = { version = "0.8", default-features = false, features = ["v4"] }
 strum = "0.16.0"
@@ -44,9 +61,6 @@ derive_builder = "0.10.2"
 tokio = { version = "1.20.4" }
 thiserror = "1.0.37"
 url = { version = "2.3", features = ["serde"] }
-
-[target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.5"
 
 [dev-dependencies]
 async-channel = "1.7.1"

--- a/aries_vcx/src/handlers/connection/cloud_agent.rs
+++ b/aries_vcx/src/handlers/connection/cloud_agent.rs
@@ -148,7 +148,6 @@ impl CloudAgentInfo {
         let a2a_messages = self
             .decrypt_decode_messages(&agency_client.get_wallet(), &messages, expect_sender_vk)
             .await?;
-        _log_messages_optionally(&a2a_messages);
         Ok(a2a_messages)
     }
 
@@ -174,7 +173,6 @@ impl CloudAgentInfo {
         let a2a_messages = self
             .decrypt_decode_messages_noauth(&agency_client.get_wallet(), &messages)
             .await?;
-        _log_messages_optionally(&a2a_messages);
         Ok(a2a_messages)
     }
 

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -42,7 +42,6 @@ use crate::utils::constants::GENESIS_PATH;
 use crate::utils::file::write_file;
 use crate::utils::get_temp_dir_path;
 use crate::utils::provision::provision_cloud_agent;
-use crate::utils::test_logger::LibvcxDefaultLogger;
 
 pub struct SetupEmpty;
 
@@ -561,7 +560,7 @@ lazy_static! {
 
 pub fn init_test_logging() {
     TEST_LOGGING_INIT.call_once(|| {
-        LibvcxDefaultLogger::init_testing_logger();
+        crate::utils::test_logger::TestLogger::init_testing_logger();
     })
 }
 

--- a/aries_vcx/src/utils/mod.rs
+++ b/aries_vcx/src/utils/mod.rs
@@ -10,7 +10,7 @@ use crate::utils::encryption_envelope::EncryptionEnvelope;
 use messages::AriesMessage;
 
 #[macro_use]
-#[cfg(feature = "vdrtools")]
+#[cfg(test)]
 pub mod devsetup;
 
 #[cfg(debug_assertions)]
@@ -54,7 +54,7 @@ pub mod random;
 pub mod uuid;
 
 #[macro_use]
-#[cfg(feature = "test_utils")]
+#[cfg(test)]
 pub mod test_logger;
 pub mod encryption_envelope;
 pub mod filters;

--- a/aries_vcx/src/utils/mod.rs
+++ b/aries_vcx/src/utils/mod.rs
@@ -54,6 +54,7 @@ pub mod random;
 pub mod uuid;
 
 #[macro_use]
+#[cfg(feature = "test_utils")]
 pub mod test_logger;
 pub mod encryption_envelope;
 pub mod filters;

--- a/aries_vcx/src/utils/test_logger.rs
+++ b/aries_vcx/src/utils/test_logger.rs
@@ -1,8 +1,3 @@
-#[cfg(target_os = "android")]
-extern crate android_logger;
-#[cfg(target_os = "android")]
-use self::android_logger::Filter;
-
 extern crate env_logger;
 extern crate log;
 
@@ -18,7 +13,7 @@ use self::env_logger::fmt::Formatter;
 use self::env_logger::Builder as EnvLoggerBuilder;
 use self::log::{LevelFilter, Record};
 
-pub struct LibvcxDefaultLogger;
+pub struct TestLogger;
 
 fn _get_timestamp<'a>() -> DelayedFormat<StrftimeItems<'a>> {
     Local::now().format("%Y-%m-%d %H:%M:%S.%f")
@@ -52,53 +47,33 @@ fn text_no_color_format(buf: &mut Formatter, record: &Record) -> std::io::Result
     )
 }
 
-impl LibvcxDefaultLogger {
+impl TestLogger {
     pub fn init_testing_logger() {
         env::var("RUST_LOG").map_or((), |log_pattern| {
-            LibvcxDefaultLogger::init(Some(log_pattern)).expect("Failed to initialize LibvcxDefaultLogger for testing");
+            TestLogger::init(Some(log_pattern)).expect("Failed to initialize LibvcxDefaultLogger for testing");
         });
     }
 
     pub fn init(pattern: Option<String>) -> VcxResult<()> {
         let pattern = pattern.or(env::var("RUST_LOG").ok());
-        if cfg!(target_os = "android") {
-            #[cfg(target_os = "android")]
-            let log_filter = match pattern.as_ref() {
-                Some(val) => match val.to_lowercase().as_ref() {
-                    "error" => Filter::default().with_min_level(log::Level::Error),
-                    "warn" => Filter::default().with_min_level(log::Level::Warn),
-                    "info" => Filter::default().with_min_level(log::Level::Info),
-                    "debug" => Filter::default().with_min_level(log::Level::Debug),
-                    "trace" => Filter::default().with_min_level(log::Level::Trace),
-                    _ => Filter::default().with_min_level(log::Level::Error),
-                },
-                None => Filter::default().with_min_level(log::Level::Error),
-            };
-
-            //Set logging to off when deploying production android app.
-            #[cfg(target_os = "android")]
-            android_logger::init_once(log_filter);
-            info!("Logging for Android");
-        } else {
-            let formatter = match env::var("RUST_LOG_FORMATTER") {
-                Ok(val) => match val.as_str() {
-                    "text_no_color" => text_no_color_format,
-                    _ => text_format,
-                },
+        let formatter = match env::var("RUST_LOG_FORMATTER") {
+            Ok(val) => match val.as_str() {
+                "text_no_color" => text_no_color_format,
                 _ => text_format,
-            };
-            EnvLoggerBuilder::new()
-                .format(formatter)
-                .filter(None, LevelFilter::Off)
-                .parse_filters(pattern.as_deref().unwrap_or("warn"))
-                .try_init()
-                .map_err(|err| {
-                    AriesVcxError::from_msg(
-                        AriesVcxErrorKind::LoggingError,
-                        format!("Cannot init logger: {:?}", err),
-                    )
-                })?;
-        }
+            },
+            _ => text_format,
+        };
+        EnvLoggerBuilder::new()
+            .format(formatter)
+            .filter(None, LevelFilter::Off)
+            .parse_filters(pattern.as_deref().unwrap_or("warn"))
+            .try_init()
+            .map_err(|err| {
+                AriesVcxError::from_msg(
+                    AriesVcxErrorKind::LoggingError,
+                    format!("Cannot init logger: {:?}", err),
+                )
+            })?;
         Ok(())
     }
 }

--- a/wrappers/node/package-lock.json
+++ b/wrappers/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/node-vcx-wrapper",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/node-vcx-wrapper",
-      "version": "0.54.1",
+      "version": "0.55.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hyperledger/vcx-napi-rs": "file:../vcx-napi-rs",

--- a/wrappers/node/package.json
+++ b/wrappers/node/package.json
@@ -3,7 +3,7 @@
   "name": "@hyperledger/node-vcx-wrapper",
   "description": "NodeJS wrapper Aries Framework",
   "license": "Apache-2.0",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "directories": {
     "test": "test",
     "build": "dist",

--- a/wrappers/vcx-napi-rs/Cargo.toml
+++ b/wrappers/vcx-napi-rs/Cargo.toml
@@ -12,12 +12,15 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
+env_logger = "0.9.0"
+chrono = "0.4.23"
 libvcx_core = { path = "../../libvcx_core"  }
 log = "0.4.16"
 napi = { version = "2.10.14", default-features = false, features = [ "async" ] }
 napi-derive = { version = "2.10.1" }
 uuid = { version = "0.8", default-features = false, features = ["v4"] }
 chrono = "0.4.23"
+
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/wrappers/vcx-napi-rs/Cargo.toml
+++ b/wrappers/vcx-napi-rs/Cargo.toml
@@ -19,7 +19,6 @@ log = "0.4.16"
 napi = { version = "2.10.14", default-features = false, features = [ "async" ] }
 napi-derive = { version = "2.10.1" }
 uuid = { version = "0.8", default-features = false, features = ["v4"] }
-chrono = "0.4.23"
 
 
 [build-dependencies]

--- a/wrappers/vcx-napi-rs/src/api/logging.rs
+++ b/wrappers/vcx-napi-rs/src/api/logging.rs
@@ -1,10 +1,72 @@
 use napi_derive::napi;
 
-use libvcx_core::aries_vcx::utils::test_logger::LibvcxDefaultLogger;
-
 use crate::error::ariesvcx_to_napi_err;
+
+use std::env;
+use std::io::Write;
+
+use chrono::format::{DelayedFormat, StrftimeItems};
+use chrono::Local;
+
+use env_logger::fmt::Formatter;
+use env_logger::Builder as EnvLoggerBuilder;
+use log::{LevelFilter, Record};
+
+pub struct Logger;
+
+fn _get_timestamp<'a>() -> DelayedFormat<StrftimeItems<'a>> {
+    Local::now().format("%Y-%m-%d %H:%M:%S.%f")
+}
+
+fn text_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
+    let level = buf.default_styled_level(record.level());
+    writeln!(
+        buf,
+        "{}|{:>5}|{:<30}|{:>35}:{:<4}| {}",
+        _get_timestamp(),
+        level,
+        record.target(),
+        record.file().get_or_insert(""),
+        record.line().get_or_insert(0),
+        record.args()
+    )
+}
+
+fn text_no_color_format(buf: &mut Formatter, record: &Record) -> std::io::Result<()> {
+    let level = record.level();
+    writeln!(
+        buf,
+        "{}|{:>5}|{:<30}|{:>35}:{:<4}| {}",
+        _get_timestamp(),
+        level,
+        record.target(),
+        record.file().get_or_insert(""),
+        record.line().get_or_insert(0),
+        record.args()
+    )
+}
+
+impl Logger {
+    pub fn init(pattern: Option<String>) -> napi::Result<()> {
+        let pattern = pattern.or(env::var("RUST_LOG").ok());
+        let formatter = match env::var("RUST_LOG_FORMATTER") {
+            Ok(val) => match val.as_str() {
+                "text_no_color" => text_no_color_format,
+                _ => text_format,
+            },
+            _ => text_format,
+        };
+        EnvLoggerBuilder::new()
+            .format(formatter)
+            .filter(None, LevelFilter::Off)
+            .parse_filters(pattern.as_deref().unwrap_or("warn"))
+            .try_init()
+            .map_err(|err| napi::Error::new(napi::Status::GenericFailure, format!("Cannot init logger: {:?}", err)))?;
+        Ok(())
+    }
+}
 
 #[napi]
 pub fn init_default_logger(pattern: Option<String>) -> napi::Result<()> {
-    LibvcxDefaultLogger::init(pattern).map_err(ariesvcx_to_napi_err)
+    Logger::init(pattern)
 }

--- a/wrappers/vcx-napi-rs/src/lib.rs
+++ b/wrappers/vcx-napi-rs/src/lib.rs
@@ -2,6 +2,8 @@
 
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate env_logger;
 extern crate core;
 
 pub mod api;


### PR DESCRIPTION
- `aries-vcx` should not specify `log` implementation, removed `env_logger` as well as android build dependency `android_logger`
- similar changes in other crates as well
- added `env_logger` to `vcx-napi-rs` along with its initialization (same as previously in `aries-vcx`) 