### PR TITLE
Make DidDocument's service generic over method-specific fields

### DIFF
--- a/did_doc/src/lib.rs
+++ b/did_doc/src/lib.rs
@@ -3,3 +3,5 @@ extern crate serde_json;
 
 pub mod error;
 pub mod schema;
+
+pub use did_parser;

--- a/did_doc/src/schema/service.rs
+++ b/did_doc/src/schema/service.rs
@@ -1,7 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use crate::error::DidDocumentBuilderError;
 
@@ -14,22 +13,26 @@ type ServiceTypeAlias = OneOrList<String>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct Service {
+pub struct Service<E>
+where
+    E: Default,
+{
     id: Uri,
     #[serde(rename = "type")]
     service_type: ServiceTypeAlias,
     service_endpoint: Url,
     #[serde(flatten)]
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    #[serde(default)]
-    extra: HashMap<String, Value>,
+    extra: E,
 }
 
-impl Service {
+impl<E> Service<E>
+where
+    E: Default,
+{
     pub fn builder(
         id: Uri,
         service_endpoint: Url,
-    ) -> Result<ServiceBuilder, DidDocumentBuilderError> {
+    ) -> Result<ServiceBuilder<E>, DidDocumentBuilderError> {
         ServiceBuilder::new(id, service_endpoint)
     }
 
@@ -41,30 +44,33 @@ impl Service {
         &self.service_type
     }
 
-    pub fn service_endpoint(&self) -> &str {
-        self.service_endpoint.as_ref()
+    pub fn service_endpoint(&self) -> &Url {
+        &self.service_endpoint
     }
 
-    pub fn extra_field(&self, key: &str) -> Option<&Value> {
-        self.extra.get(key)
+    pub fn extra(&self) -> &E {
+        &self.extra
     }
 }
 
 #[derive(Debug)]
-pub struct ServiceBuilder {
+pub struct ServiceBuilder<E> {
     id: Uri,
     service_type: HashSet<String>,
     service_endpoint: Url,
-    extra: HashMap<String, Value>,
+    extra: E,
 }
 
-impl ServiceBuilder {
+impl<E> ServiceBuilder<E>
+where
+    E: Default,
+{
     pub fn new(id: Uri, service_endpoint: Url) -> Result<Self, DidDocumentBuilderError> {
         Ok(Self {
             id,
             service_endpoint,
             service_type: HashSet::new(),
-            extra: HashMap::new(),
+            extra: E::default(),
         })
     }
 
@@ -79,12 +85,12 @@ impl ServiceBuilder {
         Ok(self)
     }
 
-    pub fn add_extra_field(mut self, key: String, value: Value) -> Self {
-        self.extra.insert(key, value);
+    pub fn add_extra(mut self, extra: E) -> Self {
+        self.extra = extra;
         self
     }
 
-    pub fn build(self) -> Result<Service, DidDocumentBuilderError> {
+    pub fn build(self) -> Result<Service<E>, DidDocumentBuilderError> {
         if self.service_type.is_empty() {
             Err(DidDocumentBuilderError::MissingField("type"))
         } else {
@@ -106,21 +112,30 @@ mod tests {
         Uri::new("http://example.com").unwrap()
     }
 
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ExtraSov {
+        pub priority: u32,
+        pub recipient_keys: Vec<String>,
+        pub routing_keys: Vec<String>,
+    }
+
     #[test]
     fn test_service_builder_basic() {
         let id = create_valid_uri();
         let service_endpoint = "http://example.com/endpoint";
         let service_type = "DIDCommMessaging".to_string();
 
-        let service = ServiceBuilder::new(id.clone(), service_endpoint.try_into().unwrap())
-            .unwrap()
-            .add_service_type(service_type.clone())
-            .unwrap()
-            .build()
-            .unwrap();
+        let service =
+            ServiceBuilder::<ExtraSov>::new(id.clone(), service_endpoint.try_into().unwrap())
+                .unwrap()
+                .add_service_type(service_type.clone())
+                .unwrap()
+                .build()
+                .unwrap();
 
         assert_eq!(service.id(), &id);
-        assert_eq!(service.service_endpoint(), service_endpoint);
+        assert_eq!(service.service_endpoint().as_ref(), service_endpoint);
         assert_eq!(service.service_type(), &OneOrList::List(vec![service_type]));
     }
 
@@ -129,18 +144,24 @@ mod tests {
         let id = create_valid_uri();
         let service_endpoint = "http://example.com/endpoint";
         let service_type = "DIDCommMessaging".to_string();
-        let extra_key = "foo".to_string();
-        let extra_value = Value::String("bar".to_string());
+        let recipient_keys = vec!["foo".to_string()];
+        let routing_keys = vec!["bar".to_string()];
+        let extra = ExtraSov {
+            priority: 0,
+            recipient_keys: recipient_keys.clone(),
+            routing_keys: routing_keys.clone(),
+        };
 
-        let service = ServiceBuilder::new(id, service_endpoint.try_into().unwrap())
+        let service = ServiceBuilder::<ExtraSov>::new(id, service_endpoint.try_into().unwrap())
             .unwrap()
             .add_service_type(service_type)
             .unwrap()
-            .add_extra_field(extra_key.clone(), extra_value.clone())
+            .add_extra(extra)
             .build()
             .unwrap();
 
-        assert_eq!(service.extra_field(&extra_key).unwrap(), &extra_value);
+        assert_eq!(service.extra().recipient_keys, recipient_keys);
+        assert_eq!(service.extra().routing_keys, routing_keys);
     }
 
     #[test]
@@ -149,7 +170,7 @@ mod tests {
         let service_endpoint = "http://example.com/endpoint";
         let service_type = "DIDCommMessaging".to_string();
 
-        let service = ServiceBuilder::new(id, service_endpoint.try_into().unwrap())
+        let service = ServiceBuilder::<ExtraSov>::new(id, service_endpoint.try_into().unwrap())
             .unwrap()
             .add_service_type(service_type.clone())
             .unwrap()
@@ -166,7 +187,7 @@ mod tests {
         let id = create_valid_uri();
         let service_endpoint = "http://example.com/endpoint";
 
-        let res = ServiceBuilder::new(id, service_endpoint.try_into().unwrap())
+        let res = ServiceBuilder::<ExtraSov>::new(id, service_endpoint.try_into().unwrap())
             .unwrap()
             .add_service_type("".to_string());
         assert!(res.is_err());
@@ -188,7 +209,7 @@ mod tests {
           "serviceEndpoint": "https://example.com/endpoint"
         }"##;
 
-        let service: Service = serde_json::from_str(service_serialized).unwrap();
+        let service: Service<ExtraSov> = serde_json::from_str(service_serialized).unwrap();
         assert_eq!(
             service.id(),
             &Uri::new("did:sov:HR6vs6GEZ8rHaVgjg2WodM#did-communication").unwrap()
@@ -197,16 +218,14 @@ mod tests {
             service.service_type(),
             &OneOrList::One("did-communication".to_string())
         );
-        assert_eq!(service.service_endpoint(), "https://example.com/endpoint");
         assert_eq!(
-            service.extra_field("priority").unwrap(),
-            &Value::Number(0.into())
+            service.service_endpoint().as_ref(),
+            "https://example.com/endpoint"
         );
+        assert_eq!(service.extra().priority, 0);
         assert_eq!(
-            service.extra_field("recipientKeys").unwrap(),
-            &Value::Array(vec![Value::String(
-                "did:sov:HR6vs6GEZ8rHaVgjg2WodM#key-agreement-1".to_string()
-            )])
+            service.extra().recipient_keys,
+            vec!["did:sov:HR6vs6GEZ8rHaVgjg2WodM#key-agreement-1".to_string()]
         );
     }
 }

--- a/did_doc/src/schema/types/url.rs
+++ b/did_doc/src/schema/types/url.rs
@@ -1,3 +1,5 @@
+use std::{fmt::Display, str::FromStr};
+
 use serde::{Deserialize, Serialize};
 use url::Url as UrlDep;
 
@@ -20,8 +22,34 @@ impl TryFrom<&str> for Url {
     }
 }
 
+impl FromStr for Url {
+    type Err = DidDocumentBuilderError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(UrlDep::parse(s)?))
+    }
+}
+
+impl From<UrlDep> for Url {
+    fn from(url: UrlDep) -> Self {
+        Self(url)
+    }
+}
+
+impl From<Url> for UrlDep {
+    fn from(url: Url) -> Self {
+        url.0
+    }
+}
+
 impl AsRef<str> for Url {
     fn as_ref(&self) -> &str {
         self.0.as_str()
+    }
+}
+
+impl Display for Url {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.as_str().fmt(f)
     }
 }

--- a/did_doc/src/schema/utils/mod.rs
+++ b/did_doc/src/schema/utils/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Display};
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -5,4 +7,13 @@ use serde::{Deserialize, Serialize};
 pub enum OneOrList<T> {
     One(T),
     List(Vec<T>),
+}
+
+impl<T: Display + Debug> Display for OneOrList<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OneOrList::One(t) => write!(f, "{}", t),
+            OneOrList::List(t) => write!(f, "{:?}", t),
+        }
+    }
 }

--- a/did_doc/tests/serde.rs
+++ b/did_doc/tests/serde.rs
@@ -73,7 +73,7 @@ const VALID_DID_DOC_JSON: &str = r##"
 
 #[test]
 fn test_deserialization() {
-    let did_doc: DidDocument = serde_json::from_str(VALID_DID_DOC_JSON).unwrap();
+    let did_doc: DidDocument<()> = serde_json::from_str(VALID_DID_DOC_JSON).unwrap();
 
     assert_eq!(
         did_doc.id(),
@@ -181,11 +181,11 @@ fn test_deserialization() {
 
 #[test]
 fn test_serialization() {
-    let did_doc: DidDocument = serde_json::from_str(VALID_DID_DOC_JSON).unwrap();
+    let did_doc: DidDocument<()> = serde_json::from_str(VALID_DID_DOC_JSON).unwrap();
 
     let serialized_json = serde_json::to_string(&did_doc).unwrap();
 
-    let original_json_value: DidDocument = serde_json::from_str(VALID_DID_DOC_JSON).unwrap();
-    let serialized_json_value: DidDocument = serde_json::from_str(&serialized_json).unwrap();
+    let original_json_value: DidDocument<()> = serde_json::from_str(VALID_DID_DOC_JSON).unwrap();
+    let serialized_json_value: DidDocument<()> = serde_json::from_str(&serialized_json).unwrap();
     assert_eq!(serialized_json_value, original_json_value);
 }

--- a/did_parser/src/did.rs
+++ b/did_parser/src/did.rs
@@ -1,11 +1,12 @@
 use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{error::ParseError, utils::parse::parse_did_method_id, DidRange};
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Did {
     did: String,
     method: DidRange,
@@ -48,9 +49,27 @@ impl TryFrom<String> for Did {
     }
 }
 
+impl FromStr for Did {
+    type Err = ParseError;
+
+    fn from_str(did: &str) -> Result<Self, Self::Err> {
+        Self::parse(did.to_string())
+    }
+}
+
 impl Display for Did {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.did)
+    }
+}
+
+impl Default for Did {
+    fn default() -> Self {
+        Self {
+            did: "did:example:123456789abcdefghi".to_string(),
+            method: 4..11,
+            id: 12..30,
+        }
     }
 }
 

--- a/did_parser/src/did_url.rs
+++ b/did_parser/src/did_url.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Display};
+use std::{collections::HashMap, fmt::Display, str::FromStr};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -153,6 +153,14 @@ impl TryFrom<String> for DidUrl {
 
     fn try_from(did_url: String) -> Result<Self, Self::Error> {
         Self::parse(did_url)
+    }
+}
+
+impl FromStr for DidUrl {
+    type Err = ParseError;
+
+    fn from_str(did: &str) -> Result<Self, Self::Err> {
+        Self::parse(did.to_string())
     }
 }
 

--- a/did_resolver/src/traits/resolvable/mod.rs
+++ b/did_resolver/src/traits/resolvable/mod.rs
@@ -11,9 +11,11 @@ use self::{resolution_options::DidResolutionOptions, resolution_output::DidResol
 
 #[async_trait]
 pub trait DidResolvable {
+    type ExtraFields: Default;
+
     async fn resolve(
         &self,
         did: &Did,
         options: &DidResolutionOptions,
-    ) -> Result<DidResolutionOutput, GenericError>;
+    ) -> Result<DidResolutionOutput<Self::ExtraFields>, GenericError>;
 }

--- a/did_resolver/src/traits/resolvable/resolution_output.rs
+++ b/did_resolver/src/traits/resolvable/resolution_output.rs
@@ -9,14 +9,14 @@ use crate::shared_types::did_document_metadata::DidDocumentMetadata;
 // non-empty field in DidResolutionOutput in the error case.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct DidResolutionOutput {
-    did_document: DidDocument,
+pub struct DidResolutionOutput<E: Default> {
+    did_document: DidDocument<E>,
     did_resolution_metadata: DidResolutionMetadata,
     did_document_metadata: DidDocumentMetadata,
 }
 
-impl DidResolutionOutput {
-    pub fn builder(did_document: DidDocument) -> DidResolutionOutputBuilder {
+impl<E: Default> DidResolutionOutput<E> {
+    pub fn builder(did_document: DidDocument<E>) -> DidResolutionOutputBuilder<E> {
         DidResolutionOutputBuilder {
             did_document,
             did_resolution_metadata: None,
@@ -24,7 +24,7 @@ impl DidResolutionOutput {
         }
     }
 
-    pub fn did_document(&self) -> &DidDocument {
+    pub fn did_document(&self) -> &DidDocument<E> {
         &self.did_document
     }
 
@@ -37,13 +37,13 @@ impl DidResolutionOutput {
     }
 }
 
-pub struct DidResolutionOutputBuilder {
-    did_document: DidDocument,
+pub struct DidResolutionOutputBuilder<E: Default> {
+    did_document: DidDocument<E>,
     did_resolution_metadata: Option<DidResolutionMetadata>,
     did_document_metadata: Option<DidDocumentMetadata>,
 }
 
-impl DidResolutionOutputBuilder {
+impl<E: Default> DidResolutionOutputBuilder<E> {
     pub fn did_resolution_metadata(
         mut self,
         did_resolution_metadata: DidResolutionMetadata,
@@ -57,7 +57,7 @@ impl DidResolutionOutputBuilder {
         self
     }
 
-    pub fn build(self) -> DidResolutionOutput {
+    pub fn build(self) -> DidResolutionOutput<E> {
         DidResolutionOutput {
             did_document: self.did_document,
             did_resolution_metadata: self.did_resolution_metadata.unwrap_or_default(),

--- a/did_resolver_sov/src/resolution/resolver.rs
+++ b/did_resolver_sov/src/resolution/resolver.rs
@@ -31,11 +31,14 @@ impl DidSovResolver {
 
 #[async_trait]
 impl DidResolvable for DidSovResolver {
+    // TODO: Change to ExtraFields from Sovrin-specific DDO wrapper
+    type ExtraFields = ();
+
     async fn resolve(
         &self,
         parsed_did: &Did,
         options: &DidResolutionOptions,
-    ) -> Result<DidResolutionOutput, GenericError> {
+    ) -> Result<DidResolutionOutput<Self::ExtraFields>, GenericError> {
         if let Some(accept) = options.accept() {
             if accept != &MediaType::DidJson {
                 return Err(Box::new(DidSovError::RepresentationNotSupported(

--- a/did_resolver_sov/src/resolution/utils.rs
+++ b/did_resolver_sov/src/resolution/utils.rs
@@ -59,11 +59,11 @@ pub(super) fn is_valid_sovrin_did_id(id: &str) -> bool {
     id.chars().all(|c| base58_chars.contains(c))
 }
 
-pub(super) async fn ledger_response_to_ddo(
+pub(super) async fn ledger_response_to_ddo<E: Default>(
     did: &str,
     resp: &str,
     verkey: String,
-) -> Result<DidResolutionOutput, DidSovError> {
+) -> Result<DidResolutionOutput<E>, DidSovError> {
     let (service_id, ddo_id) = prepare_ids(did)?;
 
     let service_data = get_data_from_response(resp)?;
@@ -176,12 +176,14 @@ mod tests {
             }
         }"#;
         let verkey = "9wvq2i4xUa5umXoThe83CDgx1e5bsjZKJL4DEWvTP9qe".to_string();
-        let resolution_output = ledger_response_to_ddo(did, resp, verkey).await.unwrap();
+        let resolution_output = ledger_response_to_ddo::<()>(did, resp, verkey)
+            .await
+            .unwrap();
         let ddo = resolution_output.did_document();
         assert_eq!(ddo.id().to_string(), "did:example:1234567890");
         assert_eq!(ddo.service()[0].id().to_string(), "did:example:1234567890");
         assert_eq!(
-            ddo.service()[0].service_endpoint().to_string(),
+            ddo.service()[0].service_endpoint().as_ref(),
             "https://example.com/"
         );
         assert_eq!(

--- a/did_resolver_web/src/resolution/resolver.rs
+++ b/did_resolver_web/src/resolution/resolver.rs
@@ -65,7 +65,13 @@ impl<C> DidResolvable for DidWebResolver<C>
 where
     C: Connect + Send + Sync + Clone + 'static,
 {
-    async fn resolve(&self, did: &Did, options: &DidResolutionOptions) -> Result<DidResolutionOutput, GenericError> {
+    type ExtraFields = ();
+
+    async fn resolve(
+        &self,
+        did: &Did,
+        options: &DidResolutionOptions,
+    ) -> Result<DidResolutionOutput<()>, GenericError> {
         if did.method() != "web" {
             return Err(Box::new(DidWebError::MethodNotSupported(did.method().to_string())));
         }

--- a/did_resolver_web/tests/resolution.rs
+++ b/did_resolver_web/tests/resolution.rs
@@ -88,7 +88,7 @@ async fn create_mock_server(port: u16) -> String {
 
 #[tokio::test]
 async fn test_did_web_resolver() {
-    fn verify_did_document(did_document: &DidDocument) {
+    fn verify_did_document(did_document: &DidDocument<()>) {
         assert_eq!(did_document.id().to_string(), "did:web:example.com".to_string());
         assert_eq!(did_document.verification_method().len(), 3);
         assert_eq!(did_document.authentication().len(), 2);


### PR DESCRIPTION
As it was decided that `DidDocument` integration will be postponed, this PR cherry-picks those changes made in #864 which are isolated to the new crates and thus can be merged independently from the `DidDocument` integration.