### PR TITLE
Split BaseLedger trait

### DIFF
--- a/agents/rust/aries-vcx-agent/src/services/schema.rs
+++ b/agents/rust/aries-vcx-agent/src/services/schema.rs
@@ -34,7 +34,7 @@ impl ServiceSchemas {
     }
 
     pub async fn schema_json(&self, thread_id: &str) -> AgentResult<String> {
-        let ledger = Arc::clone(&self.profile).inject_ledger();
+        let ledger = Arc::clone(&self.profile).inject_anoncreds_ledger_read();
         Ok(ledger.get_schema(thread_id, None).await?)
     }
 

--- a/aries_vcx/src/common/anoncreds.rs
+++ b/aries_vcx/src/common/anoncreds.rs
@@ -71,7 +71,7 @@ pub mod integration_tests {
             )
             .await;
 
-            let ledger = Arc::clone(&holder_setup.profile).inject_ledger();
+            let ledger = Arc::clone(&holder_setup.profile).inject_anoncreds_ledger_read();
 
             let (_, first_rev_reg_delta, first_timestamp) =
                 ledger.get_rev_reg_delta_json(&rev_reg_id, None, None).await.unwrap();

--- a/aries_vcx/src/common/keys.rs
+++ b/aries_vcx/src/common/keys.rs
@@ -6,7 +6,7 @@ use crate::core::profile::profile::Profile;
 use crate::errors::error::prelude::*;
 
 pub async fn rotate_verkey_apply(profile: &Arc<dyn Profile>, did: &str, temp_vk: &str) -> VcxResult<()> {
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_indy_ledger_write();
 
     let nym_result = ledger.publish_nym(did, did, Some(temp_vk), None, None).await?;
 
@@ -41,7 +41,7 @@ pub async fn rotate_verkey(profile: &Arc<dyn Profile>, did: &str) -> VcxResult<(
 }
 
 pub async fn get_verkey_from_ledger(profile: &Arc<dyn Profile>, did: &str) -> VcxResult<String> {
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_indy_ledger_read();
 
     let nym_response: String = ledger.get_nym(did).await?;
     let nym_json: Value = serde_json::from_str(&nym_response).map_err(|err| {
@@ -75,17 +75,17 @@ pub async fn get_verkey_from_ledger(profile: &Arc<dyn Profile>, did: &str) -> Vc
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use aries_vcx_core::indy::utils::mocks::pool_mocks::{enable_pool_mocks, PoolMocks};
-
-    use crate::utils::devsetup::*;
-    use crate::utils::mockdata::mockdata_pool;
-
-    use super::*;
-
     #[tokio::test]
     #[ignore]
     #[cfg(not(feature = "vdr_proxy_ledger"))]
     async fn test_pool_rotate_verkey_fails() {
+        use super::*;
+
+        use aries_vcx_core::indy::utils::mocks::pool_mocks::{enable_pool_mocks, PoolMocks};
+
+        use crate::utils::devsetup::*;
+        use crate::utils::mockdata::mockdata_pool;
+
         SetupProfile::run_indy(|setup| async move {
             enable_pool_mocks();
 

--- a/aries_vcx/src/common/primitives/credential_schema.rs
+++ b/aries_vcx/src/common/primitives/credential_schema.rs
@@ -90,7 +90,7 @@ impl Schema {
         source_id: &str,
         schema_id: &str,
     ) -> VcxResult<Self> {
-        let ledger = Arc::clone(profile).inject_ledger();
+        let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
         let schema_json = ledger.get_schema(schema_id, None).await?;
         let schema_data: SchemaData = serde_json::from_str(&schema_json).map_err(|err| {
             AriesVcxError::from_msg(
@@ -121,7 +121,7 @@ impl Schema {
             });
         }
 
-        let ledger = Arc::clone(profile).inject_ledger();
+        let ledger = Arc::clone(profile).inject_anoncreds_ledger_write();
         ledger
             .publish_schema(&self.schema_json, &self.submitter_did, endorser_did)
             .await?;
@@ -153,7 +153,7 @@ impl Schema {
     }
 
     pub async fn update_state(&mut self, profile: &Arc<dyn Profile>) -> VcxResult<u32> {
-        let ledger = Arc::clone(profile).inject_ledger();
+        let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
         if ledger.get_schema(&self.schema_id, None).await.is_ok() {
             self.state = PublicEntityStateType::Published
         }
@@ -164,7 +164,7 @@ impl Schema {
         if !self.schema_json.is_empty() {
             Ok(self.schema_json.clone())
         } else {
-            let ledger = Arc::clone(profile).inject_ledger();
+            let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
             Ok(ledger.get_schema(&self.schema_id, None).await?)
         }
     }

--- a/aries_vcx/src/common/primitives/mod.rs
+++ b/aries_vcx/src/common/primitives/mod.rs
@@ -54,7 +54,7 @@ pub mod integration_tests {
             let (_, _, _, _, rev_reg_id, _, _) =
                 create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
 
-            let ledger = Arc::clone(&setup.profile).inject_ledger();
+            let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let _json = ledger.get_rev_reg_def_json(&rev_reg_id).await.unwrap();
         })
         .await;
@@ -68,7 +68,7 @@ pub mod integration_tests {
             let (_, _, _, _, rev_reg_id, _, _) =
                 create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
 
-            let ledger = Arc::clone(&setup.profile).inject_ledger();
+            let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let (id, _delta, _timestamp) = ledger.get_rev_reg_delta_json(&rev_reg_id, None, None).await.unwrap();
 
             assert_eq!(id, rev_reg_id);
@@ -84,7 +84,7 @@ pub mod integration_tests {
             let (_, _, _, _, rev_reg_id, _, _) =
                 create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
 
-            let ledger = Arc::clone(&setup.profile).inject_ledger();
+            let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let (id, _rev_reg, _timestamp) = ledger
                 .get_rev_reg(&rev_reg_id, time::OffsetDateTime::now_utc().unix_timestamp() as u64)
                 .await
@@ -103,7 +103,7 @@ pub mod integration_tests {
             let (_, _, cred_def_id, cred_def_json, _) =
                 create_and_store_nonrevocable_credential_def(&setup.profile, &setup.institution_did, attrs).await;
 
-            let ledger = Arc::clone(&setup.profile).inject_ledger();
+            let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let cred_def = ledger.get_cred_def(&cred_def_id, None).await.unwrap();
 
             assert_eq!(
@@ -121,7 +121,7 @@ pub mod integration_tests {
             let (schema_id, _schema_json) =
                 create_and_write_test_schema(&setup.profile, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
 
-            let ledger = Arc::clone(&setup.profile).inject_ledger();
+            let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let rc = ledger.get_schema(&schema_id, None).await;
 
             let retrieved_schema = rc.unwrap();

--- a/aries_vcx/src/common/primitives/revocation_registry.rs
+++ b/aries_vcx/src/common/primitives/revocation_registry.rs
@@ -101,7 +101,7 @@ impl RevocationRegistry {
             &self.rev_reg_def
         );
         self.rev_reg_def.value.tails_location = String::from(tails_url);
-        let ledger = Arc::clone(profile).inject_ledger();
+        let ledger = Arc::clone(profile).inject_anoncreds_ledger_write();
         ledger
             .publish_rev_reg_def(&json!(self.rev_reg_def).to_string(), issuer_did)
             .await
@@ -121,7 +121,7 @@ impl RevocationRegistry {
             issuer_did,
             self.rev_reg_id
         );
-        let ledger = Arc::clone(profile).inject_ledger();
+        let ledger = Arc::clone(profile).inject_anoncreds_ledger_write();
         ledger
             .publish_rev_reg_delta(&self.rev_reg_id, &self.rev_reg_entry, issuer_did)
             .await
@@ -196,7 +196,7 @@ impl RevocationRegistry {
 
     pub async fn publish_local_revocations(&self, profile: &Arc<dyn Profile>, submitter_did: &str) -> VcxResult<()> {
         let anoncreds = Arc::clone(profile).inject_anoncreds();
-        let ledger = Arc::clone(profile).inject_ledger();
+        let ledger = Arc::clone(profile).inject_anoncreds_ledger_write();
 
         if let Some(delta) = anoncreds.get_rev_reg_delta(&self.rev_reg_id).await? {
             ledger

--- a/aries_vcx/src/common/primitives/revocation_registry_delta.rs
+++ b/aries_vcx/src/common/primitives/revocation_registry_delta.rs
@@ -38,7 +38,7 @@ impl RevocationRegistryDelta {
         from: Option<u64>,
         to: Option<u64>,
     ) -> VcxResult<Self> {
-        let ledger = Arc::clone(profile).inject_ledger();
+        let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
         let (_, rev_reg_delta_json, _) = ledger.get_rev_reg_delta_json(rev_reg_id, from, to).await?;
         serde_json::from_str(&rev_reg_delta_json).map_err(|err| {
             AriesVcxError::from_msg(

--- a/aries_vcx/src/common/proofs/prover/prover_internal.rs
+++ b/aries_vcx/src/common/proofs/prover/prover_internal.rs
@@ -31,7 +31,7 @@ pub async fn build_schemas_json_prover(
         "build_schemas_json_prover >>> credentials_identifiers: {:?}",
         credentials_identifiers
     );
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut rtn: Value = json!({});
 
     for cred_info in credentials_identifiers {
@@ -62,7 +62,7 @@ pub async fn build_cred_defs_json_prover(
         "build_cred_defs_json_prover >>> credentials_identifiers: {:?}",
         credentials_identifiers
     );
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut rtn: Value = json!({});
 
     for cred_info in credentials_identifiers {
@@ -167,7 +167,7 @@ pub async fn build_rev_states_json(
         "build_rev_states_json >> credentials_identifiers: {:?}",
         credentials_identifiers
     );
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let anoncreds = Arc::clone(profile).inject_anoncreds();
     let mut rtn: Value = json!({});
     let mut timestamps: HashMap<String, u64> = HashMap::new();

--- a/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
@@ -101,7 +101,7 @@ pub async fn build_cred_defs_json_verifier(
     credential_data: &[CredInfoVerifier],
 ) -> VcxResult<String> {
     debug!("building credential_def_json for proof validation");
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut credential_json = json!({});
 
     for cred_info in credential_data.iter() {
@@ -129,7 +129,7 @@ pub async fn build_schemas_json_verifier(
 ) -> VcxResult<String> {
     debug!("building schemas json for proof validation");
 
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut schemas_json = json!({});
 
     for cred_info in credential_data.iter() {
@@ -158,7 +158,7 @@ pub async fn build_rev_reg_defs_json(
 ) -> VcxResult<String> {
     debug!("building rev_reg_def_json for proof validation");
 
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut rev_reg_defs_json = json!({});
 
     for cred_info in credential_data.iter() {
@@ -183,7 +183,7 @@ pub async fn build_rev_reg_defs_json(
 pub async fn build_rev_reg_json(profile: &Arc<dyn Profile>, credential_data: &[CredInfoVerifier]) -> VcxResult<String> {
     debug!("building rev_reg_json for proof validation");
 
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut rev_regs_json = json!({});
 
     for cred_info in credential_data.iter() {

--- a/aries_vcx/src/common/test_utils.rs
+++ b/aries_vcx/src/common/test_utils.rs
@@ -37,7 +37,7 @@ pub async fn create_and_write_test_schema(
     attr_list: &str,
 ) -> (String, String) {
     let (schema_id, schema_json) = create_schema(profile, attr_list, submitter_did).await;
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_write();
     let _response = ledger.publish_schema(&schema_json, submitter_did, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(1000)).await;
     (schema_id, schema_json)
@@ -65,7 +65,7 @@ pub async fn create_and_store_nonrevocable_credential_def(
     let cred_def_id = cred_def.get_cred_def_id();
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let cred_def_json = ledger.get_cred_def(&cred_def_id, None).await.unwrap();
     (schema_id, schema_json, cred_def_id, cred_def_json, cred_def)
 }
@@ -115,7 +115,7 @@ pub async fn create_and_store_credential_def(
     tokio::time::sleep(Duration::from_millis(1000)).await;
     let cred_def_id = cred_def.get_cred_def_id();
     tokio::time::sleep(Duration::from_millis(1000)).await;
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let cred_def_json = ledger.get_cred_def(&cred_def_id, None).await.unwrap();
     (
         schema_id,
@@ -178,7 +178,7 @@ pub async fn create_and_store_credential(
     /* create cred */
     let credential_data = r#"{"address1": ["123 Main St"], "address2": ["Suite 3"], "city": ["Draper"], "state": ["UT"], "zip": ["84000"]}"#;
     let encoded_attributes = encode_attributes(&credential_data).unwrap();
-    let ledger = Arc::clone(issuer).inject_ledger();
+    let ledger = Arc::clone(issuer).inject_anoncreds_ledger_read();
     let rev_def_json = ledger.get_rev_reg_def_json(&rev_reg_id).await.unwrap();
     let tails_file = get_temp_dir_path(TAILS_DIR).to_str().unwrap().to_string();
 

--- a/aries_vcx/src/core/profile/modular_libs_profile.rs
+++ b/aries_vcx/src/core/profile/modular_libs_profile.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
 use aries_vcx_core::anoncreds::credx_anoncreds::IndyCredxAnonCreds;
-use aries_vcx_core::ledger::base_ledger::BaseLedger;
+use aries_vcx_core::ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite};
 use aries_vcx_core::ledger::indy_vdr_ledger::{IndyVdrLedger, IndyVdrLedgerConfig};
 use aries_vcx_core::ledger::request_signer::base_wallet::BaseWalletRequestSigner;
 use aries_vcx_core::ledger::request_submitter::vdr_ledger::{IndyVdrLedgerPool, IndyVdrSubmitter, LedgerPoolConfig};
@@ -19,8 +19,11 @@ use super::profile::Profile;
 #[derive(Debug)]
 pub struct ModularLibsProfile {
     wallet: Arc<dyn BaseWallet>,
-    ledger: Arc<dyn BaseLedger>,
     anoncreds: Arc<dyn BaseAnonCreds>,
+    anoncreds_ledger_read: Arc<dyn AnoncredsLedgerRead>,
+    anoncreds_ledger_write: Arc<dyn AnoncredsLedgerWrite>,
+    indy_ledger_read: Arc<dyn IndyLedgerRead>,
+    indy_ledger_write: Arc<dyn IndyLedgerWrite>,
 }
 
 impl ModularLibsProfile {
@@ -44,19 +47,34 @@ impl ModularLibsProfile {
         let ledger = Arc::new(IndyVdrLedger::new(config));
         Ok(ModularLibsProfile {
             wallet,
-            ledger,
             anoncreds,
+            anoncreds_ledger_read: ledger.clone(),
+            anoncreds_ledger_write: ledger.clone(),
+            indy_ledger_read: ledger.clone(),
+            indy_ledger_write: ledger,
         })
     }
 }
 
 impl Profile for ModularLibsProfile {
-    fn inject_ledger(self: Arc<Self>) -> Arc<dyn BaseLedger> {
-        Arc::clone(&self.ledger)
+    fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead> {
+        Arc::clone(&self.indy_ledger_read)
+    }
+
+    fn inject_indy_ledger_write(self: Arc<Self>) -> Arc<dyn IndyLedgerWrite> {
+        Arc::clone(&self.indy_ledger_write)
     }
 
     fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds> {
         Arc::clone(&self.anoncreds)
+    }
+
+    fn inject_anoncreds_ledger_read(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerRead> {
+        Arc::clone(&self.anoncreds_ledger_read)
+    }
+
+    fn inject_anoncreds_ledger_write(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerWrite> {
+        Arc::clone(&self.anoncreds_ledger_write)
     }
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {

--- a/aries_vcx/src/core/profile/profile.rs
+++ b/aries_vcx/src/core/profile/profile.rs
@@ -1,13 +1,21 @@
 use std::sync::Arc;
 
 use aries_vcx_core::{
-    anoncreds::base_anoncreds::BaseAnonCreds, ledger::base_ledger::BaseLedger, wallet::base_wallet::BaseWallet,
+    anoncreds::base_anoncreds::BaseAnonCreds,
+    ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
+    wallet::base_wallet::BaseWallet,
 };
 
 pub trait Profile: std::fmt::Debug + Send + Sync {
-    fn inject_ledger(self: Arc<Self>) -> Arc<dyn BaseLedger>;
+    fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead>;
+
+    fn inject_indy_ledger_write(self: Arc<Self>) -> Arc<dyn IndyLedgerWrite>;
 
     fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds>;
+
+    fn inject_anoncreds_ledger_read(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerRead>;
+
+    fn inject_anoncreds_ledger_write(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerWrite>;
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet>;
 }

--- a/aries_vcx/src/core/profile/vdr_proxy_profile.rs
+++ b/aries_vcx/src/core/profile/vdr_proxy_profile.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 use aries_vcx_core::{
     anoncreds::{base_anoncreds::BaseAnonCreds, indy_anoncreds::IndySdkAnonCreds},
     ledger::{
-        base_ledger::BaseLedger,
+        base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
         indy_vdr_ledger::{IndyVdrLedger, IndyVdrLedgerConfig},
         request_signer::base_wallet::BaseWalletRequestSigner,
         request_submitter::vdr_proxy::VdrProxySubmitter,
@@ -20,8 +20,11 @@ use super::profile::Profile;
 #[derive(Debug)]
 pub struct VdrProxyProfile {
     wallet: Arc<dyn BaseWallet>,
-    ledger: Arc<dyn BaseLedger>,
     anoncreds: Arc<dyn BaseAnonCreds>,
+    anoncreds_ledger_read: Arc<dyn AnoncredsLedgerRead>,
+    anoncreds_ledger_write: Arc<dyn AnoncredsLedgerWrite>,
+    indy_ledger_read: Arc<dyn IndyLedgerRead>,
+    indy_ledger_write: Arc<dyn IndyLedgerWrite>,
 }
 
 impl VdrProxyProfile {
@@ -45,19 +48,34 @@ impl VdrProxyProfile {
         let ledger = Arc::new(IndyVdrLedger::new(config));
         Ok(VdrProxyProfile {
             wallet,
-            ledger,
             anoncreds,
+            anoncreds_ledger_read: ledger.clone(),
+            anoncreds_ledger_write: ledger.clone(),
+            indy_ledger_read: ledger.clone(),
+            indy_ledger_write: ledger,
         })
     }
 }
 
 impl Profile for VdrProxyProfile {
-    fn inject_ledger(self: Arc<Self>) -> Arc<dyn BaseLedger> {
-        Arc::clone(&self.ledger)
+    fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead> {
+        Arc::clone(&self.indy_ledger_read)
+    }
+
+    fn inject_indy_ledger_write(self: Arc<Self>) -> Arc<dyn IndyLedgerWrite> {
+        Arc::clone(&self.indy_ledger_write)
     }
 
     fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds> {
         Arc::clone(&self.anoncreds)
+    }
+
+    fn inject_anoncreds_ledger_read(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerRead> {
+        Arc::clone(&self.anoncreds_ledger_read)
+    }
+
+    fn inject_anoncreds_ledger_write(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerWrite> {
+        Arc::clone(&self.anoncreds_ledger_write)
     }
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {

--- a/aries_vcx/src/core/profile/vdrtools_profile.rs
+++ b/aries_vcx/src/core/profile/vdrtools_profile.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use aries_vcx_core::{
     anoncreds::{base_anoncreds::BaseAnonCreds, indy_anoncreds::IndySdkAnonCreds},
-    ledger::{base_ledger::BaseLedger, indy_ledger::IndySdkLedger},
+    ledger::{
+        base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
+        indy_ledger::IndySdkLedger,
+    },
     wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
     PoolHandle, WalletHandle,
 };
@@ -12,30 +15,48 @@ use super::profile::Profile;
 #[derive(Debug)]
 pub struct VdrtoolsProfile {
     wallet: Arc<dyn BaseWallet>,
-    ledger: Arc<dyn BaseLedger>,
     anoncreds: Arc<dyn BaseAnonCreds>,
+    anoncreds_ledger_read: Arc<dyn AnoncredsLedgerRead>,
+    anoncreds_ledger_write: Arc<dyn AnoncredsLedgerWrite>,
+    indy_ledger_read: Arc<dyn IndyLedgerRead>,
+    indy_ledger_write: Arc<dyn IndyLedgerWrite>,
 }
 
 impl VdrtoolsProfile {
     pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
         let wallet = Arc::new(IndySdkWallet::new(indy_wallet_handle));
-        let ledger = Arc::new(IndySdkLedger::new(indy_wallet_handle, indy_pool_handle));
         let anoncreds = Arc::new(IndySdkAnonCreds::new(indy_wallet_handle));
+        let ledger = Arc::new(IndySdkLedger::new(indy_wallet_handle, indy_pool_handle));
         VdrtoolsProfile {
             wallet,
-            ledger,
             anoncreds,
+            anoncreds_ledger_read: ledger.clone(),
+            anoncreds_ledger_write: ledger.clone(),
+            indy_ledger_read: ledger.clone(),
+            indy_ledger_write: ledger,
         }
     }
 }
 
 impl Profile for VdrtoolsProfile {
-    fn inject_ledger(self: Arc<Self>) -> Arc<dyn BaseLedger> {
-        Arc::clone(&self.ledger)
+    fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead> {
+        Arc::clone(&self.indy_ledger_read)
+    }
+
+    fn inject_indy_ledger_write(self: Arc<Self>) -> Arc<dyn IndyLedgerWrite> {
+        Arc::clone(&self.indy_ledger_write)
     }
 
     fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds> {
         Arc::clone(&self.anoncreds)
+    }
+
+    fn inject_anoncreds_ledger_read(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerRead> {
+        Arc::clone(&self.anoncreds_ledger_read)
+    }
+
+    fn inject_anoncreds_ledger_write(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerWrite> {
+        Arc::clone(&self.anoncreds_ledger_write)
     }
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {

--- a/aries_vcx/src/global/author_agreement.rs
+++ b/aries_vcx/src/global/author_agreement.rs
@@ -1,5 +1,5 @@
 use crate::errors::error::VcxResult;
-use aries_vcx_core::global::author_agreement::{set_txn_author_agreement, TxnAuthorAgreementAcceptanceData};
+use aries_vcx_core::global::author_agreement::set_txn_author_agreement;
 
 pub fn proxy_set_txn_author_agreement(
     text: Option<String>,

--- a/aries_vcx/src/protocols/issuance/holder/state_machine.rs
+++ b/aries_vcx/src/protocols/issuance/holder/state_machine.rs
@@ -578,7 +578,7 @@ async fn _store_credential(
         cred_def_json
     );
 
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let anoncreds = Arc::clone(profile).inject_anoncreds();
 
     let credential_json = get_attach_as_string!(&credential.content.credentials_attach);
@@ -619,7 +619,7 @@ pub async fn create_credential_request(
     prover_did: &str,
     cred_offer: &str,
 ) -> VcxResult<(String, String, String, String)> {
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let anoncreds = Arc::clone(profile).inject_anoncreds();
     let cred_def_json = ledger.get_cred_def(cred_def_id, None).await?;
 

--- a/aries_vcx/src/protocols/issuance/mod.rs
+++ b/aries_vcx/src/protocols/issuance/mod.rs
@@ -23,7 +23,7 @@ pub fn verify_thread_id(thread_id: &str, message: &CredentialIssuanceAction) -> 
 }
 
 pub async fn is_cred_def_revokable(profile: &Arc<dyn Profile>, cred_def_id: &str) -> VcxResult<bool> {
-    let ledger = Arc::clone(profile).inject_ledger();
+    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let cred_def_json = ledger.get_cred_def(cred_def_id, None).await.map_err(|err| {
         AriesVcxError::from_msg(
             AriesVcxErrorKind::InvalidLedgerResponse,

--- a/aries_vcx/src/utils/mockdata/mock_settings.rs
+++ b/aries_vcx/src/utils/mockdata/mock_settings.rs
@@ -1,5 +1,5 @@
+use std::collections::HashMap;
 use std::sync::RwLock;
-use std::{collections::HashMap, sync::Mutex};
 
 use crate::errors::error::{AriesVcxError, VcxResult};
 

--- a/aries_vcx/src/utils/mockdata/profile/mock_ledger.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_ledger.rs
@@ -1,32 +1,16 @@
 use aries_vcx_core::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
-use aries_vcx_core::ledger::base_ledger::BaseLedger;
+use aries_vcx_core::ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite};
 use async_trait::async_trait;
 
-use crate::utils::{
-    self,
-    constants::{rev_def_json, CRED_DEF_JSON, REV_REG_DELTA_JSON, REV_REG_ID, REV_REG_JSON, SCHEMA_JSON},
-};
+use crate::utils;
+use crate::utils::constants::{rev_def_json, CRED_DEF_JSON, REV_REG_DELTA_JSON, REV_REG_ID, REV_REG_JSON, SCHEMA_JSON};
 
 #[derive(Debug)]
 pub(crate) struct MockLedger;
 
-// NOTE : currently matches the expected results if indy_mocks are enabled
-/// Implementation of [BaseLedger] which responds with mock data
 #[allow(unused)]
 #[async_trait]
-impl BaseLedger for MockLedger {
-    async fn submit_request(&self, request_json: &str) -> VcxCoreResult<String> {
-        // not needed yet
-        Err(AriesVcxCoreError::from_msg(
-            AriesVcxCoreErrorKind::UnimplementedFeature,
-            "unimplemented mock method: submit_request",
-        ))
-    }
-
-    async fn endorse_transaction(&self, endorser_did: &str, request_json: &str) -> VcxCoreResult<()> {
-        Ok(())
-    }
-
+impl IndyLedgerRead for MockLedger {
     async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String> {
         Ok(utils::constants::REQUEST_WITH_ENDORSER.to_string())
     }
@@ -43,6 +27,22 @@ impl BaseLedger for MockLedger {
         ))
     }
 
+    async fn get_attr(&self, target_did: &str, attr_name: &str) -> VcxCoreResult<String> {
+        Ok(r#"{"rc":"success"}"#.to_string())
+    }
+
+    async fn get_ledger_txn(&self, seq_no: i32, submitter_did: Option<&str>) -> VcxCoreResult<String> {
+        Ok(r#"{"rc":"success"}"#.to_string())
+    }
+}
+
+#[allow(unused)]
+#[async_trait]
+impl IndyLedgerWrite for MockLedger {
+    async fn endorse_transaction(&self, endorser_did: &str, request_json: &str) -> VcxCoreResult<()> {
+        Ok(())
+    }
+
     async fn publish_nym(
         &self,
         submitter_did: &str,
@@ -54,20 +54,20 @@ impl BaseLedger for MockLedger {
         Ok(r#"{"rc":"success"}"#.to_string())
     }
 
+    async fn add_attr(&self, target_did: &str, attrib_json: &str) -> VcxCoreResult<String> {
+        Ok(r#"{"rc":"success"}"#.to_string())
+    }
+}
+
+#[allow(unused)]
+#[async_trait]
+impl AnoncredsLedgerRead for MockLedger {
     async fn get_schema(&self, schema_id: &str, submitter_did: Option<&str>) -> VcxCoreResult<String> {
         Ok(SCHEMA_JSON.to_string())
     }
 
     async fn get_cred_def(&self, cred_def_id: &str, submitter_did: Option<&str>) -> VcxCoreResult<String> {
         Ok(CRED_DEF_JSON.to_string())
-    }
-
-    async fn get_attr(&self, target_did: &str, attr_name: &str) -> VcxCoreResult<String> {
-        Ok(r#"{"rc":"success"}"#.to_string())
-    }
-
-    async fn add_attr(&self, target_did: &str, attrib_json: &str) -> VcxCoreResult<String> {
-        Ok(r#"{"rc":"success"}"#.to_string())
     }
 
     async fn get_rev_reg_def_json(&self, rev_reg_id: &str) -> VcxCoreResult<String> {
@@ -86,11 +86,11 @@ impl BaseLedger for MockLedger {
     async fn get_rev_reg(&self, rev_reg_id: &str, timestamp: u64) -> VcxCoreResult<(String, String, u64)> {
         Ok((REV_REG_ID.to_string(), REV_REG_JSON.to_string(), 1))
     }
+}
 
-    async fn get_ledger_txn(&self, seq_no: i32, submitter_did: Option<&str>) -> VcxCoreResult<String> {
-        Ok(r#"{"rc":"success"}"#.to_string())
-    }
-
+#[allow(unused)]
+#[async_trait]
+impl AnoncredsLedgerWrite for MockLedger {
     async fn publish_schema(
         &self,
         schema_json: &str,
@@ -124,7 +124,7 @@ mod unit_tests {
 
     use aries_vcx_core::{
         errors::error::{AriesVcxCoreErrorKind, VcxCoreResult},
-        ledger::base_ledger::BaseLedger,
+        ledger::base_ledger::IndyLedgerRead,
     };
 
     use super::MockLedger;
@@ -137,9 +137,8 @@ mod unit_tests {
             assert_eq!(result.unwrap_err().kind(), AriesVcxCoreErrorKind::UnimplementedFeature)
         }
 
-        let ledger: Box<dyn BaseLedger> = Box::new(MockLedger);
+        let ledger: Box<dyn IndyLedgerRead> = Box::new(MockLedger);
 
-        assert_unimplemented(ledger.submit_request("").await);
         assert_unimplemented(ledger.get_nym("").await);
     }
 }

--- a/aries_vcx/src/utils/mockdata/profile/mock_profile.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_profile.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use aries_vcx_core::{
-    anoncreds::base_anoncreds::BaseAnonCreds, ledger::base_ledger::BaseLedger, wallet::base_wallet::BaseWallet,
+    anoncreds::base_anoncreds::BaseAnonCreds,
+    ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
+    wallet::base_wallet::BaseWallet,
 };
 
 use crate::core::profile::profile::Profile;
@@ -14,7 +16,11 @@ use super::{mock_anoncreds::MockAnoncreds, mock_ledger::MockLedger, mock_wallet:
 pub struct MockProfile;
 
 impl Profile for MockProfile {
-    fn inject_ledger(self: Arc<Self>) -> Arc<dyn BaseLedger> {
+    fn inject_indy_ledger_write(self: Arc<Self>) -> Arc<dyn IndyLedgerWrite> {
+        Arc::new(MockLedger {})
+    }
+
+    fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead> {
         Arc::new(MockLedger {})
     }
 
@@ -24,5 +30,13 @@ impl Profile for MockProfile {
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {
         Arc::new(MockWallet {})
+    }
+
+    fn inject_anoncreds_ledger_read(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerRead> {
+        Arc::new(MockLedger {})
+    }
+
+    fn inject_anoncreds_ledger_write(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerWrite> {
+        Arc::new(MockLedger {})
     }
 }

--- a/aries_vcx/tests/test_agency.rs
+++ b/aries_vcx/tests/test_agency.rs
@@ -9,7 +9,6 @@ pub mod utils;
 #[cfg(test)]
 mod integration_tests {
     use std::sync::Arc;
-    use std::thread;
     use std::time::Duration;
 
     use agency_client::agency_client::AgencyClient;

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -13,7 +13,6 @@ mod integration_tests {
         create_and_store_credential, create_and_store_nonrevocable_credential,
         create_and_store_nonrevocable_credential_def, create_indy_proof,
     };
-    use aries_vcx::errors::error::VcxResult;
     use aries_vcx::handlers::proof_presentation::prover::Prover;
     use aries_vcx::handlers::proof_presentation::verifier::Verifier;
     use aries_vcx::handlers::util::AttachmentId;
@@ -75,7 +74,7 @@ mod integration_tests {
             )
             .await;
 
-            let ledger = Arc::clone(&setup.profile).inject_ledger();
+            let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let r_cred_def_json = ledger.get_cred_def(&cred_def_id, None).await.unwrap();
 
             let def1: serde_json::Value = serde_json::from_str(&cred_def_json).unwrap();
@@ -464,7 +463,6 @@ mod integration_tests {
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
     use std::time::Duration;
 
     use messages::msg_fields::protocols::cred_issuance::offer_credential::OfferCredential;
@@ -492,7 +490,6 @@ mod tests {
         send_cred_proposal, send_cred_proposal_1, send_cred_req, send_credential, send_proof_proposal,
         send_proof_proposal_1, send_proof_request, verifier_create_proof_and_send_request, verify_proof,
     };
-    use crate::utils::test_macros::ProofStateType;
 
     use super::*;
 

--- a/aries_vcx/tests/test_creds_proofs_revocations.rs
+++ b/aries_vcx/tests/test_creds_proofs_revocations.rs
@@ -7,7 +7,6 @@ pub mod utils;
 
 #[cfg(test)]
 mod integration_tests {
-    use std::thread;
     use std::time::Duration;
 
     use aries_vcx::protocols::proof_presentation::prover::state_machine::ProverState;
@@ -23,7 +22,6 @@ mod integration_tests {
         revoke_credential_and_publish_accumulator, revoke_credential_local, rotate_rev_reg, send_proof_request,
         verifier_create_proof_and_send_request,
     };
-    use crate::utils::test_macros::ProofStateType;
 
     use super::*;
 

--- a/aries_vcx/tests/test_pool.rs
+++ b/aries_vcx/tests/test_pool.rs
@@ -12,9 +12,8 @@ mod integration_tests {
     use aries_vcx::common::ledger::transactions::{
         add_attr, add_new_did, clear_attr, get_attr, get_service, write_endpoint, write_endpoint_legacy,
     };
-    use aries_vcx::common::primitives::credential_schema::{Schema, SchemaData};
     use aries_vcx::common::test_utils::create_and_store_nonrevocable_credential_def;
-    use aries_vcx::utils::constants::{DEFAULT_SCHEMA_ATTRS, SCHEMA_DATA};
+    use aries_vcx::utils::constants::DEFAULT_SCHEMA_ATTRS;
     use aries_vcx::utils::devsetup::{SetupProfile, SetupWalletPool};
     use diddoc_legacy::aries::service::AriesService;
     use std::sync::Arc;
@@ -42,7 +41,7 @@ mod integration_tests {
             )
             .await;
 
-            let ledger = Arc::clone(&setup.profile).inject_ledger();
+            let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
 
             let r_cred_def_json = ledger.get_cred_def(&cred_def_id, None).await.unwrap();
 

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -447,6 +447,7 @@ pub mod test_utils {
     }
 
     pub async fn create_test_alice_instance(setup: &SetupPool) -> Alice {
+        #[cfg(not(feature = "modular_libs"))]
         let (alice_profile, teardown) = {
             info!("create_test_alice_instance >> using indy profile");
             Alice::setup_indy_profile(setup.pool_handle).await

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -48,7 +48,6 @@ pub mod test_utils {
     use aries_vcx::utils::get_temp_dir_path;
 
     use crate::utils::devsetup_agent::test_utils::{Alice, Faber};
-    use crate::utils::test_macros::ProofStateType;
 
     pub fn _send_message(sender: Sender<AriesMessage>) -> Option<SendClosureConnection> {
         Some(Box::new(
@@ -769,7 +768,7 @@ pub mod test_utils {
     }
 
     pub async fn revoke_credential_local(faber: &mut Faber, issuer_credential: &Issuer, rev_reg_id: &str) {
-        let ledger = Arc::clone(&faber.profile).inject_ledger();
+        let ledger = Arc::clone(&faber.profile).inject_anoncreds_ledger_read();
         let (_, delta, timestamp) = ledger.get_rev_reg_delta_json(&rev_reg_id, None, None).await.unwrap();
         info!("revoking credential locally");
         issuer_credential.revoke_credential_local(&faber.profile).await.unwrap();

--- a/aries_vcx_core/src/global/mockdata/mock_settings.rs
+++ b/aries_vcx_core/src/global/mockdata/mock_settings.rs
@@ -1,5 +1,5 @@
+use std::collections::HashMap;
 use std::sync::RwLock;
-use std::{collections::HashMap, sync::Mutex};
 
 use crate::errors::error::VcxCoreResult;
 

--- a/aries_vcx_core/src/indy/credentials/issuer/mod.rs
+++ b/aries_vcx_core/src/indy/credentials/issuer/mod.rs
@@ -1,6 +1,6 @@
 use vdrtools::{CredentialOffer, CredentialRequest, CredentialValues, Locator, RevocationRegistryId};
 
-use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
+use crate::errors::error::VcxCoreResult;
 use crate::global::settings;
 use crate::indy::anoncreds;
 use crate::indy::utils::parse_and_validate;

--- a/aries_vcx_core/src/indy/primitives/revocation_registry.rs
+++ b/aries_vcx_core/src/indy/primitives/revocation_registry.rs
@@ -1,17 +1,13 @@
-use std::sync::Arc;
-
 use vdrtools::{DidValue, Locator};
 
-use crate::anoncreds::base_anoncreds::BaseAnonCreds;
-use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
+use crate::errors::error::VcxCoreResult;
 use crate::global::settings;
 use crate::indy::anoncreds;
 use crate::indy::ledger::transactions::{
     build_rev_reg_delta_request, build_rev_reg_request, check_response, sign_and_submit_to_ledger,
 };
 use crate::indy::utils::parse_and_validate;
-use crate::indy::wallet_non_secrets::{clear_rev_reg_delta, get_rev_reg_delta, set_rev_reg_delta};
-use crate::ledger::base_ledger::BaseLedger;
+use crate::indy::wallet_non_secrets::{get_rev_reg_delta, set_rev_reg_delta};
 use crate::{PoolHandle, WalletHandle};
 
 pub const BLOB_STORAGE_TYPE: &str = "default";

--- a/aries_vcx_core/src/ledger/base_ledger.rs
+++ b/aries_vcx_core/src/ledger/base_ledger.rs
@@ -1,25 +1,20 @@
+use std::fmt::Debug;
+
 use async_trait::async_trait;
 
 use crate::errors::error::VcxCoreResult;
 
-/// Trait defining standard 'ledger' related functionality.
 #[async_trait]
-pub trait BaseLedger: std::fmt::Debug + Send + Sync {
-    // returns request result as JSON
-    async fn submit_request(&self, request_json: &str) -> VcxCoreResult<String>;
-
-    // endorsers/multi signs a request, submits to ledger, and verifies successful result
-    async fn endorse_transaction(&self, endorser_did: &str, request_json: &str) -> VcxCoreResult<()>;
-
-    // adds endorser to request and signs with submitter_did, returns the transaction ready for endorser to take
-    async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String>;
-
-    async fn get_txn_author_agreement(&self) -> VcxCoreResult<String>;
-
-    // returns request result as JSON
+pub trait IndyLedgerRead: Debug + Send + Sync {
+    async fn get_attr(&self, target_did: &str, attr_name: &str) -> VcxCoreResult<String>;
     async fn get_nym(&self, did: &str) -> VcxCoreResult<String>;
+    async fn get_txn_author_agreement(&self) -> VcxCoreResult<String>;
+    async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String>;
+    async fn get_ledger_txn(&self, seq_no: i32, submitter_did: Option<&str>) -> VcxCoreResult<String>;
+}
 
-    // returns request result as JSON
+#[async_trait]
+pub trait IndyLedgerWrite: Debug + Send + Sync {
     async fn publish_nym(
         &self,
         submitter_did: &str,
@@ -28,90 +23,34 @@ pub trait BaseLedger: std::fmt::Debug + Send + Sync {
         data: Option<&str>,
         role: Option<&str>,
     ) -> VcxCoreResult<String>;
-
-    // Schema json.
-    // {
-    //     id: identifier of schema
-    //     attrNames: array of attribute name strings
-    //     name: Schema's name string
-    //     version: Schema's version string
-    //     ver: Version of the Schema json
-    // }
-    // if submitter_did provided - use cache
-    // TO CONSIDER - do we need to return the schema ID in a tuple? is it ever different to the input?
-    async fn get_schema(&self, schema_id: &str, submitter_did: Option<&str>) -> VcxCoreResult<String>;
-
-    // if submitter_did provided, try use cache
-    // TO CONSIDER - do we need to return the cred def ID in a tuple? is it ever different to the input?
-    async fn get_cred_def(&self, cred_def_id: &str, submitter_did: Option<&str>) -> VcxCoreResult<String>;
-
-    // returns request result as JSON
-    async fn get_attr(&self, target_did: &str, attr_name: &str) -> VcxCoreResult<String>;
-
-    // returns request result as JSON
+    async fn endorse_transaction(&self, endorser_did: &str, request_json: &str) -> VcxCoreResult<()>;
     async fn add_attr(&self, target_did: &str, attrib_json: &str) -> VcxCoreResult<String>;
+}
 
-    // # Returns
-    // Revocation Registry Definition Id and Revocation Registry Definition json.
-    // {
-    //     "id": string - ID of the Revocation Registry,
-    //     "revocDefType": string - Revocation Registry type (only CL_ACCUM is supported for now),
-    //     "tag": string - Unique descriptive ID of the Registry,
-    //     "credDefId": string - ID of the corresponding CredentialDefinition,
-    //     "value": Registry-specific data {
-    //         "issuanceType": string - Type of Issuance(ISSUANCE_BY_DEFAULT or ISSUANCE_ON_DEMAND),
-    //         "maxCredNum": number - Maximum number of credentials the Registry can serve.
-    //         "tailsHash": string - Hash of tails.
-    //         "tailsLocation": string - Location of tails file.
-    //         "publicKeys": <public_keys> - Registry's public key.
-    //     },
-    //     "ver": string - version of revocation registry definition json.
-    // }
-    // TO CONSIDER - do we need to return the rev reg id in a tuple? is it ever different to the input?
+#[async_trait]
+pub trait AnoncredsLedgerRead: Debug + Send + Sync {
+    async fn get_schema(&self, schema_id: &str, submitter_did: Option<&str>) -> VcxCoreResult<String>;
+    async fn get_cred_def(&self, cred_def_id: &str, submitter_did: Option<&str>) -> VcxCoreResult<String>;
     async fn get_rev_reg_def_json(&self, rev_reg_id: &str) -> VcxCoreResult<String>;
-
-    // # Returns
-    // Revocation Registry Definition Id, Revocation Registry Delta json and Timestamp.
-    // {
-    //     "value": Registry-specific data {
-    //         prevAccum: string - previous accumulator value.
-    //         accum: string - current accumulator value.
-    //         issued: array<number> - an array of issued indices.
-    //         revoked: array<number> an array of revoked indices.
-    //     },
-    //     "ver": string - version revocation registry delta json
-    // }
     async fn get_rev_reg_delta_json(
         &self,
         rev_reg_id: &str,
         from: Option<u64>,
         to: Option<u64>,
     ) -> VcxCoreResult<(String, String, u64)>;
-
-    // # Returns
-    // Revocation Registry Definition Id, Revocation Registry json and Timestamp.
-    // {
-    //     "value": Registry-specific data {
-    //         "accum": string - current accumulator value.
-    //     },
-    //     "ver": string - version revocation registry json
-    // }
     async fn get_rev_reg(&self, rev_reg_id: &str, timestamp: u64) -> VcxCoreResult<(String, String, u64)>;
+}
 
-    // returns request result as JSON
-    async fn get_ledger_txn(&self, seq_no: i32, submitter_did: Option<&str>) -> VcxCoreResult<String>;
-
+#[async_trait]
+pub trait AnoncredsLedgerWrite: Debug + Send + Sync {
     async fn publish_schema(
         &self,
         schema_json: &str,
         submitter_did: &str,
         endorser_did: Option<String>,
     ) -> VcxCoreResult<()>;
-
     async fn publish_cred_def(&self, cred_def_json: &str, submitter_did: &str) -> VcxCoreResult<()>;
-
     async fn publish_rev_reg_def(&self, rev_reg_def: &str, submitter_did: &str) -> VcxCoreResult<()>;
-
     async fn publish_rev_reg_delta(
         &self,
         rev_reg_id: &str,

--- a/aries_vcx_core/src/utils/mod.rs
+++ b/aries_vcx_core/src/utils/mod.rs
@@ -1,5 +1,3 @@
-use std::{env, path::PathBuf};
-
 pub mod async_fn_iterator;
 pub(crate) mod constants;
 pub(crate) mod json;

--- a/did_resolver_sov/src/reader/mod.rs
+++ b/did_resolver_sov/src/reader/mod.rs
@@ -5,7 +5,7 @@ pub mod vdr_reader;
 
 use std::sync::Arc;
 
-use aries_vcx_core::ledger::base_ledger::BaseLedger;
+use aries_vcx_core::ledger::base_ledger::IndyLedgerRead;
 use async_trait::async_trait;
 
 use crate::error::DidSovError;
@@ -18,7 +18,7 @@ pub trait AttrReader: Send + Sync {
 }
 
 pub struct ConcreteAttrReader {
-    ledger: Arc<dyn BaseLedger>,
+    ledger: Arc<dyn IndyLedgerRead>,
 }
 
 #[async_trait]
@@ -35,8 +35,8 @@ impl AttrReader for ConcreteAttrReader {
     }
 }
 
-impl From<Arc<dyn BaseLedger>> for ConcreteAttrReader {
-    fn from(ledger: Arc<dyn BaseLedger>) -> Self {
+impl From<Arc<dyn IndyLedgerRead>> for ConcreteAttrReader {
+    fn from(ledger: Arc<dyn IndyLedgerRead>) -> Self {
         Self { ledger }
     }
 }

--- a/did_resolver_sov/tests/resolution.rs
+++ b/did_resolver_sov/tests/resolution.rs
@@ -30,7 +30,7 @@ async fn write_service_on_ledger_and_resolve_did_doc() {
         let did = format!("did:sov:{}", init.institution_did);
         write_test_endpoint(&init.profile, &init.institution_did).await;
         let resolver = DidSovResolver::new(Arc::<ConcreteAttrReader>::new(
-            init.profile.inject_ledger().into(),
+            init.profile.inject_indy_ledger_read().into(),
         ));
         let did_doc = resolver
             .resolve(
@@ -50,7 +50,7 @@ async fn test_error_handling_during_resolution() {
         let did = format!("did:unknownmethod:{}", init.institution_did);
 
         let resolver = DidSovResolver::new(Arc::<ConcreteAttrReader>::new(
-            init.profile.inject_ledger().into(),
+            init.profile.inject_indy_ledger_read().into(),
         ));
 
         let result = resolver

--- a/libvcx_core/src/api_vcx/api_global/ledger.rs
+++ b/libvcx_core/src/api_vcx/api_global/ledger.rs
@@ -18,13 +18,13 @@ pub async fn endorse_transaction(transaction: &str) -> LibvcxResult<()> {
     let endorser_did = get_config_value(CONFIG_INSTITUTION_DID)?;
 
     let profile = get_main_profile()?;
-    let ledger = profile.inject_ledger();
+    let ledger = profile.inject_indy_ledger_write();
     map_ariesvcx_core_result(ledger.endorse_transaction(&endorser_did, transaction).await)
 }
 
 pub async fn get_ledger_txn(seq_no: i32, submitter_did: Option<String>) -> LibvcxResult<String> {
     let profile = get_main_profile()?;
-    let ledger = profile.inject_ledger();
+    let ledger = profile.inject_indy_ledger_read();
     map_ariesvcx_core_result(ledger.get_ledger_txn(seq_no, submitter_did.as_deref()).await)
 }
 
@@ -94,7 +94,7 @@ pub async fn ledger_clear_attr(target_did: &str, attr: &str) -> LibvcxResult<Str
 
 pub async fn ledger_get_txn_author_agreement() -> LibvcxResult<String> {
     let profile = get_main_profile()?;
-    let ledger = profile.inject_ledger();
+    let ledger = profile.inject_indy_ledger_read();
     map_ariesvcx_core_result(ledger.get_txn_author_agreement().await)
 }
 

--- a/libvcx_core/src/api_vcx/api_global/pool.rs
+++ b/libvcx_core/src/api_vcx/api_global/pool.rs
@@ -1,5 +1,5 @@
 use aries_vcx::aries_vcx_core::indy::ledger::pool::{close, create_pool_ledger_config, open_pool_ledger, PoolConfig};
-use aries_vcx::aries_vcx_core::{PoolHandle, INVALID_POOL_HANDLE};
+use aries_vcx::aries_vcx_core::INVALID_POOL_HANDLE;
 use aries_vcx::global::settings::{indy_mocks_enabled, DEFAULT_POOL_NAME};
 use std::sync::RwLock;
 

--- a/libvcx_core/src/api_vcx/api_global/profile.rs
+++ b/libvcx_core/src/api_vcx/api_global/profile.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::errors::error::LibvcxResult;
 use aries_vcx::aries_vcx_core::{
     wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
-    PoolHandle, WalletHandle,
+    WalletHandle,
 };
 use aries_vcx::core::profile::{profile::Profile, vdrtools_profile::VdrtoolsProfile};
 use aries_vcx::{global::settings::indy_mocks_enabled, utils::mockdata::profile::mock_profile::MockProfile};

--- a/libvcx_core/src/api_vcx/api_handle/schema.rs
+++ b/libvcx_core/src/api_vcx/api_handle/schema.rs
@@ -1,5 +1,4 @@
 use std::string::ToString;
-use std::sync::Arc;
 
 use serde_json;
 


### PR DESCRIPTION
Splits `BaseLedger` trait into smaller ones:
* `AnoncredsLedgerRead` - methods for resolving Anoncreds primitives
* `AnoncredsLedgerWrite` - methods for registering Anoncreds primitives
* `IndyLedgerRead` - methods for reading Indy-specific transactions from the ledger
* `IndyLedgerWrite` - methods for writing Indy-specific transactions to the Ledger

Among other things, this allows eventual elimination of TAA stored in global state by building the "reader" which allows to obtain the TAA from ledger and use said TAA to construct a "writer" which needs TAA to write to the ledger.

The associated methods `set_endorser` and `endorse_transaction` may stand out:
* The method `set_endorser`, temporarily associated with `IndyLedgerRead`, does not read from the ledger, but merely modifies a transaction.
* The method `endorse_transaction`, temporarily associated with `IndyLedgerWrite`, again only manipulates an existing transaction (adds a multisignature) before submitting.
The pattern with the remaining methods is that a ledger-specific request is built from scratch using the supplied data and submitted to the ledger. Perhaps therefore, local modification of existing requests should not be the responsibility of mentioned traits.