### PR TITLE
Split IndyVdrLedger and IndySdkLedger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,26 @@ jobs:
         run: |
           cd libvcx && cargo clippy
 
+  check-did-resolver-feature-variants:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Git checkout"
+        uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65.0
+      - name: "Install dependencies"
+        shell: bash
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libsodium-dev libssl-dev libzmq3-dev
+      - name: "Verify aries_vcx compiles with different dependency feature variants"
+        run: |
+          cd did_resolver_sov
+          cargo check
+          cargo check --features vdrtools --no-default-features
+          cargo check --features modular_libs --no-default-features
+
   check-aries-vcx-feature-variants:
     runs-on: ubuntu-20.04
     steps:

--- a/aries_vcx/src/core/profile/modular_libs_profile.rs
+++ b/aries_vcx/src/core/profile/modular_libs_profile.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
 use aries_vcx_core::anoncreds::credx_anoncreds::IndyCredxAnonCreds;
 use aries_vcx_core::ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite};
-use aries_vcx_core::ledger::indy_vdr_ledger::{IndyVdrLedger, IndyVdrLedgerConfig};
+use aries_vcx_core::ledger::indy_vdr_ledger::{
+    IndyVdrLedgerRead, IndyVdrLedgerReadConfig, IndyVdrLedgerWrite, IndyVdrLedgerWriteConfig,
+};
 use aries_vcx_core::ledger::request_signer::base_wallet::BaseWalletRequestSigner;
 use aries_vcx_core::ledger::request_submitter::vdr_ledger::{IndyVdrLedgerPool, IndyVdrSubmitter, LedgerPoolConfig};
 use aries_vcx_core::ledger::response_cacher::in_memory::{InMemoryResponseCacher, InMemoryResponseCacherConfig};
@@ -38,20 +40,24 @@ impl ModularLibsProfile {
             .capacity(1000)?
             .build();
         let response_cacher = Arc::new(InMemoryResponseCacher::new(cacher_config));
-        let config = IndyVdrLedgerConfig {
-            request_signer,
-            request_submitter,
+        let config_read = IndyVdrLedgerReadConfig {
+            request_submitter: request_submitter.clone(),
             response_parser,
             response_cacher,
         };
-        let ledger = Arc::new(IndyVdrLedger::new(config));
+        let config_write = IndyVdrLedgerWriteConfig {
+            request_signer,
+            request_submitter,
+        };
+        let ledger_read = Arc::new(IndyVdrLedgerRead::new(config_read));
+        let ledger_write = Arc::new(IndyVdrLedgerWrite::new(config_write));
         Ok(ModularLibsProfile {
             wallet,
             anoncreds,
-            anoncreds_ledger_read: ledger.clone(),
-            anoncreds_ledger_write: ledger.clone(),
-            indy_ledger_read: ledger.clone(),
-            indy_ledger_write: ledger,
+            anoncreds_ledger_read: ledger_read.clone(),
+            anoncreds_ledger_write: ledger_write.clone(),
+            indy_ledger_read: ledger_read.clone(),
+            indy_ledger_write: ledger_write,
         })
     }
 }

--- a/aries_vcx/src/core/profile/vdr_proxy_profile.rs
+++ b/aries_vcx/src/core/profile/vdr_proxy_profile.rs
@@ -4,7 +4,7 @@ use aries_vcx_core::{
     anoncreds::{base_anoncreds::BaseAnonCreds, indy_anoncreds::IndySdkAnonCreds},
     ledger::{
         base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
-        indy_vdr_ledger::{IndyVdrLedger, IndyVdrLedgerConfig},
+        indy_vdr_ledger::{IndyVdrLedgerRead, IndyVdrLedgerReadConfig, IndyVdrLedgerWrite, IndyVdrLedgerWriteConfig},
         request_signer::base_wallet::BaseWalletRequestSigner,
         request_submitter::vdr_proxy::VdrProxySubmitter,
         response_cacher::in_memory::{InMemoryResponseCacher, InMemoryResponseCacherConfig},
@@ -39,20 +39,24 @@ impl VdrProxyProfile {
             .capacity(1000)?
             .build();
         let response_cacher = Arc::new(InMemoryResponseCacher::new(cacher_config));
-        let config = IndyVdrLedgerConfig {
-            request_signer,
-            request_submitter,
+        let config_read = IndyVdrLedgerReadConfig {
+            request_submitter: request_submitter.clone(),
             response_parser,
             response_cacher,
         };
-        let ledger = Arc::new(IndyVdrLedger::new(config));
+        let config_write = IndyVdrLedgerWriteConfig {
+            request_submitter,
+            request_signer,
+        };
+        let ledger_read = Arc::new(IndyVdrLedgerRead::new(config_read));
+        let ledger_write = Arc::new(IndyVdrLedgerWrite::new(config_write));
         Ok(VdrProxyProfile {
             wallet,
             anoncreds,
-            anoncreds_ledger_read: ledger.clone(),
-            anoncreds_ledger_write: ledger.clone(),
-            indy_ledger_read: ledger.clone(),
-            indy_ledger_write: ledger,
+            anoncreds_ledger_read: ledger_read.clone(),
+            anoncreds_ledger_write: ledger_write.clone(),
+            indy_ledger_read: ledger_read,
+            indy_ledger_write: ledger_write,
         })
     }
 }

--- a/aries_vcx/src/core/profile/vdrtools_profile.rs
+++ b/aries_vcx/src/core/profile/vdrtools_profile.rs
@@ -4,7 +4,7 @@ use aries_vcx_core::{
     anoncreds::{base_anoncreds::BaseAnonCreds, indy_anoncreds::IndySdkAnonCreds},
     ledger::{
         base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
-        indy_ledger::IndySdkLedger,
+        indy_ledger::{IndySdkLedgerRead, IndySdkLedgerWrite},
     },
     wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
     PoolHandle, WalletHandle,
@@ -26,14 +26,15 @@ impl VdrtoolsProfile {
     pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
         let wallet = Arc::new(IndySdkWallet::new(indy_wallet_handle));
         let anoncreds = Arc::new(IndySdkAnonCreds::new(indy_wallet_handle));
-        let ledger = Arc::new(IndySdkLedger::new(indy_wallet_handle, indy_pool_handle));
+        let ledger_read = Arc::new(IndySdkLedgerRead::new(indy_wallet_handle, indy_pool_handle));
+        let ledger_write = Arc::new(IndySdkLedgerWrite::new(indy_wallet_handle, indy_pool_handle));
         VdrtoolsProfile {
             wallet,
             anoncreds,
-            anoncreds_ledger_read: ledger.clone(),
-            anoncreds_ledger_write: ledger.clone(),
-            indy_ledger_read: ledger.clone(),
-            indy_ledger_write: ledger,
+            anoncreds_ledger_read: ledger_read.clone(),
+            anoncreds_ledger_write: ledger_write.clone(),
+            indy_ledger_read: ledger_read,
+            indy_ledger_write: ledger_write,
         }
     }
 }

--- a/aries_vcx/src/utils/mockdata/profile/mock_ledger.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_ledger.rs
@@ -11,10 +11,6 @@ pub(crate) struct MockLedger;
 #[allow(unused)]
 #[async_trait]
 impl IndyLedgerRead for MockLedger {
-    async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String> {
-        Ok(utils::constants::REQUEST_WITH_ENDORSER.to_string())
-    }
-
     async fn get_txn_author_agreement(&self) -> VcxCoreResult<String> {
         Ok(utils::constants::DEFAULT_AUTHOR_AGREEMENT.to_string())
     }
@@ -39,6 +35,10 @@ impl IndyLedgerRead for MockLedger {
 #[allow(unused)]
 #[async_trait]
 impl IndyLedgerWrite for MockLedger {
+    async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String> {
+        Ok(utils::constants::REQUEST_WITH_ENDORSER.to_string())
+    }
+
     async fn endorse_transaction(&self, endorser_did: &str, request_json: &str) -> VcxCoreResult<()> {
         Ok(())
     }

--- a/aries_vcx_core/src/ledger/base_ledger.rs
+++ b/aries_vcx_core/src/ledger/base_ledger.rs
@@ -9,7 +9,6 @@ pub trait IndyLedgerRead: Debug + Send + Sync {
     async fn get_attr(&self, target_did: &str, attr_name: &str) -> VcxCoreResult<String>;
     async fn get_nym(&self, did: &str) -> VcxCoreResult<String>;
     async fn get_txn_author_agreement(&self) -> VcxCoreResult<String>;
-    async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String>;
     async fn get_ledger_txn(&self, seq_no: i32, submitter_did: Option<&str>) -> VcxCoreResult<String>;
 }
 
@@ -23,6 +22,7 @@ pub trait IndyLedgerWrite: Debug + Send + Sync {
         data: Option<&str>,
         role: Option<&str>,
     ) -> VcxCoreResult<String>;
+    async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String>;
     async fn endorse_transaction(&self, endorser_did: &str, request_json: &str) -> VcxCoreResult<()>;
     async fn add_attr(&self, target_did: &str, attrib_json: &str) -> VcxCoreResult<String>;
 }

--- a/aries_vcx_core/src/ledger/indy_ledger.rs
+++ b/aries_vcx_core/src/ledger/indy_ledger.rs
@@ -6,14 +6,29 @@ use crate::{indy, PoolHandle, WalletHandle};
 use super::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite};
 
 #[derive(Debug)]
-pub struct IndySdkLedger {
+pub struct IndySdkLedgerRead {
     indy_wallet_handle: WalletHandle,
     indy_pool_handle: PoolHandle,
 }
 
-impl IndySdkLedger {
+impl IndySdkLedgerRead {
     pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
-        IndySdkLedger {
+        IndySdkLedgerRead {
+            indy_wallet_handle,
+            indy_pool_handle,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct IndySdkLedgerWrite {
+    indy_wallet_handle: WalletHandle,
+    indy_pool_handle: PoolHandle,
+}
+
+impl IndySdkLedgerWrite {
+    pub fn new(indy_wallet_handle: WalletHandle, indy_pool_handle: PoolHandle) -> Self {
+        IndySdkLedgerWrite {
             indy_wallet_handle,
             indy_pool_handle,
         }
@@ -21,7 +36,7 @@ impl IndySdkLedger {
 }
 
 #[async_trait]
-impl IndyLedgerRead for IndySdkLedger {
+impl IndyLedgerRead for IndySdkLedgerRead {
     async fn get_attr(&self, target_did: &str, attr_name: &str) -> VcxCoreResult<String> {
         indy::ledger::transactions::get_attr(self.indy_pool_handle, target_did, attr_name).await
     }
@@ -32,10 +47,6 @@ impl IndyLedgerRead for IndySdkLedger {
 
     async fn get_txn_author_agreement(&self) -> VcxCoreResult<String> {
         indy::ledger::transactions::libindy_get_txn_author_agreement(self.indy_pool_handle).await
-    }
-
-    async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String> {
-        indy::ledger::transactions::set_endorser(self.indy_wallet_handle, submitter_did, request, endorser).await
     }
 
     async fn get_ledger_txn(&self, seq_no: i32, submitter_did: Option<&str>) -> VcxCoreResult<String> {
@@ -50,7 +61,7 @@ impl IndyLedgerRead for IndySdkLedger {
 }
 
 #[async_trait]
-impl IndyLedgerWrite for IndySdkLedger {
+impl IndyLedgerWrite for IndySdkLedgerWrite {
     async fn publish_nym(
         &self,
         submitter_did: &str,
@@ -73,6 +84,10 @@ impl IndyLedgerWrite for IndySdkLedger {
         .await
     }
 
+    async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String> {
+        indy::ledger::transactions::set_endorser(self.indy_wallet_handle, submitter_did, request, endorser).await
+    }
+
     async fn endorse_transaction(&self, endorser_did: &str, request_json: &str) -> VcxCoreResult<()> {
         indy::ledger::transactions::endorse_transaction(
             self.indy_wallet_handle,
@@ -90,7 +105,7 @@ impl IndyLedgerWrite for IndySdkLedger {
 }
 
 #[async_trait]
-impl AnoncredsLedgerRead for IndySdkLedger {
+impl AnoncredsLedgerRead for IndySdkLedgerRead {
     async fn get_schema(&self, schema_id: &str, submitter_did: Option<&str>) -> VcxCoreResult<String> {
         if let Some(submitter_did) = submitter_did {
             // with cache if possible
@@ -136,7 +151,7 @@ impl AnoncredsLedgerRead for IndySdkLedger {
 }
 
 #[async_trait]
-impl AnoncredsLedgerWrite for IndySdkLedger {
+impl AnoncredsLedgerWrite for IndySdkLedgerWrite {
     async fn publish_schema(
         &self,
         schema_json: &str,

--- a/aries_vcx_core/src/ledger/indy_vdr_ledger.rs
+++ b/aries_vcx_core/src/ledger/indy_vdr_ledger.rs
@@ -228,7 +228,7 @@ where
             &identifier,
             &dest,
             None,
-            Some(&serde_json::to_value(attrib_json)?),
+            Some(&serde_json::from_str::<Value>(attrib_json)?),
             None,
         )?;
         let request = _append_txn_author_agreement_to_request(request).await?;

--- a/did_resolver_sov/src/reader/indy_reader.rs
+++ b/did_resolver_sov/src/reader/indy_reader.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use aries_vcx_core::{ledger::indy_ledger::IndySdkLedger, PoolHandle, INVALID_WALLET_HANDLE};
+use aries_vcx_core::{ledger::indy_ledger::IndySdkLedgerRead, PoolHandle, INVALID_WALLET_HANDLE};
 
 use super::ConcreteAttrReader;
 
 impl From<PoolHandle> for ConcreteAttrReader {
     fn from(pool_handle: PoolHandle) -> Self {
         Self {
-            ledger: Arc::new(IndySdkLedger::new(INVALID_WALLET_HANDLE, pool_handle)),
+            ledger: Arc::new(IndySdkLedgerRead::new(INVALID_WALLET_HANDLE, pool_handle)),
         }
     }
 }

--- a/did_resolver_sov/src/reader/vdr_reader.rs
+++ b/did_resolver_sov/src/reader/vdr_reader.rs
@@ -4,12 +4,10 @@ use crate::error::DidSovError;
 use aries_vcx_core::{
     ledger::{
         indy_vdr_ledger::{IndyVdrLedgerRead, IndyVdrLedgerReadConfig},
-        request_signer::base_wallet::BaseWalletRequestSigner,
         request_submitter::vdr_ledger::{IndyVdrLedgerPool, IndyVdrSubmitter, LedgerPoolConfig},
         response_cacher::in_memory::{InMemoryResponseCacher, InMemoryResponseCacherConfig},
     },
-    wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
-    ResponseParser, INVALID_WALLET_HANDLE,
+    ResponseParser,
 };
 
 use super::ConcreteAttrReader;
@@ -18,10 +16,8 @@ impl TryFrom<LedgerPoolConfig> for ConcreteAttrReader {
     type Error = DidSovError;
 
     fn try_from(pool_config: LedgerPoolConfig) -> Result<Self, Self::Error> {
-        let wallet = Arc::new(IndySdkWallet::new(INVALID_WALLET_HANDLE)) as Arc<dyn BaseWallet>;
         let ledger_pool = Arc::new(IndyVdrLedgerPool::new(pool_config)?);
         let request_submitter = Arc::new(IndyVdrSubmitter::new(ledger_pool));
-        let request_signer = Arc::new(BaseWalletRequestSigner::new(wallet.clone()));
         let response_parser = Arc::new(ResponseParser::new());
         let cacher_config = InMemoryResponseCacherConfig::builder()
             .ttl(Duration::from_secs(60))
@@ -29,7 +25,6 @@ impl TryFrom<LedgerPoolConfig> for ConcreteAttrReader {
             .build();
         let response_cacher = Arc::new(InMemoryResponseCacher::new(cacher_config));
         let config = IndyVdrLedgerReadConfig {
-            request_signer,
             request_submitter,
             response_parser,
             response_cacher,

--- a/did_resolver_sov/src/reader/vdr_reader.rs
+++ b/did_resolver_sov/src/reader/vdr_reader.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 use crate::error::DidSovError;
 use aries_vcx_core::{
     ledger::{
-        indy_vdr_ledger::{IndyVdrLedger, IndyVdrLedgerConfig},
+        indy_vdr_ledger::{IndyVdrLedgerRead, IndyVdrLedgerReadConfig},
         request_signer::base_wallet::BaseWalletRequestSigner,
         request_submitter::vdr_ledger::{IndyVdrLedgerPool, IndyVdrSubmitter, LedgerPoolConfig},
         response_cacher::in_memory::{InMemoryResponseCacher, InMemoryResponseCacherConfig},
@@ -28,13 +28,13 @@ impl TryFrom<LedgerPoolConfig> for ConcreteAttrReader {
             .capacity(1000)?
             .build();
         let response_cacher = Arc::new(InMemoryResponseCacher::new(cacher_config));
-        let config = IndyVdrLedgerConfig {
+        let config = IndyVdrLedgerReadConfig {
             request_signer,
             request_submitter,
             response_parser,
             response_cacher,
         };
-        let ledger = Arc::new(IndyVdrLedger::new(config));
+        let ledger = Arc::new(IndyVdrLedgerRead::new(config));
         Ok(Self { ledger })
     }
 }


### PR DESCRIPTION
Splits 
* `IndyVdrLedger` -> `IndyVdrLedgerRead` & `IndyVdrLedgerWrite`, and
* `IndySdkLedger` -> `IndySdkLedgerRead` & `IndySdkLedgerWrite`

This allows each implementation to use only what it needs (e.g. `IndyVdrLedgerRead` variant doesn't need `RequestSigner`, `IndyVdrLedgerWrite` doesn't need `ResponseCacher` and `ResponseParser`). Moreover, since both are initialized separately, a `IndyLedgerRead` implementation can be used to initialize a `IndyLedgerWrite` implementation.