### PR TITLE
Fix/protocols problem report

### DIFF
--- a/aries_vcx/src/handlers/util.rs
+++ b/aries_vcx/src/handlers/util.rs
@@ -98,6 +98,9 @@ pub fn verify_thread_id(thread_id: &str, message: &AriesMessage) -> VcxResult<()
         AriesMessage::CredentialIssuance(CredentialIssuance::RequestCredential(msg)) => {
             matches_opt_thread_id!(msg, thread_id)
         }
+        AriesMessage::CredentialIssuance(CredentialIssuance::ProblemReport(msg)) => {
+            matches_opt_thread_id!(msg, thread_id)
+        }
         AriesMessage::DiscoverFeatures(DiscoverFeatures::Query(msg)) => msg.id == thread_id,
         AriesMessage::DiscoverFeatures(DiscoverFeatures::Disclose(msg)) => matches_thread_id!(msg, thread_id),
         AriesMessage::Notification(Notification::Ack(msg)) => matches_thread_id!(msg, thread_id),
@@ -109,6 +112,7 @@ pub fn verify_thread_id(thread_id: &str, message: &AriesMessage) -> VcxResult<()
         AriesMessage::PresentProof(PresentProof::Presentation(msg)) => matches_thread_id!(msg, thread_id),
         AriesMessage::PresentProof(PresentProof::ProposePresentation(msg)) => matches_opt_thread_id!(msg, thread_id),
         AriesMessage::PresentProof(PresentProof::RequestPresentation(msg)) => matches_opt_thread_id!(msg, thread_id),
+        AriesMessage::PresentProof(PresentProof::ProblemReport(msg)) => matches_opt_thread_id!(msg, thread_id),
         AriesMessage::ReportProblem(msg) => matches_opt_thread_id!(msg, thread_id),
         AriesMessage::Revocation(Revocation::Revoke(msg)) => matches_opt_thread_id!(msg, thread_id),
         AriesMessage::Revocation(Revocation::Ack(msg)) => matches_thread_id!(msg, thread_id),

--- a/aries_vcx/src/protocols/issuance/actions.rs
+++ b/aries_vcx/src/protocols/issuance/actions.rs
@@ -56,7 +56,7 @@ impl From<AriesMessage> for CredentialIssuanceAction {
             }
             AriesMessage::CredentialIssuance(CredentialIssuance::Ack(ack)) => {
                 CredentialIssuanceAction::CredentialAck(ack)
-            },
+            }
             AriesMessage::Notification(Notification::Ack(ack)) => {
                 let MsgParts {
                     id,

--- a/aries_vcx/src/protocols/issuance/actions.rs
+++ b/aries_vcx/src/protocols/issuance/actions.rs
@@ -56,7 +56,7 @@ impl From<AriesMessage> for CredentialIssuanceAction {
             }
             AriesMessage::CredentialIssuance(CredentialIssuance::Ack(ack)) => {
                 CredentialIssuanceAction::CredentialAck(ack)
-            }
+            },
             AriesMessage::Notification(Notification::Ack(ack)) => {
                 let MsgParts {
                     id,
@@ -68,6 +68,15 @@ impl From<AriesMessage> for CredentialIssuanceAction {
             }
             AriesMessage::ReportProblem(report) => CredentialIssuanceAction::ProblemReport(report),
             AriesMessage::Notification(Notification::ProblemReport(report)) => {
+                let MsgParts {
+                    id,
+                    content,
+                    decorators,
+                } = report;
+                let report = ProblemReport::with_decorators(id, content.0, decorators);
+                CredentialIssuanceAction::ProblemReport(report)
+            }
+            AriesMessage::CredentialIssuance(CredentialIssuance::ProblemReport(report)) => {
                 let MsgParts {
                     id,
                     content,

--- a/aries_vcx/src/protocols/issuance/holder/state_machine.rs
+++ b/aries_vcx/src/protocols/issuance/holder/state_machine.rs
@@ -172,6 +172,11 @@ impl HolderSM {
                             return Some((uid, message));
                         }
                     }
+                    AriesMessage::CredentialIssuance(CredentialIssuance::ProblemReport(problem_report)) => {
+                        if matches_opt_thread_id!(problem_report, self.thread_id.as_str()) {
+                            return Some((uid, message));
+                        }
+                    }
                     AriesMessage::ReportProblem(problem_report) => {
                         if matches_opt_thread_id!(problem_report, self.thread_id.as_str()) {
                             return Some((uid, message));

--- a/aries_vcx/src/protocols/proof_presentation/prover/messages.rs
+++ b/aries_vcx/src/protocols/proof_presentation/prover/messages.rs
@@ -54,6 +54,9 @@ impl From<AriesMessage> for ProverMessages {
                 ProverMessages::PresentationAckReceived(ack)
             }
             AriesMessage::PresentProof(PresentProof::Ack(ack)) => ProverMessages::PresentationAckReceived(ack),
+            AriesMessage::PresentProof(PresentProof::RequestPresentation(request)) => {
+                ProverMessages::PresentationRequestReceived(request)
+            }
             AriesMessage::ReportProblem(report) => ProverMessages::PresentationRejectReceived(report),
             AriesMessage::Notification(Notification::ProblemReport(report)) => {
                 let MsgParts {
@@ -64,8 +67,14 @@ impl From<AriesMessage> for ProverMessages {
                 let report = ProblemReport::with_decorators(id, content.0, decorators);
                 ProverMessages::PresentationRejectReceived(report)
             }
-            AriesMessage::PresentProof(PresentProof::RequestPresentation(request)) => {
-                ProverMessages::PresentationRequestReceived(request)
+            AriesMessage::PresentProof(PresentProof::ProblemReport(report)) => {
+                let MsgParts {
+                    id,
+                    content,
+                    decorators,
+                } = report;
+                let report = ProblemReport::with_decorators(id, content.0, decorators);
+                ProverMessages::PresentationRejectReceived(report)
             }
             _ => ProverMessages::Unknown,
         }

--- a/aries_vcx/src/protocols/proof_presentation/prover/state_machine.rs
+++ b/aries_vcx/src/protocols/proof_presentation/prover/state_machine.rs
@@ -324,6 +324,11 @@ impl ProverSM {
                             return Some((uid, message));
                         }
                     }
+                    AriesMessage::PresentProof(PresentProof::ProblemReport(msg)) => {
+                        if matches_opt_thread_id!(msg, self.thread_id.as_str()) {
+                            return Some((uid, message));
+                        }
+                    }
                     _ => {}
                 },
                 _ => {}

--- a/aries_vcx/src/protocols/proof_presentation/verifier/messages.rs
+++ b/aries_vcx/src/protocols/proof_presentation/verifier/messages.rs
@@ -55,6 +55,15 @@ impl From<AriesMessage> for VerifierMessages {
                 let report = ProblemReport::with_decorators(id, content.0, decorators);
                 VerifierMessages::PresentationRejectReceived(report)
             }
+            AriesMessage::PresentProof(PresentProof::ProblemReport(report)) => {
+                let MsgParts {
+                    id,
+                    content,
+                    decorators,
+                } = report;
+                let report = ProblemReport::with_decorators(id, content.0, decorators);
+                VerifierMessages::PresentationRejectReceived(report)
+            }
             _ => VerifierMessages::Unknown,
         }
     }

--- a/aries_vcx/src/protocols/proof_presentation/verifier/state_machine.rs
+++ b/aries_vcx/src/protocols/proof_presentation/verifier/state_machine.rs
@@ -20,10 +20,8 @@ use chrono::Utc;
 use messages::decorators::thread::Thread;
 use messages::decorators::timing::Timing;
 use messages::msg_fields::protocols::notification::ack::{AckDecorators, AckStatus};
-use messages::msg_fields::protocols::notification::problem_report::{
-    NotificationProblemReport, NotificationProblemReportContent,
-};
 use messages::msg_fields::protocols::present_proof::ack::{AckPresentation, AckPresentationContent};
+use messages::msg_fields::protocols::present_proof::problem_report::{PresentProofProblemReport, PresentProofProblemReportContent};
 use messages::msg_fields::protocols::present_proof::request::{
     RequestPresentation, RequestPresentationContent, RequestPresentationDecorators,
 };
@@ -257,9 +255,9 @@ impl VerifierSM {
                             decorators,
                         } = problem_report;
 
-                        let problem_report = NotificationProblemReport::with_decorators(
+                        let problem_report = PresentProofProblemReport::with_decorators(
                             id,
-                            NotificationProblemReportContent(content),
+                            PresentProofProblemReportContent(content),
                             decorators,
                         );
 

--- a/aries_vcx/src/protocols/proof_presentation/verifier/state_machine.rs
+++ b/aries_vcx/src/protocols/proof_presentation/verifier/state_machine.rs
@@ -21,7 +21,9 @@ use messages::decorators::thread::Thread;
 use messages::decorators::timing::Timing;
 use messages::msg_fields::protocols::notification::ack::{AckDecorators, AckStatus};
 use messages::msg_fields::protocols::present_proof::ack::{AckPresentation, AckPresentationContent};
-use messages::msg_fields::protocols::present_proof::problem_report::{PresentProofProblemReport, PresentProofProblemReportContent};
+use messages::msg_fields::protocols::present_proof::problem_report::{
+    PresentProofProblemReport, PresentProofProblemReportContent,
+};
 use messages::msg_fields::protocols::present_proof::request::{
     RequestPresentation, RequestPresentationContent, RequestPresentationDecorators,
 };

--- a/ci/libvcx.dockerfile
+++ b/ci/libvcx.dockerfile
@@ -30,6 +30,6 @@ RUN cp /usr/share/zoneinfo/UTC /etc/localtime && echo UTC > /etc/timezone
 ENV TZ=UTC
 
 RUN echo 'https://dl-cdn.alpinelinux.org/alpine/v3.17/main' >> /etc/apk/repositories
-RUN apk add --no-cache nodejs=18.14.2-r0
+RUN apk add --no-cache nodejs~=18
 
 USER node

--- a/messages/src/msg_fields/protocols/cred_issuance/mod.rs
+++ b/messages/src/msg_fields/protocols/cred_issuance/mod.rs
@@ -3,9 +3,9 @@
 pub mod ack;
 pub mod issue_credential;
 pub mod offer_credential;
+pub mod problem_report;
 pub mod propose_credential;
 pub mod request_credential;
-pub mod problem_report;
 
 use std::str::FromStr;
 
@@ -17,8 +17,9 @@ use self::{
     ack::{AckCredential, AckCredentialContent},
     issue_credential::{IssueCredential, IssueCredentialContent, IssueCredentialDecorators},
     offer_credential::{OfferCredential, OfferCredentialContent, OfferCredentialDecorators},
+    problem_report::{CredIssuanceProblemReport, CredIssuanceProblemReportContent},
     propose_credential::{ProposeCredential, ProposeCredentialContent, ProposeCredentialDecorators},
-    request_credential::{RequestCredential, RequestCredentialContent, RequestCredentialDecorators}, problem_report::{CredIssuanceProblemReport, CredIssuanceProblemReportContent},
+    request_credential::{RequestCredential, RequestCredentialContent, RequestCredentialDecorators},
 };
 use super::{notification::ack::AckDecorators, report_problem::ProblemReportDecorators};
 use crate::{
@@ -68,7 +69,9 @@ impl DelayedSerde for CredentialIssuance {
             }
             CredentialIssuanceTypeV1_0::IssueCredential => IssueCredential::deserialize(deserializer).map(From::from),
             CredentialIssuanceTypeV1_0::Ack => AckCredential::deserialize(deserializer).map(From::from),
-            CredentialIssuanceTypeV1_0::ProblemReport => CredIssuanceProblemReport::deserialize(deserializer).map(From::from),
+            CredentialIssuanceTypeV1_0::ProblemReport => {
+                CredIssuanceProblemReport::deserialize(deserializer).map(From::from)
+            }
             CredentialIssuanceTypeV1_0::CredentialPreview => Err(utils::not_standalone_msg::<D>(kind_str)),
         }
     }
@@ -178,7 +181,10 @@ transit_to_aries_msg!(
 );
 transit_to_aries_msg!(IssueCredentialContent: IssueCredentialDecorators, CredentialIssuance);
 transit_to_aries_msg!(AckCredentialContent: AckDecorators, CredentialIssuance);
-transit_to_aries_msg!(CredIssuanceProblemReportContent: ProblemReportDecorators, CredentialIssuance);
+transit_to_aries_msg!(
+    CredIssuanceProblemReportContent: ProblemReportDecorators,
+    CredentialIssuance
+);
 
 into_msg_with_type!(OfferCredential, CredentialIssuanceTypeV1_0, OfferCredential);
 into_msg_with_type!(ProposeCredential, CredentialIssuanceTypeV1_0, ProposeCredential);

--- a/messages/src/msg_fields/protocols/cred_issuance/mod.rs
+++ b/messages/src/msg_fields/protocols/cred_issuance/mod.rs
@@ -5,6 +5,7 @@ pub mod issue_credential;
 pub mod offer_credential;
 pub mod propose_credential;
 pub mod request_credential;
+pub mod problem_report;
 
 use std::str::FromStr;
 
@@ -17,9 +18,9 @@ use self::{
     issue_credential::{IssueCredential, IssueCredentialContent, IssueCredentialDecorators},
     offer_credential::{OfferCredential, OfferCredentialContent, OfferCredentialDecorators},
     propose_credential::{ProposeCredential, ProposeCredentialContent, ProposeCredentialDecorators},
-    request_credential::{RequestCredential, RequestCredentialContent, RequestCredentialDecorators},
+    request_credential::{RequestCredential, RequestCredentialContent, RequestCredentialDecorators}, problem_report::{CredIssuanceProblemReport, CredIssuanceProblemReportContent},
 };
-use super::notification::ack::AckDecorators;
+use super::{notification::ack::AckDecorators, report_problem::ProblemReportDecorators};
 use crate::{
     misc::{
         utils::{self, into_msg_with_type, transit_to_aries_msg},
@@ -42,6 +43,7 @@ pub enum CredentialIssuance {
     RequestCredential(RequestCredential),
     IssueCredential(IssueCredential),
     Ack(AckCredential),
+    ProblemReport(CredIssuanceProblemReport),
 }
 
 impl DelayedSerde for CredentialIssuance {
@@ -66,6 +68,7 @@ impl DelayedSerde for CredentialIssuance {
             }
             CredentialIssuanceTypeV1_0::IssueCredential => IssueCredential::deserialize(deserializer).map(From::from),
             CredentialIssuanceTypeV1_0::Ack => AckCredential::deserialize(deserializer).map(From::from),
+            CredentialIssuanceTypeV1_0::ProblemReport => CredIssuanceProblemReport::deserialize(deserializer).map(From::from),
             CredentialIssuanceTypeV1_0::CredentialPreview => Err(utils::not_standalone_msg::<D>(kind_str)),
         }
     }
@@ -80,6 +83,7 @@ impl DelayedSerde for CredentialIssuance {
             Self::RequestCredential(v) => MsgWithType::from(v).serialize(serializer),
             Self::IssueCredential(v) => MsgWithType::from(v).serialize(serializer),
             Self::Ack(v) => MsgWithType::from(v).serialize(serializer),
+            Self::ProblemReport(v) => MsgWithType::from(v).serialize(serializer),
         }
     }
 }
@@ -174,9 +178,11 @@ transit_to_aries_msg!(
 );
 transit_to_aries_msg!(IssueCredentialContent: IssueCredentialDecorators, CredentialIssuance);
 transit_to_aries_msg!(AckCredentialContent: AckDecorators, CredentialIssuance);
+transit_to_aries_msg!(CredIssuanceProblemReportContent: ProblemReportDecorators, CredentialIssuance);
 
 into_msg_with_type!(OfferCredential, CredentialIssuanceTypeV1_0, OfferCredential);
 into_msg_with_type!(ProposeCredential, CredentialIssuanceTypeV1_0, ProposeCredential);
 into_msg_with_type!(RequestCredential, CredentialIssuanceTypeV1_0, RequestCredential);
 into_msg_with_type!(IssueCredential, CredentialIssuanceTypeV1_0, IssueCredential);
 into_msg_with_type!(AckCredential, CredentialIssuanceTypeV1_0, Ack);
+into_msg_with_type!(CredIssuanceProblemReport, CredentialIssuanceTypeV1_0, ProblemReport);

--- a/messages/src/msg_fields/protocols/cred_issuance/problem_report.rs
+++ b/messages/src/msg_fields/protocols/cred_issuance/problem_report.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    msg_fields::protocols::report_problem::{ProblemReportContent, ProblemReportDecorators},
+    msg_parts::MsgParts,
+};
+
+pub type CredIssuanceProblemReport = MsgParts<CredIssuanceProblemReportContent, ProblemReportDecorators>;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(transparent)]
+pub struct CredIssuanceProblemReportContent(pub ProblemReportContent);
+
+impl CredIssuanceProblemReportContent {
+    pub fn new(code: String) -> Self {
+        Self(ProblemReportContent::new(code))
+    }
+}

--- a/messages/src/msg_fields/protocols/present_proof/mod.rs
+++ b/messages/src/msg_fields/protocols/present_proof/mod.rs
@@ -4,6 +4,7 @@ pub mod ack;
 pub mod present;
 pub mod propose;
 pub mod request;
+pub mod problem_report;
 
 use derive_more::From;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
@@ -12,9 +13,9 @@ use self::{
     ack::{AckPresentation, AckPresentationContent},
     present::{Presentation, PresentationContent, PresentationDecorators},
     propose::{ProposePresentation, ProposePresentationContent, ProposePresentationDecorators},
-    request::{RequestPresentation, RequestPresentationContent, RequestPresentationDecorators},
+    request::{RequestPresentation, RequestPresentationContent, RequestPresentationDecorators}, problem_report::{PresentProofProblemReport, PresentProofProblemReportContent},
 };
-use super::notification::ack::AckDecorators;
+use super::{notification::ack::AckDecorators, report_problem::ProblemReportDecorators};
 use crate::{
     misc::utils::{self, into_msg_with_type, transit_to_aries_msg},
     msg_fields::traits::DelayedSerde,
@@ -30,6 +31,7 @@ pub enum PresentProof {
     RequestPresentation(RequestPresentation),
     Presentation(Presentation),
     Ack(AckPresentation),
+    ProblemReport(PresentProofProblemReport)
 }
 
 impl DelayedSerde for PresentProof {
@@ -50,6 +52,7 @@ impl DelayedSerde for PresentProof {
             PresentProofTypeV1_0::RequestPresentation => RequestPresentation::deserialize(deserializer).map(From::from),
             PresentProofTypeV1_0::Presentation => Presentation::deserialize(deserializer).map(From::from),
             PresentProofTypeV1_0::Ack => AckPresentation::deserialize(deserializer).map(From::from),
+            PresentProofTypeV1_0::ProblemReport => PresentProofProblemReport::deserialize(deserializer).map(From::from),
             PresentProofTypeV1_0::PresentationPreview => Err(utils::not_standalone_msg::<D>(kind_str)),
         }
     }
@@ -63,6 +66,7 @@ impl DelayedSerde for PresentProof {
             Self::RequestPresentation(v) => MsgWithType::from(v).serialize(serializer),
             Self::Presentation(v) => MsgWithType::from(v).serialize(serializer),
             Self::Ack(v) => MsgWithType::from(v).serialize(serializer),
+            Self::ProblemReport(v) => MsgWithType::from(v).serialize(serializer),
         }
     }
 }
@@ -71,8 +75,10 @@ transit_to_aries_msg!(ProposePresentationContent: ProposePresentationDecorators,
 transit_to_aries_msg!(RequestPresentationContent: RequestPresentationDecorators, PresentProof);
 transit_to_aries_msg!(PresentationContent: PresentationDecorators, PresentProof);
 transit_to_aries_msg!(AckPresentationContent: AckDecorators, PresentProof);
+transit_to_aries_msg!(PresentProofProblemReportContent: ProblemReportDecorators, PresentProof);
 
 into_msg_with_type!(ProposePresentation, PresentProofTypeV1_0, ProposePresentation);
 into_msg_with_type!(RequestPresentation, PresentProofTypeV1_0, RequestPresentation);
 into_msg_with_type!(Presentation, PresentProofTypeV1_0, Presentation);
 into_msg_with_type!(AckPresentation, PresentProofTypeV1_0, Ack);
+into_msg_with_type!(PresentProofProblemReport, PresentProofTypeV1_0, ProblemReport);

--- a/messages/src/msg_fields/protocols/present_proof/mod.rs
+++ b/messages/src/msg_fields/protocols/present_proof/mod.rs
@@ -2,9 +2,9 @@
 
 pub mod ack;
 pub mod present;
+pub mod problem_report;
 pub mod propose;
 pub mod request;
-pub mod problem_report;
 
 use derive_more::From;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
@@ -12,8 +12,9 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use self::{
     ack::{AckPresentation, AckPresentationContent},
     present::{Presentation, PresentationContent, PresentationDecorators},
+    problem_report::{PresentProofProblemReport, PresentProofProblemReportContent},
     propose::{ProposePresentation, ProposePresentationContent, ProposePresentationDecorators},
-    request::{RequestPresentation, RequestPresentationContent, RequestPresentationDecorators}, problem_report::{PresentProofProblemReport, PresentProofProblemReportContent},
+    request::{RequestPresentation, RequestPresentationContent, RequestPresentationDecorators},
 };
 use super::{notification::ack::AckDecorators, report_problem::ProblemReportDecorators};
 use crate::{
@@ -31,7 +32,7 @@ pub enum PresentProof {
     RequestPresentation(RequestPresentation),
     Presentation(Presentation),
     Ack(AckPresentation),
-    ProblemReport(PresentProofProblemReport)
+    ProblemReport(PresentProofProblemReport),
 }
 
 impl DelayedSerde for PresentProof {

--- a/messages/src/msg_fields/protocols/present_proof/problem_report.rs
+++ b/messages/src/msg_fields/protocols/present_proof/problem_report.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    msg_fields::protocols::report_problem::{ProblemReportContent, ProblemReportDecorators},
+    msg_parts::MsgParts,
+};
+
+pub type PresentProofProblemReport = MsgParts<PresentProofProblemReportContent, ProblemReportDecorators>;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(transparent)]
+pub struct PresentProofProblemReportContent(pub ProblemReportContent);
+
+impl PresentProofProblemReportContent {
+    pub fn new(code: String) -> Self {
+        Self(ProblemReportContent::new(code))
+    }
+}

--- a/messages/src/msg_types/protocols/cred_issuance.rs
+++ b/messages/src/msg_types/protocols/cred_issuance.rs
@@ -29,6 +29,7 @@ pub enum CredentialIssuanceTypeV1_0 {
     IssueCredential,
     CredentialPreview,
     Ack,
+    ProblemReport,
 }
 
 #[cfg(test)]

--- a/messages/src/msg_types/protocols/present_proof.rs
+++ b/messages/src/msg_types/protocols/present_proof.rs
@@ -28,6 +28,7 @@ pub enum PresentProofTypeV1_0 {
     Presentation,
     PresentationPreview,
     Ack,
+    ProblemReport,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR addresses #835 and #836, essentially adding a `ProblemReport` message to both the `IssueCredential` and `PresentProof` protocols.