### PR TITLE
Regression: Fix dependency tree when using aries_vcx_core

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,6 +150,28 @@ jobs:
         run: |
           cd libvcx && cargo clippy
 
+  check-aries-vcx-feature-variants:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Git checkout"
+        uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65.0
+          components: rustfmt, clippy
+      - name: "Install dependencies"
+        shell: bash
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libsodium-dev libssl-dev libzmq3-dev
+      - name: "Verify aries_vcx compiles with different dependency feature variants"
+        run: |
+          cd aries_vcx
+          cargo check
+          cargo check --no-default-features
+          cargo check --features vdrtools --no-default-features
+          cargo check --features modular_libs --no-default-features
+
   ##########################################################################################
   ##############################   DOCKER BUILD   ##########################################
 

--- a/aries_vcx/Cargo.toml
+++ b/aries_vcx/Cargo.toml
@@ -36,6 +36,10 @@ fatal_warnings = []
 warnlog_fetched_messages = []
 
 [dependencies]
+agency_client = { path = "../agency_client" }
+messages = { path  = "../messages" }
+# default-features as false, since we transitively choose features via `vdrtools` and `modular_libs` features
+aries_vcx_core = { path  = "../aries_vcx_core", default-features = false }
 bs58 = "0.4.0"
 async-trait = "0.1.53"
 env_logger = "0.9.0"
@@ -50,16 +54,12 @@ serde_derive = "1.0.97"
 regex = "1.1.0"
 base64 = "0.10"
 openssl = { version = "0.10.48" }
-# ----------------------
 futures = { version = "0.3", default-features = false }
 uuid = { version = "0.8", default-features = false, features = ["v4"] }
 strum = "0.16.0"
 strum_macros = "0.16.0"
-agency_client = { path = "../agency_client" }
 derive_builder = "0.10.2"
 tokio = { version = "1.20.4" }
-messages = { path  = "../messages" }
-aries_vcx_core = { path  = "../aries_vcx_core" }
 thiserror = "1.0.37"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/aries_vcx/src/global/settings.rs
+++ b/aries_vcx/src/global/settings.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use aries_vcx_core::global::settings::{disable_indy_mocks, enable_indy_mocks};
-use aries_vcx_core::indy::wallet::IssuerConfig;
 
 use crate::errors::error::prelude::*;
 

--- a/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
@@ -1,5 +1,4 @@
 use aries_vcx_core::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
-use aries_vcx_core::indy::utils::mocks::did_mocks::DidMocks;
 use aries_vcx_core::utils::async_fn_iterator::AsyncFnIterator;
 use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use async_trait::async_trait;

--- a/aries_vcx_core/src/indy/credentials/issuer/mod.rs
+++ b/aries_vcx_core/src/indy/credentials/issuer/mod.rs
@@ -3,9 +3,9 @@ use vdrtools::{CredentialOffer, CredentialRequest, CredentialValues, Locator, Re
 use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
 use crate::global::settings;
 use crate::indy::anoncreds;
+use crate::indy::utils::parse_and_validate;
 use crate::utils::constants::LIBINDY_CRED_OFFER;
 use crate::utils::mockdata::mock_settings::StatusCodeMock;
-use crate::indy::utils::parse_and_validate;
 use crate::{utils, WalletHandle};
 
 pub async fn libindy_issuer_create_credential_offer(

--- a/aries_vcx_core/src/indy/credentials/issuer/mod.rs
+++ b/aries_vcx_core/src/indy/credentials/issuer/mod.rs
@@ -5,7 +5,7 @@ use crate::global::settings;
 use crate::indy::anoncreds;
 use crate::utils::constants::LIBINDY_CRED_OFFER;
 use crate::utils::mockdata::mock_settings::StatusCodeMock;
-use crate::utils::parse_and_validate;
+use crate::indy::utils::parse_and_validate;
 use crate::{utils, WalletHandle};
 
 pub async fn libindy_issuer_create_credential_offer(

--- a/aries_vcx_core/src/indy/ledger/transactions.rs
+++ b/aries_vcx_core/src/indy/ledger/transactions.rs
@@ -8,7 +8,7 @@ use crate::utils::constants::{
     rev_def_json, CRED_DEF_ID, CRED_DEF_JSON, CRED_DEF_REQ, REVOC_REG_TYPE, REV_REG_DELTA_JSON, REV_REG_ID,
     REV_REG_JSON, SCHEMA_ID, SCHEMA_JSON, SCHEMA_TXN, SUBMIT_SCHEMA_RESPONSE,
 };
-use crate::utils::parse_and_validate;
+use crate::indy::utils::parse_and_validate;
 use crate::utils::random::generate_random_did;
 use crate::{utils, PoolHandle, WalletHandle};
 

--- a/aries_vcx_core/src/indy/ledger/transactions.rs
+++ b/aries_vcx_core/src/indy/ledger/transactions.rs
@@ -4,11 +4,11 @@ use crate::common::ledger::transactions::{Request, Response};
 use crate::errors::error::prelude::*;
 use crate::global::settings;
 use crate::indy::utils::mocks::pool_mocks::PoolMocks;
+use crate::indy::utils::parse_and_validate;
 use crate::utils::constants::{
     rev_def_json, CRED_DEF_ID, CRED_DEF_JSON, CRED_DEF_REQ, REVOC_REG_TYPE, REV_REG_DELTA_JSON, REV_REG_ID,
     REV_REG_JSON, SCHEMA_ID, SCHEMA_JSON, SCHEMA_TXN, SUBMIT_SCHEMA_RESPONSE,
 };
-use crate::indy::utils::parse_and_validate;
 use crate::utils::random::generate_random_did;
 use crate::{utils, PoolHandle, WalletHandle};
 

--- a/aries_vcx_core/src/indy/mod.rs
+++ b/aries_vcx_core/src/indy/mod.rs
@@ -9,3 +9,18 @@ pub(crate) mod signing;
 pub mod utils;
 pub mod wallet; // temporarily left public due to wallet set up utils
 pub(crate) mod wallet_non_secrets;
+
+
+// Vdrtools handle wrappers
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct WalletHandle(pub vdrtools::WalletHandle);
+pub const INVALID_WALLET_HANDLE: WalletHandle = WalletHandle(vdrtools::INVALID_WALLET_HANDLE);
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct SearchHandle(pub vdrtools::SearchHandle);
+pub const INVALID_SEARCH_HANDLE: SearchHandle = SearchHandle(vdrtools::INVALID_SEARCH_HANDLE);
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct PoolHandle(pub vdrtools::PoolHandle);
+pub const INVALID_POOL_HANDLE: PoolHandle = PoolHandle(vdrtools::INVALID_POOL_HANDLE);

--- a/aries_vcx_core/src/indy/mod.rs
+++ b/aries_vcx_core/src/indy/mod.rs
@@ -10,7 +10,6 @@ pub mod utils;
 pub mod wallet; // temporarily left public due to wallet set up utils
 pub(crate) mod wallet_non_secrets;
 
-
 // Vdrtools handle wrappers
 
 #[derive(Debug, PartialEq, Copy, Clone)]

--- a/aries_vcx_core/src/indy/primitives/credential_definition.rs
+++ b/aries_vcx_core/src/indy/primitives/credential_definition.rs
@@ -3,7 +3,7 @@ use vdrtools::{DidValue, Locator};
 use crate::errors::error::VcxCoreResult;
 use crate::global::settings;
 use crate::indy::ledger::transactions::{build_cred_def_request, check_response, sign_and_submit_to_ledger};
-use crate::utils::parse_and_validate;
+use crate::indy::utils::parse_and_validate;
 use crate::{PoolHandle, WalletHandle};
 
 // consider relocating out of primitive

--- a/aries_vcx_core/src/indy/primitives/revocation_registry.rs
+++ b/aries_vcx_core/src/indy/primitives/revocation_registry.rs
@@ -6,8 +6,8 @@ use crate::indy::anoncreds;
 use crate::indy::ledger::transactions::{
     build_rev_reg_delta_request, build_rev_reg_request, check_response, sign_and_submit_to_ledger,
 };
-use crate::indy::wallet_non_secrets::{clear_rev_reg_delta, get_rev_reg_delta, set_rev_reg_delta};
 use crate::indy::utils::parse_and_validate;
+use crate::indy::wallet_non_secrets::{clear_rev_reg_delta, get_rev_reg_delta, set_rev_reg_delta};
 use crate::{PoolHandle, WalletHandle};
 
 pub const BLOB_STORAGE_TYPE: &str = "default";

--- a/aries_vcx_core/src/indy/primitives/revocation_registry.rs
+++ b/aries_vcx_core/src/indy/primitives/revocation_registry.rs
@@ -7,7 +7,7 @@ use crate::indy::ledger::transactions::{
     build_rev_reg_delta_request, build_rev_reg_request, check_response, sign_and_submit_to_ledger,
 };
 use crate::indy::wallet_non_secrets::{clear_rev_reg_delta, get_rev_reg_delta, set_rev_reg_delta};
-use crate::utils::parse_and_validate;
+use crate::indy::utils::parse_and_validate;
 use crate::{PoolHandle, WalletHandle};
 
 pub const BLOB_STORAGE_TYPE: &str = "default";

--- a/aries_vcx_core/src/indy/proofs/prover/mod.rs
+++ b/aries_vcx_core/src/indy/proofs/prover/mod.rs
@@ -5,8 +5,8 @@ use vdrtools::Locator;
 use crate::errors::error::VcxCoreResult;
 use crate::global::settings;
 use crate::indy;
-use crate::utils::constants::REV_STATE_JSON;
 use crate::indy::utils::parse_and_validate;
+use crate::utils::constants::REV_STATE_JSON;
 
 pub async fn libindy_prover_create_revocation_state(
     tails_file_path: &str,

--- a/aries_vcx_core/src/indy/proofs/prover/mod.rs
+++ b/aries_vcx_core/src/indy/proofs/prover/mod.rs
@@ -6,7 +6,7 @@ use crate::errors::error::VcxCoreResult;
 use crate::global::settings;
 use crate::indy;
 use crate::utils::constants::REV_STATE_JSON;
-use crate::utils::parse_and_validate;
+use crate::indy::utils::parse_and_validate;
 
 pub async fn libindy_prover_create_revocation_state(
     tails_file_path: &str,

--- a/aries_vcx_core/src/indy/proofs/prover/prover.rs
+++ b/aries_vcx_core/src/indy/proofs/prover/prover.rs
@@ -5,7 +5,7 @@ use crate::errors::error::prelude::*;
 use crate::global::settings;
 use crate::indy::anoncreds::close_search_handle;
 use crate::utils::constants::{ATTRS, PROOF_REQUESTED_PREDICATES, REQUESTED_ATTRIBUTES};
-use crate::utils::parse_and_validate;
+use crate::indy::utils::parse_and_validate;
 use crate::{utils, WalletHandle};
 
 pub async fn libindy_prover_create_proof(

--- a/aries_vcx_core/src/indy/proofs/prover/prover.rs
+++ b/aries_vcx_core/src/indy/proofs/prover/prover.rs
@@ -4,8 +4,8 @@ use vdrtools::{Locator, SearchHandle};
 use crate::errors::error::prelude::*;
 use crate::global::settings;
 use crate::indy::anoncreds::close_search_handle;
-use crate::utils::constants::{ATTRS, PROOF_REQUESTED_PREDICATES, REQUESTED_ATTRIBUTES};
 use crate::indy::utils::parse_and_validate;
+use crate::utils::constants::{ATTRS, PROOF_REQUESTED_PREDICATES, REQUESTED_ATTRIBUTES};
 use crate::{utils, WalletHandle};
 
 pub async fn libindy_prover_create_proof(

--- a/aries_vcx_core/src/indy/proofs/verifier/verifier.rs
+++ b/aries_vcx_core/src/indy/proofs/verifier/verifier.rs
@@ -1,7 +1,7 @@
 use vdrtools::Locator;
 
 use crate::errors::error::VcxCoreResult;
-use crate::utils::parse_and_validate;
+use crate::indy::utils::parse_and_validate;
 
 pub async fn libindy_verifier_verify_proof(
     proof_req_json: &str,

--- a/aries_vcx_core/src/indy/utils/mod.rs
+++ b/aries_vcx_core/src/indy/utils/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
-use vdrtools::{CommandHandle, types::validation::Validatable};
+use vdrtools::{types::validation::Validatable, CommandHandle};
 
-use crate::errors::error::{VcxCoreResult, AriesVcxCoreError, AriesVcxCoreErrorKind};
+use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
 
 pub mod mocks;
 

--- a/aries_vcx_core/src/lib.rs
+++ b/aries_vcx_core/src/lib.rs
@@ -30,19 +30,13 @@ pub mod anoncreds;
 mod common;
 pub mod errors;
 pub mod global;
+#[cfg(feature = "vdrtools")]
 pub mod indy;
 pub mod ledger;
 pub mod utils;
 pub mod wallet;
 
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub struct WalletHandle(pub vdrtools::WalletHandle);
-pub const INVALID_WALLET_HANDLE: WalletHandle = WalletHandle(vdrtools::INVALID_WALLET_HANDLE);
-
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub struct SearchHandle(pub vdrtools::SearchHandle);
-pub const INVALID_SEARCH_HANDLE: SearchHandle = SearchHandle(vdrtools::INVALID_SEARCH_HANDLE);
-
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub struct PoolHandle(pub vdrtools::PoolHandle);
-pub const INVALID_POOL_HANDLE: PoolHandle = PoolHandle(vdrtools::INVALID_POOL_HANDLE);
+#[cfg(feature = "vdrtools")]
+pub use indy::{
+    PoolHandle, SearchHandle, WalletHandle, INVALID_POOL_HANDLE, INVALID_SEARCH_HANDLE, INVALID_WALLET_HANDLE,
+};

--- a/aries_vcx_core/src/utils/mod.rs
+++ b/aries_vcx_core/src/utils/mod.rs
@@ -1,9 +1,5 @@
 use std::{env, path::PathBuf};
 
-use vdrtools::types::validation::Validatable;
-
-use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
-
 pub mod async_fn_iterator;
 pub(crate) mod author_agreement;
 pub(crate) mod constants;
@@ -11,22 +7,6 @@ pub(crate) mod json;
 pub(crate) mod mockdata;
 pub(crate) mod random;
 pub(crate) mod uuid;
-
-pub fn parse_and_validate<'a, T>(s: &'a str) -> VcxCoreResult<T>
-where
-    T: Validatable,
-    T: serde::Deserialize<'a>,
-{
-    let data = serde_json::from_str::<T>(s)?;
-
-    match data.validate() {
-        Ok(_) => Ok(data),
-        Err(s) => Err(AriesVcxCoreError::from_msg(
-            AriesVcxCoreErrorKind::LibindyInvalidStructure,
-            s,
-        )),
-    }
-}
 
 pub fn get_temp_dir_path(filename: &str) -> PathBuf {
     let mut path = env::temp_dir();


### PR DESCRIPTION
apologies, I should have manually checked this when approving the core PR.

But since the aries_vcx_core crate was being pulled in without opting out of default features, this means that the aries_vcx crate now has no way to opt-out of depending on vdrtools.

This fix addresses that regression whilst keeping vdrtools as the default flag (should not affect consumers who are happy with the default vdrtools flag)


I also fix some of regressions in certain indy elements which should remain to be hidden behind the vdrtools.

also added a CI step to check the aries_vcx compiles with some of the common feature flags