### PR TITLE
Verifier presentation failure adjustments

### DIFF
--- a/agents/node/vcxagent-core/test/issue-verify.spec.js
+++ b/agents/node/vcxagent-core/test/issue-verify.spec.js
@@ -138,7 +138,7 @@ describe('test update state', () => {
     const request = await faber.requestProofFromAlice(proofRequestDataStandard(issuerDid))
     await alice.sendHolderProof(JSON.parse(request), revRegId => tailsDir, { attribute_3: 'Smith' })
     await faber.updateStateVerifierProof(VerifierStateType.Finished)
-    await alice.updateStateHolderProof(ProverStateType.Finished)
+    await alice.updateStateHolderProof(ProverStateType.Failed)
     const {
       presentationVerificationStatus
     } = await faber.getPresentationInfo()


### PR DESCRIPTION
This PR fixes an emerging problem regarding the verifier not doing anything in case the presentation verification fails (a problem report might be generated, but not sent, so the prover would be in the dark). 