### PR TITLE
Refactor messages crate tests

### DIFF
--- a/messages/src/msg_fields/protocols/cred_issuance/issue_credential.rs
+++ b/messages/src/msg_fields/protocols/cred_issuance/issue_credential.rs
@@ -69,8 +69,14 @@ mod tests {
         let decorators = IssueCredentialDecorators::new(make_extended_thread());
 
         let expected = json!({
-            "credentials~attach": content.credentials_attach,
-            "~thread": decorators.thread
+            "credentials~attach": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "~thread": {
+                "field_1": "value1",
+                "field_2": "value2",
+            }
         });
 
         test_utils::test_msg(
@@ -91,11 +97,26 @@ mod tests {
         decorators.please_ack = Some(make_minimal_please_ack());
 
         let expected = json!({
-            "credentials~attach": content.credentials_attach,
-            "comment": content.comment,
-            "~thread": decorators.thread,
-            "~timing": decorators.timing,
-            "~please_ack": decorators.please_ack
+            "credentials~attach": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "comment": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "~thread": {
+                "field1": "value1",
+                "field1": "value1",
+            },
+            "~timing": {
+                "field1": "value1",
+                "field2": "value2"
+            },
+            "~please_ack": {
+                "field1": "value1",
+                "field2": "value2",
+            }
         });
 
         test_utils::test_msg(

--- a/messages/src/msg_fields/protocols/cred_issuance/offer_credential.rs
+++ b/messages/src/msg_fields/protocols/cred_issuance/offer_credential.rs
@@ -87,11 +87,25 @@ mod tests {
         decorators.timing = Some(make_extended_timing());
 
         let expected = json!({
-            "offers~attach": content.offers_attach,
-            "credential_preview": content.credential_preview,
-            "comment": content.comment,
-            "~thread": decorators.thread,
-            "~timing": decorators.timing
+            "offers~attach": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "credential_preview": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "comment": {
+                "field1": "value1",
+            },
+            "~thread": {
+                "field_1": "value1",
+                "field_1": "value1"
+            },
+            "~timing": {
+                "field1": "value1",
+                "field2": "value2",
+            }
         });
 
         test_utils::test_msg(

--- a/messages/src/msg_fields/protocols/cred_issuance/propose_credential.rs
+++ b/messages/src/msg_fields/protocols/cred_issuance/propose_credential.rs
@@ -62,9 +62,12 @@ mod tests {
         let decorators = ProposeCredentialDecorators::default();
 
         let expected = json!({
-            "credential_proposal": content.credential_proposal,
-            "schema_id": content.schema_id,
-            "cred_def_id": content.cred_def_id,
+            "credential_proposal": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "schema_id": "result",
+            "cred_def_id": "result"
         });
 
         test_utils::test_msg(
@@ -89,12 +92,24 @@ mod tests {
         decorators.timing = Some(make_extended_timing());
 
         let expected = json!({
-            "credential_proposal": content.credential_proposal,
-            "schema_id": content.schema_id,
-            "cred_def_id": content.cred_def_id,
-            "comment": content.comment,
-            "~thread": decorators.thread,
-            "~timing": decorators.timing
+            "credential_proposal": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "schema_id": "result",
+            "cred_def_id": "result",
+            "comment": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "~thread": {
+                "field_1": "value1",
+                "field_2": "value2",
+            },
+            "~timing": {
+                "field1": "value1",
+                "field2": "value2",
+            }
         });
 
         test_utils::test_msg(

--- a/messages/src/msg_fields/protocols/cred_issuance/request_credential.rs
+++ b/messages/src/msg_fields/protocols/cred_issuance/request_credential.rs
@@ -54,7 +54,10 @@ mod tests {
         let decorators = RequestCredentialDecorators::default();
 
         let expected = json!({
-            "requests~attach": content.requests_attach,
+            "requests~attach": {
+                "field1": "value1",
+                "field2": "value2",
+            },
         });
 
         test_utils::test_msg(
@@ -74,9 +77,18 @@ mod tests {
         decorators.thread = Some(make_extended_thread());
 
         let expected = json!({
-            "requests~attach": content.requests_attach,
-            "comment": content.comment,
-            "~thread": decorators.thread
+            "requests~attach": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "comment": {
+                "field1": "value1",
+                "field2": "value2",
+            },
+            "~thread": {
+                "field_1": "value1",
+                "field_2": "value2",
+            }
         });
 
         test_utils::test_msg(


### PR DESCRIPTION
fix: #822 

Just want to know that the direction in which I'm going is upright! For using the `Static JSON` in message crate tests