### PR TITLE
Feature/credx issuer

### DIFF
--- a/.github/actions/setup-codecov-rust/action.yml
+++ b/.github/actions/setup-codecov-rust/action.yml
@@ -10,10 +10,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install latest nightly
+    - name: Install nightly 1.71
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2023-05-08
         override: true
     - uses: Swatinem/rust-cache@v2
     - name: "Install dependencies"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,6 +196,7 @@ jobs:
           cargo check --features vdrtools --no-default-features
           cargo check --features modular_libs --no-default-features
           cargo check --features vdr_proxy_ledger --no-default-features
+          cargo check --features mixed_breed
 
   ##########################################################################################
   ##############################   DOCKER BUILD   ##########################################
@@ -499,6 +500,17 @@ jobs:
           skip-vdrproxy-setup: false
       - name: "Run aries-vcx tests: vdrproxy_test"
         run: cargo test --manifest-path="aries_vcx/Cargo.toml" -F vdr_proxy_ledger -- --ignored
+
+  test-integration-aries-vcx-mixed-breed:
+    needs: workflow-setup
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Git checkout"
+        uses: actions/checkout@v3
+      - name: "Setup rust testing environment"
+        uses: ./.github/actions/setup-testing-rust
+      - name: "Run aries-vcx tests: pool_tests agency_pool_tests"
+        run: RUST_TEST_THREADS=1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F mixed_breed -- --include-ignored;
 
   test-integration-libvcx:
     needs: workflow-setup

--- a/aries_vcx/Cargo.toml
+++ b/aries_vcx/Cargo.toml
@@ -18,6 +18,9 @@ modular_libs = ["aries_vcx_core/modular_libs"]
 # TODO: Remove using "vdrtools" feature flag for vdr_proxy_ledger once IndyCredxAnonCreds
 # is fully implemented
 vdr_proxy_ledger = ["aries_vcx_core/vdr_proxy_ledger", "vdrtools"]
+# Temporary feature used for testing the full credx anoncreds impl
+# using vdrtools ledger and wallet.
+mixed_breed = ["vdrtools", "modular_libs"]
 
 [dependencies]
 agency_client = { path = "../agency_client" }

--- a/aries_vcx/src/common/anoncreds.rs
+++ b/aries_vcx/src/common/anoncreds.rs
@@ -7,7 +7,7 @@ pub mod integration_tests {
 
     use crate::common::test_utils::create_and_store_credential;
     use crate::utils::constants::TAILS_DIR;
-    use crate::utils::devsetup::{init_holder_setup_in_indy_context, SetupProfile};
+    use crate::utils::devsetup::SetupProfile;
     use crate::utils::get_temp_dir_path;
 
     #[tokio::test]
@@ -61,17 +61,15 @@ pub mod integration_tests {
     #[ignore]
     async fn test_pool_revoke_credential() {
         SetupProfile::run(|setup| async move {
-            let holder_setup = init_holder_setup_in_indy_context(&setup).await;
-
             let (_, _, _, _, _, _, _, _, rev_reg_id, cred_rev_id, _, rev_reg) = create_and_store_credential(
                 &setup.profile,
-                &holder_setup.profile,
+                &setup.profile,
                 &setup.institution_did,
                 crate::utils::constants::DEFAULT_SCHEMA_ATTRS,
             )
             .await;
 
-            let ledger = Arc::clone(&holder_setup.profile).inject_anoncreds_ledger_read();
+            let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
 
             let (_, first_rev_reg_delta, first_timestamp) =
                 ledger.get_rev_reg_delta_json(&rev_reg_id, None, None).await.unwrap();

--- a/aries_vcx/src/common/anoncreds.rs
+++ b/aries_vcx/src/common/anoncreds.rs
@@ -59,7 +59,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_revoke_credential() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;

--- a/aries_vcx/src/common/anoncreds.rs
+++ b/aries_vcx/src/common/anoncreds.rs
@@ -59,8 +59,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_revoke_credential() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             let (_, _, _, _, _, _, _, _, rev_reg_id, cred_rev_id, _, rev_reg) = create_and_store_credential(

--- a/aries_vcx/src/common/credentials/mod.rs
+++ b/aries_vcx/src/common/credentials/mod.rs
@@ -48,17 +48,15 @@ mod integration_tests {
 
     use crate::common::test_utils::create_and_store_credential;
     use crate::utils::constants::DEFAULT_SCHEMA_ATTRS;
-    use crate::utils::devsetup::{init_holder_setup_in_indy_context, SetupProfile};
+    use crate::utils::devsetup::SetupProfile;
 
     #[tokio::test]
     #[ignore]
     async fn test_pool_prover_get_credential() {
         SetupProfile::run(|setup| async move {
-            let holder_setup = init_holder_setup_in_indy_context(&setup).await;
-
             let res = create_and_store_credential(
                 &setup.profile,
-                &holder_setup.profile,
+                &setup.profile,
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -69,7 +67,7 @@ mod integration_tests {
             let rev_reg_id = res.8;
             let cred_rev_id = res.9;
 
-            let anoncreds = Arc::clone(&holder_setup.profile).inject_anoncreds();
+            let anoncreds = Arc::clone(&setup.profile).inject_anoncreds();
 
             let cred_json = anoncreds.prover_get_credential(&cred_id).await.unwrap();
             let prover_cred = serde_json::from_str::<ProverCredential>(&cred_json).unwrap();
@@ -86,11 +84,9 @@ mod integration_tests {
     #[ignore]
     async fn test_pool_get_cred_rev_id() {
         SetupProfile::run(|setup| async move {
-            let holder_setup = init_holder_setup_in_indy_context(&setup).await;
-
             let res = create_and_store_credential(
                 &setup.profile,
-                &holder_setup.profile,
+                &setup.profile,
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -98,7 +94,7 @@ mod integration_tests {
             let cred_id = res.7;
             let cred_rev_id = res.9;
 
-            let cred_rev_id_ = get_cred_rev_id(&holder_setup.profile, &cred_id).await.unwrap();
+            let cred_rev_id_ = get_cred_rev_id(&setup.profile, &cred_id).await.unwrap();
 
             assert_eq!(cred_rev_id, cred_rev_id_.to_string());
         })
@@ -109,11 +105,9 @@ mod integration_tests {
     #[ignore]
     async fn test_pool_is_cred_revoked() {
         SetupProfile::run(|setup| async move {
-            let holder_setup = init_holder_setup_in_indy_context(&setup).await;
-
             let res = create_and_store_credential(
                 &setup.profile,
-                &holder_setup.profile,
+                &setup.profile,
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -123,7 +117,7 @@ mod integration_tests {
             let tails_file = res.10;
             let rev_reg = res.11;
 
-            assert!(!is_cred_revoked(&holder_setup.profile, &rev_reg_id, &cred_rev_id)
+            assert!(!is_cred_revoked(&setup.profile, &rev_reg_id, &cred_rev_id)
                 .await
                 .unwrap());
 
@@ -140,7 +134,7 @@ mod integration_tests {
 
             std::thread::sleep(std::time::Duration::from_millis(500));
 
-            assert!(is_cred_revoked(&holder_setup.profile, &rev_reg_id, &cred_rev_id)
+            assert!(is_cred_revoked(&setup.profile, &rev_reg_id, &cred_rev_id)
                 .await
                 .unwrap());
         })

--- a/aries_vcx/src/common/credentials/mod.rs
+++ b/aries_vcx/src/common/credentials/mod.rs
@@ -52,8 +52,9 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_prover_get_credential() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             let res = create_and_store_credential(
@@ -84,8 +85,9 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_cred_rev_id() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             let res = create_and_store_credential(
@@ -107,8 +109,9 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_is_cred_revoked() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             let res = create_and_store_credential(

--- a/aries_vcx/src/common/credentials/mod.rs
+++ b/aries_vcx/src/common/credentials/mod.rs
@@ -52,7 +52,6 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_prover_get_credential() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
@@ -85,7 +84,6 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_cred_rev_id() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
@@ -109,7 +107,6 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_is_cred_revoked() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;

--- a/aries_vcx/src/common/keys.rs
+++ b/aries_vcx/src/common/keys.rs
@@ -77,7 +77,7 @@ pub async fn get_verkey_from_ledger(profile: &Arc<dyn Profile>, did: &str) -> Vc
 mod test {
     #[tokio::test]
     #[ignore]
-    #[cfg(not(feature = "vdr_proxy_ledger"))]
+    #[cfg(all(not(feature = "vdr_proxy_ledger"), not(feature = "modular_libs"), not(feature = "mixed_breed")))]
     async fn test_pool_rotate_verkey_fails() {
         use super::*;
 
@@ -86,7 +86,7 @@ mod test {
         use crate::utils::devsetup::*;
         use crate::utils::mockdata::mockdata_pool;
 
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             enable_pool_mocks();
 
             PoolMocks::set_next_pool_response(mockdata_pool::RESPONSE_REQNACK);

--- a/aries_vcx/src/common/keys.rs
+++ b/aries_vcx/src/common/keys.rs
@@ -77,7 +77,11 @@ pub async fn get_verkey_from_ledger(profile: &Arc<dyn Profile>, did: &str) -> Vc
 mod test {
     #[tokio::test]
     #[ignore]
-    #[cfg(all(not(feature = "vdr_proxy_ledger"), not(feature = "modular_libs"), not(feature = "mixed_breed")))]
+    #[cfg(all(
+        not(feature = "vdr_proxy_ledger"),
+        not(feature = "modular_libs"),
+        not(feature = "mixed_breed")
+    ))]
     async fn test_pool_rotate_verkey_fails() {
         use super::*;
 

--- a/aries_vcx/src/common/primitives/credential_definition.rs
+++ b/aries_vcx/src/common/primitives/credential_definition.rs
@@ -282,8 +282,9 @@ pub mod integration_tests {
     use crate::common::primitives::credential_definition::generate_cred_def;
     use crate::common::primitives::revocation_registry::generate_rev_reg;
     use crate::common::test_utils::create_and_write_test_schema;
-    use crate::utils::constants::DEFAULT_SCHEMA_ATTRS;
+    use crate::utils::constants::{DEFAULT_SCHEMA_ATTRS, TAILS_DIR};
     use crate::utils::devsetup::SetupProfile;
+    use crate::utils::get_temp_dir_path;
 
     #[tokio::test]
     #[ignore]
@@ -354,7 +355,7 @@ pub mod integration_tests {
                 &setup.profile,
                 &setup.institution_did,
                 &cred_def_id,
-                "tails.txt",
+                get_temp_dir_path(TAILS_DIR).to_str().unwrap(),
                 2,
                 "tag1",
             )

--- a/aries_vcx/src/common/primitives/credential_definition.rs
+++ b/aries_vcx/src/common/primitives/credential_definition.rs
@@ -353,11 +353,14 @@ pub mod integration_tests {
                 .await
                 .unwrap();
 
+            let path = get_temp_dir_path(TAILS_DIR);
+            std::fs::create_dir_all(&path).unwrap();
+
             let (rev_reg_def_id, rev_reg_def_json, rev_reg_entry_json) = generate_rev_reg(
                 &setup.profile,
                 &setup.institution_did,
                 &cred_def_id,
-                get_temp_dir_path(TAILS_DIR).to_str().unwrap(),
+                path.to_str().unwrap(),
                 2,
                 "tag1",
             )

--- a/aries_vcx/src/common/primitives/credential_definition.rs
+++ b/aries_vcx/src/common/primitives/credential_definition.rs
@@ -288,8 +288,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_create_cred_def_real() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let (schema_id, _) =
                 create_and_write_test_schema(&setup.profile, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
 
@@ -328,8 +329,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_create_rev_reg_def() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let (schema_id, _) =
                 create_and_write_test_schema(&setup.profile, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
             let ledger_read = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();

--- a/aries_vcx/src/common/primitives/credential_definition.rs
+++ b/aries_vcx/src/common/primitives/credential_definition.rs
@@ -288,7 +288,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_create_cred_def_real() {
         SetupProfile::run(|setup| async move {
             let (schema_id, _) =
@@ -329,7 +328,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_create_rev_reg_def() {
         SetupProfile::run(|setup| async move {
             let (schema_id, _) =

--- a/aries_vcx/src/common/primitives/mod.rs
+++ b/aries_vcx/src/common/primitives/mod.rs
@@ -41,7 +41,7 @@ pub mod integration_tests {
             )
             .await;
 
-            assert_eq!(rc.unwrap_err().kind(), AriesVcxErrorKind::LibindyInvalidStructure);
+            assert_eq!(rc.unwrap_err().kind(), AriesVcxErrorKind::InvalidInput);
         })
         .await;
     }

--- a/aries_vcx/src/common/primitives/mod.rs
+++ b/aries_vcx/src/common/primitives/mod.rs
@@ -19,7 +19,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_rev_reg_def_fails_for_cred_def_created_without_revocation() {
         // todo: does not need agency setup
         SetupProfile::run(|setup| async move {
@@ -49,7 +48,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_rev_reg_def_json() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
@@ -64,7 +62,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_rev_reg_delta_json() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
@@ -81,7 +78,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_rev_reg() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
@@ -101,7 +97,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_cred_def() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;

--- a/aries_vcx/src/common/primitives/mod.rs
+++ b/aries_vcx/src/common/primitives/mod.rs
@@ -19,9 +19,10 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_rev_reg_def_fails_for_cred_def_created_without_revocation() {
         // todo: does not need agency setup
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             // Cred def is created with support_revocation=false,
             // revoc_reg_def will fail in libindy because cred_Def doesn't have revocation keys
             let (_, _, cred_def_id, _, _) = create_and_store_nonrevocable_credential_def(
@@ -48,8 +49,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_rev_reg_def_json() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
             let (_, _, _, _, rev_reg_id, _, _) =
                 create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
@@ -62,8 +64,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_rev_reg_delta_json() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
             let (_, _, _, _, rev_reg_id, _, _) =
                 create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
@@ -78,8 +81,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_rev_reg() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
             let (_, _, _, _, rev_reg_id, _, _) =
                 create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
@@ -97,8 +101,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_cred_def() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
             let (_, _, cred_def_id, cred_def_json, _) =
                 create_and_store_nonrevocable_credential_def(&setup.profile, &setup.institution_did, attrs).await;

--- a/aries_vcx/src/common/primitives/revocation_registry_delta.rs
+++ b/aries_vcx/src/common/primitives/revocation_registry_delta.rs
@@ -65,8 +65,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_create_rev_reg_delta_from_ledger() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
             let (_, _, _, _, rev_reg_id, _, _) =
                 create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;

--- a/aries_vcx/src/common/primitives/revocation_registry_delta.rs
+++ b/aries_vcx/src/common/primitives/revocation_registry_delta.rs
@@ -65,7 +65,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_create_rev_reg_delta_from_ledger() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;

--- a/aries_vcx/src/common/proofs/verifier/verifier.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier.rs
@@ -128,7 +128,6 @@ pub mod unit_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_proof_restrictions() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
@@ -218,7 +217,6 @@ pub mod unit_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_proof_validate_attribute() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
@@ -335,7 +333,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_prover_verify_proof() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
@@ -356,7 +353,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_prover_verify_proof_with_predicate_success_case() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
@@ -377,7 +373,6 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_prover_verify_proof_with_predicate_fail_case() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;

--- a/aries_vcx/src/common/proofs/verifier/verifier.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier.rs
@@ -128,8 +128,9 @@ pub mod unit_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_proof_restrictions() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             let requested_attrs = json!([
@@ -217,8 +218,9 @@ pub mod unit_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_proof_validate_attribute() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             let requested_attrs = json!([
@@ -333,8 +335,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_prover_verify_proof() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             let (schemas, cred_defs, proof_req, proof) =
@@ -353,8 +356,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_prover_verify_proof_with_predicate_success_case() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             let (schemas, cred_defs, proof_req, proof) =
@@ -373,8 +377,9 @@ pub mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_prover_verify_proof_with_predicate_fail_case() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             let (schemas, cred_defs, proof_req, proof) =

--- a/aries_vcx/src/common/test_utils.rs
+++ b/aries_vcx/src/common/test_utils.rs
@@ -97,11 +97,15 @@ pub async fn create_and_store_credential_def(
         .publish_cred_def(profile)
         .await
         .unwrap();
+
+    let path = get_temp_dir_path(TAILS_DIR);
+    std::fs::create_dir_all(&path).unwrap();
+
     let mut rev_reg = RevocationRegistry::create(
         profile,
         issuer_did,
         &cred_def.get_cred_def_id(),
-        get_temp_dir_path(TAILS_DIR).to_str().unwrap(),
+        path.to_str().unwrap(),
         10,
         1,
     )

--- a/aries_vcx/src/core/profile/mixed_breed_profile.rs
+++ b/aries_vcx/src/core/profile/mixed_breed_profile.rs
@@ -4,7 +4,7 @@ use aries_vcx_core::{
     anoncreds::{base_anoncreds::BaseAnonCreds, credx_anoncreds::IndyCredxAnonCreds},
     ledger::{
         base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
-        indy_ledger::IndySdkLedger,
+        indy_ledger::{IndySdkLedgerRead, IndySdkLedgerWrite},
     },
     wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
     PoolHandle, WalletHandle,
@@ -26,15 +26,16 @@ impl MixedBreedProfile {
     pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
         let wallet: Arc<dyn BaseWallet> = Arc::new(IndySdkWallet::new(indy_wallet_handle));
         let anoncreds = Arc::new(IndyCredxAnonCreds::new(Arc::clone(&wallet)));
-        let ledger = Arc::new(IndySdkLedger::new(indy_wallet_handle, indy_pool_handle));
+        let ledger_read = Arc::new(IndySdkLedgerRead::new(indy_wallet_handle, indy_pool_handle));
+        let ledger_write = Arc::new(IndySdkLedgerWrite::new(indy_wallet_handle, indy_pool_handle));
 
         MixedBreedProfile {
             wallet,
             anoncreds,
-            anoncreds_ledger_read: ledger.clone(),
-            anoncreds_ledger_write: ledger.clone(),
-            indy_ledger_read: ledger.clone(),
-            indy_ledger_write: ledger,
+            anoncreds_ledger_read: ledger_read.clone(),
+            anoncreds_ledger_write: ledger_write.clone(),
+            indy_ledger_read: ledger_read,
+            indy_ledger_write: ledger_write,
         }
     }
 }

--- a/aries_vcx/src/core/profile/mixed_breed_profile.rs
+++ b/aries_vcx/src/core/profile/mixed_breed_profile.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use aries_vcx_core::{
+    anoncreds::{base_anoncreds::BaseAnonCreds, credx_anoncreds::IndyCredxAnonCreds, indy_anoncreds::IndySdkAnonCreds},
+    ledger::{base_ledger::BaseLedger, indy_ledger::IndySdkLedger},
+    wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
+    PoolHandle, WalletHandle,
+};
+
+use super::profile::Profile;
+
+#[derive(Debug)]
+pub struct MixedBreedProfile {
+    wallet: Arc<dyn BaseWallet>,
+    ledger: Arc<dyn BaseLedger>,
+    anoncreds: Arc<dyn BaseAnonCreds>,
+}
+
+impl MixedBreedProfile {
+    pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
+        let wallet = Arc::new(IndySdkWallet::new(indy_wallet_handle));
+        let ledger = Arc::new(IndySdkLedger::new(indy_wallet_handle, indy_pool_handle));
+        let anoncreds: Arc<IndyCredxAnonCreds> = Arc::new(IndyCredxAnonCreds::new(wallet.clone()));
+        MixedBreedProfile {
+            wallet,
+            ledger,
+            anoncreds,
+        }
+    }
+}
+
+impl Profile for MixedBreedProfile {
+    fn inject_ledger(self: Arc<Self>) -> Arc<dyn BaseLedger> {
+        Arc::clone(&self.ledger)
+    }
+
+    fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds> {
+        Arc::clone(&self.anoncreds)
+    }
+
+    fn inject_wallet(&self) -> Arc<dyn BaseWallet> {
+        Arc::clone(&self.wallet)
+    }
+}

--- a/aries_vcx/src/core/profile/mixed_breed_profile.rs
+++ b/aries_vcx/src/core/profile/mixed_breed_profile.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
 use aries_vcx_core::{
-    anoncreds::{base_anoncreds::BaseAnonCreds, credx_anoncreds::IndyCredxAnonCreds, indy_anoncreds::IndySdkAnonCreds},
-    ledger::{base_ledger::BaseLedger, indy_ledger::IndySdkLedger},
+    anoncreds::{base_anoncreds::BaseAnonCreds, credx_anoncreds::IndyCredxAnonCreds},
+    ledger::{
+        base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
+        indy_ledger::IndySdkLedger,
+    },
     wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
     PoolHandle, WalletHandle,
 };
@@ -12,30 +15,49 @@ use super::profile::Profile;
 #[derive(Debug)]
 pub struct MixedBreedProfile {
     wallet: Arc<dyn BaseWallet>,
-    ledger: Arc<dyn BaseLedger>,
     anoncreds: Arc<dyn BaseAnonCreds>,
+    anoncreds_ledger_read: Arc<dyn AnoncredsLedgerRead>,
+    anoncreds_ledger_write: Arc<dyn AnoncredsLedgerWrite>,
+    indy_ledger_read: Arc<dyn IndyLedgerRead>,
+    indy_ledger_write: Arc<dyn IndyLedgerWrite>,
 }
 
 impl MixedBreedProfile {
     pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
-        let wallet = Arc::new(IndySdkWallet::new(indy_wallet_handle));
+        let wallet: Arc<dyn BaseWallet> = Arc::new(IndySdkWallet::new(indy_wallet_handle));
+        let anoncreds = Arc::new(IndyCredxAnonCreds::new(Arc::clone(&wallet)));
         let ledger = Arc::new(IndySdkLedger::new(indy_wallet_handle, indy_pool_handle));
-        let anoncreds: Arc<IndyCredxAnonCreds> = Arc::new(IndyCredxAnonCreds::new(wallet.clone()));
+
         MixedBreedProfile {
             wallet,
-            ledger,
             anoncreds,
+            anoncreds_ledger_read: ledger.clone(),
+            anoncreds_ledger_write: ledger.clone(),
+            indy_ledger_read: ledger.clone(),
+            indy_ledger_write: ledger,
         }
     }
 }
 
 impl Profile for MixedBreedProfile {
-    fn inject_ledger(self: Arc<Self>) -> Arc<dyn BaseLedger> {
-        Arc::clone(&self.ledger)
+    fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead> {
+        Arc::clone(&self.indy_ledger_read)
+    }
+
+    fn inject_indy_ledger_write(self: Arc<Self>) -> Arc<dyn IndyLedgerWrite> {
+        Arc::clone(&self.indy_ledger_write)
     }
 
     fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds> {
         Arc::clone(&self.anoncreds)
+    }
+
+    fn inject_anoncreds_ledger_read(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerRead> {
+        Arc::clone(&self.anoncreds_ledger_read)
+    }
+
+    fn inject_anoncreds_ledger_write(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerWrite> {
+        Arc::clone(&self.anoncreds_ledger_write)
     }
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {

--- a/aries_vcx/src/core/profile/mod.rs
+++ b/aries_vcx/src/core/profile/mod.rs
@@ -5,3 +5,5 @@ pub mod profile;
 pub mod vdr_proxy_profile;
 #[cfg(feature = "vdrtools")]
 pub mod vdrtools_profile;
+#[cfg(feature =  "mixed_breed")]
+pub mod mixed_breed_profile;

--- a/aries_vcx/src/core/profile/mod.rs
+++ b/aries_vcx/src/core/profile/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "mixed_breed")]
+pub mod mixed_breed_profile;
 #[cfg(feature = "modular_libs")]
 pub mod modular_libs_profile;
 pub mod profile;
@@ -5,5 +7,3 @@ pub mod profile;
 pub mod vdr_proxy_profile;
 #[cfg(feature = "vdrtools")]
 pub mod vdrtools_profile;
-#[cfg(feature =  "mixed_breed")]
-pub mod mixed_breed_profile;

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -367,7 +367,6 @@ impl SetupWalletPool {
 }
 
 impl SetupProfile {
-    #[cfg(any(feature = "modular_libs", feature = "vdrtools"))]
     pub async fn init() -> SetupProfile {
         init_test_logging();
         set_test_configs();
@@ -513,7 +512,6 @@ impl SetupProfile {
         }
     }
 
-    #[cfg(any(feature = "modular_libs", feature = "vdrtools"))]
     pub async fn run<F>(f: impl FnOnce(Self) -> F)
     where
         F: Future<Output = ()>,

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -367,10 +367,6 @@ impl SetupWalletPool {
 }
 
 impl SetupProfile {
-    pub(self) fn should_run_modular() -> bool {
-        cfg!(feature = "modular_libs")
-    }
-
     #[cfg(any(feature = "modular_libs", feature = "vdrtools"))]
     pub async fn init() -> SetupProfile {
         init_test_logging();
@@ -534,13 +530,10 @@ impl SetupProfile {
     }
 }
 
-// TODO - FUTURE - delete this method after `SetupProfile::run_indy` is removed. The purpose of this helper method
-// is to return a test profile for a prover/holder given an existing indy-based profile setup (i.e. returned by SetupProfile::run_indy)
-#[cfg(any(feature = "modular_libs", feature = "vdrtools"))]
 pub async fn init_holder_setup_in_indy_context(indy_issuer_setup: &SetupProfile) -> SetupProfile {
-    if SetupProfile::should_run_modular() {
-        return SetupProfile::init().await; // create a new modular profile
-    }
+    #[cfg(all(not(feature = "mixed_breed"), feature = "modular_libs"))]
+    return SetupProfile::init().await; // create a new modular profile
+
     indy_issuer_setup.clone() // if indy runtime, just re-use the issuer setup
 }
 

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -528,13 +528,6 @@ impl SetupProfile {
     }
 }
 
-pub async fn init_holder_setup_in_indy_context(indy_issuer_setup: &SetupProfile) -> SetupProfile {
-    #[cfg(all(not(feature = "mixed_breed"), feature = "modular_libs"))]
-    return SetupProfile::init().await; // create a new modular profile
-
-    indy_issuer_setup.clone() // if indy runtime, just re-use the issuer setup
-}
-
 impl SetupInstitutionWallet {
     pub async fn init() -> SetupInstitutionWallet {
         init_test_logging();

--- a/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
@@ -47,6 +47,10 @@ impl BaseWallet for MockWallet {
         Ok(r#"{"id":"123","type":"record type","value":"record value","tags":null}"#.to_string())
     }
 
+    async fn get_wallet_record_value(&self, xtype: &str, id: &str) -> VcxCoreResult<String> {
+        Ok(r#""record value""#.to_owned())
+    }
+
     async fn delete_wallet_record(&self, xtype: &str, id: &str) -> VcxCoreResult<()> {
         Ok(())
     }

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -30,8 +30,9 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_agency_pool_retrieve_credentials() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
 
             create_and_store_nonrevocable_credential(
@@ -71,8 +72,9 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_agency_pool_get_credential_def() {
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let (_, _, cred_def_id, cred_def_json, _) = create_and_store_nonrevocable_credential_def(
                 &setup.profile,
                 &setup.institution_did,
@@ -92,6 +94,7 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_agency_pool_retrieve_credentials_empty() {
         SetupProfile::run(|setup| async move {
             // create skeleton proof request attachment data
@@ -163,12 +166,10 @@ mod integration_tests {
     #[tokio::test]
     #[ignore]
     async fn test_agency_pool_case_for_proof_req_doesnt_matter_for_retrieve_creds() {
-        SetupProfile::run_indy(|setup| async move {
-            let holder_setup = init_holder_setup_in_indy_context(&setup).await;
-
+        SetupProfile::run(|setup| async move {
             create_and_store_nonrevocable_credential(
                 &setup.profile,
-                &holder_setup.profile,
+                &setup.profile,
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -205,7 +206,7 @@ mod integration_tests {
             let proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
 
             // All lower case
-            let retrieved_creds = proof.retrieve_credentials(&holder_setup.profile).await.unwrap();
+            let retrieved_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
             assert_eq!(
                 retrieved_creds.credentials_by_referent["zip_1"][0].cred_info.attributes["zip"],
                 "84000"
@@ -229,7 +230,7 @@ mod integration_tests {
 
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let proof: Prover = Prover::create_from_request("2", proof_req).unwrap();
-            let retrieved_creds2 = proof.retrieve_credentials(&holder_setup.profile).await.unwrap();
+            let retrieved_creds2 = proof.retrieve_credentials(&setup.profile).await.unwrap();
             assert_eq!(
                 retrieved_creds2.credentials_by_referent["zip_1"][0]
                     .cred_info
@@ -255,7 +256,7 @@ mod integration_tests {
 
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
-            let retrieved_creds3 = proof.retrieve_credentials(&holder_setup.profile).await.unwrap();
+            let retrieved_creds3 = proof.retrieve_credentials(&setup.profile).await.unwrap();
             assert_eq!(
                 retrieved_creds3.credentials_by_referent["zip_1"][0]
                     .cred_info
@@ -269,12 +270,10 @@ mod integration_tests {
     #[tokio::test]
     #[ignore]
     async fn test_agency_pool_generate_proof() {
-        SetupProfile::run_indy(|setup| async move {
-            let holder_setup = init_holder_setup_in_indy_context(&setup).await;
-
+        SetupProfile::run(|setup| async move {
             create_and_store_credential(
                 &setup.profile,
-                &holder_setup.profile,
+                &setup.profile,
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -317,7 +316,7 @@ mod integration_tests {
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let mut proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
 
-            let all_creds = proof.retrieve_credentials(&holder_setup.profile).await.unwrap();
+            let all_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
             let selected_credentials: serde_json::Value = json!({
                "attrs":{
                   "address1_1": {
@@ -337,7 +336,7 @@ mod integration_tests {
 
             let generated_proof = proof
                 .generate_presentation(
-                    &holder_setup.profile,
+                    &setup.profile,
                     serde_json::from_value(selected_credentials).unwrap(),
                     serde_json::from_value(self_attested).unwrap(),
                 )
@@ -351,13 +350,10 @@ mod integration_tests {
     #[tokio::test]
     #[ignore]
     async fn test_agency_pool_generate_proof_with_predicates() {
-        // todo - use SetupProfile::run after modular impls
-        SetupProfile::run_indy(|setup: SetupProfile| async move {
-            let holder_setup = init_holder_setup_in_indy_context(&setup).await;
-
+        SetupProfile::run(|setup| async move {
             create_and_store_credential(
                 &setup.profile,
-                &holder_setup.profile,
+                &setup.profile,
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -402,7 +398,7 @@ mod integration_tests {
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let mut proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
 
-            let all_creds = proof.retrieve_credentials(&holder_setup.profile).await.unwrap();
+            let all_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
             let selected_credentials: serde_json::Value = json!({
                "attrs":{
                   "address1_1": {
@@ -424,7 +420,7 @@ mod integration_tests {
             });
             let generated_proof = proof
                 .generate_presentation(
-                    &holder_setup.profile,
+                    &setup.profile,
                     serde_json::from_value(selected_credentials).unwrap(),
                     serde_json::from_value(self_attested).unwrap(),
                 )
@@ -439,9 +435,7 @@ mod integration_tests {
     #[tokio::test]
     #[ignore]
     async fn test_agency_pool_generate_self_attested_proof() {
-        SetupProfile::run_indy(|setup| async move {
-            let holder_setup = init_holder_setup_in_indy_context(&setup).await;
-
+        SetupProfile::run(|setup| async move {
             let indy_proof_req = json!({
                "nonce":"123432421212",
                "name":"proof_req_1",
@@ -472,7 +466,7 @@ mod integration_tests {
             });
             proof
                 .generate_presentation(
-                    &holder_setup.profile,
+                    &setup.profile,
                     serde_json::from_value(selected_credentials).unwrap(),
                     serde_json::from_value(self_attested).unwrap(),
                 )

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -21,7 +21,7 @@ mod integration_tests {
     use aries_vcx::protocols::proof_presentation::prover::state_machine::ProverState;
     use aries_vcx::protocols::proof_presentation::verifier::verification_status::PresentationVerificationStatus;
     use aries_vcx::utils::constants::{DEFAULT_SCHEMA_ATTRS, TAILS_DIR};
-    use aries_vcx::utils::devsetup::{init_holder_setup_in_indy_context, SetupProfile};
+    use aries_vcx::utils::devsetup::SetupProfile;
     use aries_vcx::utils::get_temp_dir_path;
     use messages::msg_fields::protocols::present_proof::request::{
         RequestPresentation, RequestPresentationContent, RequestPresentationDecorators,
@@ -32,16 +32,14 @@ mod integration_tests {
     #[ignore]
     async fn test_agency_pool_retrieve_credentials() {
         SetupProfile::run(|setup| async move {
-            let holder_setup = init_holder_setup_in_indy_context(&setup).await;
-
             create_and_store_nonrevocable_credential(
                 &setup.profile,
-                &holder_setup.profile,
+                &setup.profile,
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
             .await;
-            let (_, _, req, _) = create_indy_proof(&setup.profile, &holder_setup.profile, &setup.institution_did).await;
+            let (_, _, req, _) = create_indy_proof(&setup.profile, &setup.profile, &setup.institution_did).await;
 
             let pres_req_data: PresentationRequestData = serde_json::from_str(&req).unwrap();
             let id = "test_id".to_owned();
@@ -60,7 +58,7 @@ mod integration_tests {
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
 
-            let retrieved_creds = proof.retrieve_credentials(&holder_setup.profile).await.unwrap();
+            let retrieved_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
             // assert number of cred matches for different requested referents
             assert_eq!(retrieved_creds.credentials_by_referent["address1_1"].len(), 2);
             assert_eq!(retrieved_creds.credentials_by_referent["zip_2"].len(), 2);

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -30,7 +30,6 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_agency_pool_retrieve_credentials() {
         SetupProfile::run(|setup| async move {
             let holder_setup = init_holder_setup_in_indy_context(&setup).await;
@@ -72,7 +71,6 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_agency_pool_get_credential_def() {
         SetupProfile::run(|setup| async move {
             let (_, _, cred_def_id, cred_def_json, _) = create_and_store_nonrevocable_credential_def(
@@ -94,7 +92,6 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_agency_pool_retrieve_credentials_empty() {
         SetupProfile::run(|setup| async move {
             // create skeleton proof request attachment data

--- a/aries_vcx/tests/test_pool.rs
+++ b/aries_vcx/tests/test_pool.rs
@@ -31,9 +31,7 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_credential_def() {
-        // TODO - use SetupProfile::run after modular impls
         SetupProfile::run(|setup| async move {
             let (_, _, cred_def_id, cred_def_json, _) = create_and_store_nonrevocable_credential_def(
                 &setup.profile,

--- a/aries_vcx/tests/test_pool.rs
+++ b/aries_vcx/tests/test_pool.rs
@@ -31,9 +31,10 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore]
+    #[cfg(feature = "vdrtools")]
     async fn test_pool_get_credential_def() {
         // TODO - use SetupProfile::run after modular impls
-        SetupProfile::run_indy(|setup| async move {
+        SetupProfile::run(|setup| async move {
             let (_, _, cred_def_id, cred_def_json, _) = create_and_store_nonrevocable_credential_def(
                 &setup.profile,
                 &setup.institution_did,

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -330,9 +330,14 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
             .add_wallet_record(CATEGORY_CRED_KEY_PROOF, &cred_def_id.0, &str_cred_key_proof, None)
             .await?;
 
-        self.wallet
+        let store_schema_res = self
+            .wallet
             .add_wallet_record(CATEGORY_CRED_SCHEMA, schema.id(), schema_json, None)
-            .await?;
+            .await;
+
+        if let Err(e) = store_schema_res {
+            warn!("Storing schema {schema_json} failed - {e}. It's possible it is already stored.")
+        }
 
         let str_schema_id = serde_json::to_string(schema.id())?;
 

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -943,9 +943,12 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
     }
 
     async fn revoke_credential_local(&self, tails_dir: &str, rev_reg_id: &str, cred_rev_id: &str) -> VcxCoreResult<()> {
-        let cred_rev_id = cred_rev_id
-            .parse()
-            .map_err(|e| AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::InvalidInput, e))?;
+        let cred_rev_id = cred_rev_id.parse().map_err(|e| {
+            AriesVcxCoreError::from_msg(
+                AriesVcxCoreErrorKind::InvalidInput,
+                format!("Invalid cred_rev_id {cred_rev_id} - {e}"),
+            )
+        })?;
 
         let rev_reg = self.get_wallet_record_value(CATEGORY_REV_REG, rev_reg_id).await?;
 

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -355,8 +355,10 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
             .add_wallet_record(CATEGORY_CRED_SCHEMA, schema.id(), schema_json, None)
             .await?;
 
+        let str_schema_id = serde_json::to_string(schema.id())?;
+
         self.wallet
-            .add_wallet_record(CATEGORY_CRED_SCHEMA_ID, &cred_def_id.0, schema.id(), None)
+            .add_wallet_record(CATEGORY_CRED_SCHEMA_ID, &cred_def_id.0, &str_schema_id, None)
             .await?;
 
         // Return the ID and the cred def
@@ -370,12 +372,12 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
             .get_wallet_record_value(CATEGORY_CRED_KEY_PROOF, cred_def_id)
             .await?;
 
-        let schema_id = match &cred_def {
-            CredentialDefinition::CredentialDefinitionV1(c) => &c.schema_id,
-        };
+        let schema_id = self
+            .get_wallet_record_value(CATEGORY_CRED_SCHEMA_ID, cred_def_id)
+            .await?;
 
         // If cred_def contains schema ID, why take it as an argument here...?
-        let offer = credx::issuer::create_credential_offer(schema_id, &cred_def, &correctness_proof)?;
+        let offer = credx::issuer::create_credential_offer(&schema_id, &cred_def, &correctness_proof)?;
 
         serde_json::to_string(&offer).map_err(From::from)
     }

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -40,7 +40,7 @@ const CATEGORY_LINK_SECRET: &str = "VCX_LINK_SECRET";
 
 const CATEGORY_CREDENTIAL: &str = "VCX_CREDENTIAL";
 const CATEGORY_CRED_DEF: &str = "VCX_CRED_DEF";
-const CATEGORY_CRED_KEY_PROOF: &str = "VCX_CRED_DEF_PROOF";
+const CATEGORY_CRED_KEY_CORRECTNESS_PROOF: &str = "VCX_CRED_KEY_CORRECTNESS_PROOF";
 const CATEGORY_CRED_DEF_PRIV: &str = "VCX_CRED_DEF_PRIV";
 const CATEGORY_CRED_SCHEMA: &str = "VCX_CRED_SCHEMA";
 
@@ -327,7 +327,7 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
         let str_cred_key_proof = serde_json::to_string(&cred_key_correctness_proof)?;
 
         self.wallet
-            .add_wallet_record(CATEGORY_CRED_KEY_PROOF, &cred_def_id.0, &str_cred_key_proof, None)
+            .add_wallet_record(CATEGORY_CRED_KEY_CORRECTNESS_PROOF, &cred_def_id.0, &str_cred_key_proof, None)
             .await?;
 
         let store_schema_res = self
@@ -353,7 +353,7 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
         let cred_def = self.get_wallet_record_value(CATEGORY_CRED_DEF, cred_def_id).await?;
 
         let correctness_proof = self
-            .get_wallet_record_value(CATEGORY_CRED_KEY_PROOF, cred_def_id)
+            .get_wallet_record_value(CATEGORY_CRED_KEY_CORRECTNESS_PROOF, cred_def_id)
             .await?;
 
         let schema_id = self

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -790,7 +790,6 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
         })?;
 
         let tails_reader = TailsFileReader::new(tails_path);
-        let tails_reader: credx::tails::TailsReader = credx::tails::TailsFileReader::new(&tails_file_path);
         let rev_reg_delta: RevocationRegistryDelta = serde_json::from_str(rev_reg_delta_json)?;
         let rev_reg_idx: u32 = cred_rev_id
             .parse()

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -416,7 +416,7 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
                         if rev_reg_info.curr_id > rev_reg_def.value.max_cred_num {
                             return Err(AriesVcxCoreError::from_msg(
                                 AriesVcxCoreErrorKind::ActionNotSupported,
-                                "RevocationRegistryAccumulator is full",
+                                "The revocation registry is full",
                             ));
                         }
 

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -327,7 +327,12 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
         let str_cred_key_proof = serde_json::to_string(&cred_key_correctness_proof)?;
 
         self.wallet
-            .add_wallet_record(CATEGORY_CRED_KEY_CORRECTNESS_PROOF, &cred_def_id.0, &str_cred_key_proof, None)
+            .add_wallet_record(
+                CATEGORY_CRED_KEY_CORRECTNESS_PROOF,
+                &cred_def_id.0,
+                &str_cred_key_proof,
+                None,
+            )
             .await?;
 
         let store_schema_res = self

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -428,8 +428,17 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
                     }
                 };
 
-                let tails_file_path = format!("{}/{}", tails_dir, tails_file_hash);
-                let tails_reader = TailsFileReader::new(&tails_file_path);
+                let mut tails_file_path = std::path::PathBuf::new();
+                tails_file_path.push(&tails_dir);
+                tails_file_path.push(tails_file_hash);
+
+                let tails_path = tails_file_path.to_str().ok_or_else(|| {
+                    AriesVcxCoreError::from_msg(
+                        AriesVcxCoreErrorKind::InvalidOption,
+                        "tails file is not an unicode string",
+                    )
+                })?;
+                let tails_reader = TailsFileReader::new(tails_path);
 
                 let revocation_config = CredentialRevocationConfig {
                     reg_def: rev_reg_def,
@@ -768,7 +777,19 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
         let tails_file_hash = match revoc_reg_def.borrow() {
             RevocationRegistryDefinition::RevocationRegistryDefinitionV1(r) => &r.value.tails_hash,
         };
-        let tails_file_path = format!("{}/{}", tails_dir, tails_file_hash);
+
+        let mut tails_file_path = std::path::PathBuf::new();
+        tails_file_path.push(&tails_dir);
+        tails_file_path.push(tails_file_hash);
+
+        let tails_path = tails_file_path.to_str().ok_or_else(|| {
+            AriesVcxCoreError::from_msg(
+                AriesVcxCoreErrorKind::InvalidOption,
+                "tails file is not an unicode string",
+            )
+        })?;
+
+        let tails_reader = TailsFileReader::new(tails_path);
         let tails_reader: credx::tails::TailsReader = credx::tails::TailsFileReader::new(&tails_file_path);
         let rev_reg_delta: RevocationRegistryDelta = serde_json::from_str(rev_reg_delta_json)?;
         let rev_reg_idx: u32 = cred_rev_id

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -4,17 +4,14 @@ use std::{
     sync::Arc,
 };
 
+use crate::utils::{
+    constants::ATTRS,
+    json::{AsTypeOrDeserializationError, TryGetIndex},
+};
 use crate::wallet::base_wallet::AsyncFnIteratorCollect;
 use crate::{
     errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult},
     wallet::base_wallet::BaseWallet,
-};
-use crate::{
-    indy::wallet::WalletRecord,
-    utils::{
-        constants::ATTRS,
-        json::{AsTypeOrDeserializationError, TryGetIndex},
-    },
 };
 
 use async_trait::async_trait;
@@ -75,22 +72,8 @@ impl IndyCredxAnonCreds {
     where
         T: DeserializeOwned,
     {
-        let options = r#"{
-            "retrieve_type": false,
-            "retrieve_value": true,
-            "retrieve_tags": false
-        }"#;
-
-        let str_record = self.wallet.get_wallet_record(category, id, options).await?;
-        let wallet_record: WalletRecord = serde_json::from_str(&str_record)?;
-        let str_value = wallet_record.value.ok_or_else(|| {
-            AriesVcxCoreError::from_msg(
-                AriesVcxCoreErrorKind::WalletRecordNotFound,
-                "The wallet record does not have a value",
-            )
-        })?;
-
-        serde_json::from_str(&str_value).map_err(From::from)
+        let str_record = self.wallet.get_wallet_record_value(category, id).await?;
+        serde_json::from_str(&str_record).map_err(From::from)
     }
 
     async fn get_link_secret(&self, link_secret_id: &str) -> VcxCoreResult<MasterSecret> {

--- a/aries_vcx_core/src/errors/mapping_vdrtools.rs
+++ b/aries_vcx_core/src/errors/mapping_vdrtools.rs
@@ -21,7 +21,7 @@ impl From<IndyErrorKind> for AriesVcxCoreErrorKind {
 
         match indy {
             InvalidParam(_) => AriesVcxCoreErrorKind::InvalidLibindyParam,
-            InvalidStructure => AriesVcxCoreErrorKind::LibindyInvalidStructure,
+            InvalidStructure => AriesVcxCoreErrorKind::InvalidInput,
             IOError => AriesVcxCoreErrorKind::IOError,
             InvalidWalletHandle => AriesVcxCoreErrorKind::InvalidWalletHandle,
             WalletAlreadyExists => AriesVcxCoreErrorKind::DuplicationWallet,

--- a/aries_vcx_core/src/wallet/agency_client_wallet.rs
+++ b/aries_vcx_core/src/wallet/agency_client_wallet.rs
@@ -52,6 +52,10 @@ impl BaseWallet for AgencyClientWallet {
         Err(unimplemented_agency_client_wallet_method("get_wallet_record"))
     }
 
+    async fn get_wallet_record_value(&self, xtype: &str, id: &str) -> VcxCoreResult<String> {
+        Err(unimplemented_agency_client_wallet_method("get_wallet_record_value"))
+    }
+
     async fn delete_wallet_record(&self, xtype: &str, id: &str) -> VcxCoreResult<()> {
         Err(unimplemented_agency_client_wallet_method("delete_wallet_record"))
     }

--- a/aries_vcx_core/src/wallet/base_wallet.rs
+++ b/aries_vcx_core/src/wallet/base_wallet.rs
@@ -1,8 +1,6 @@
 use async_trait::async_trait;
-use serde::de::DeserializeOwned;
 
-use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
-use crate::indy::wallet::WalletRecord;
+use crate::errors::error::VcxCoreResult;
 use crate::utils::async_fn_iterator::AsyncFnIterator;
 
 /// Trait defining standard 'wallet' related functionality. The APIs, including
@@ -33,22 +31,7 @@ pub trait BaseWallet: std::fmt::Debug + Send + Sync {
 
     async fn get_wallet_record(&self, xtype: &str, id: &str, options_json: &str) -> VcxCoreResult<String>;
 
-    async fn get_wallet_record_value(&self, xtype: &str, id: &str) -> VcxCoreResult<String> {
-        let options = r#"{
-                "retrieve_type": false,
-                "retrieve_value": true,
-                "retrieve_tags": false
-            }"#;
-
-        let str_record = self.get_wallet_record(xtype, id, options).await?;
-        let wallet_record: WalletRecord = serde_json::from_str(&str_record)?;
-        wallet_record.value.ok_or_else(|| {
-            AriesVcxCoreError::from_msg(
-                AriesVcxCoreErrorKind::WalletRecordNotFound,
-                "The wallet record does not have a value",
-            )
-        })
-    }
+    async fn get_wallet_record_value(&self, xtype: &str, id: &str) -> VcxCoreResult<String>;
 
     async fn delete_wallet_record(&self, xtype: &str, id: &str) -> VcxCoreResult<()>;
 


### PR DESCRIPTION
This PR completes the credx anoncreds implementation by adding proper handling for issuer operations. For tests, the `mixed_breed` feature flag was added (with teary eyes, since we want to get rid of them not add more) so that a new profile can be constructed.

The mixed breed profile uses the credx anoncreds impl and the indy ledger and wallet impls.

The code here is bad from a lot of perpectives, but to me that's not a problem since this will all be deleted/refactored soon enough as we transition to `anoncreds-rs`.