### PR TITLE
Extend Profile trait with update_taa_configuration method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "android_logger",
  "aries_vcx_core",
  "async-channel",
+ "async-lock",
  "async-trait",
  "base64 0.10.1",
  "bs58 0.4.0",

--- a/aries_vcx/Cargo.toml
+++ b/aries_vcx/Cargo.toml
@@ -50,6 +50,7 @@ derive_builder = "0.10.2"
 tokio = { version = "1.20.4" }
 thiserror = "1.0.37"
 url = { version = "2.3", features = ["serde"] }
+async-lock = "2.7.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.5"

--- a/aries_vcx/src/core/profile/mixed_breed_profile.rs
+++ b/aries_vcx/src/core/profile/mixed_breed_profile.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use aries_vcx_core::ledger::base_ledger::TxnAuthrAgrmtOptions;
 use aries_vcx_core::{
     anoncreds::{base_anoncreds::BaseAnonCreds, credx_anoncreds::IndyCredxAnonCreds},
     ledger::{
@@ -9,6 +10,7 @@ use aries_vcx_core::{
     wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
     PoolHandle, WalletHandle,
 };
+use async_trait::async_trait;
 
 use super::profile::Profile;
 
@@ -40,6 +42,7 @@ impl MixedBreedProfile {
     }
 }
 
+#[async_trait]
 impl Profile for MixedBreedProfile {
     fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead> {
         Arc::clone(&self.indy_ledger_read)
@@ -63,5 +66,9 @@ impl Profile for MixedBreedProfile {
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {
         Arc::clone(&self.wallet)
+    }
+
+    async fn update_taa_configuration(self: Arc<Self>, taa_options: TxnAuthrAgrmtOptions) {
+        todo!()
     }
 }

--- a/aries_vcx/src/core/profile/mod.rs
+++ b/aries_vcx/src/core/profile/mod.rs
@@ -13,10 +13,9 @@ const DEFAULT_AML_LABEL: &str = "eula";
 use std::sync::Arc;
 
 #[cfg(any(feature = "modular_libs", feature = "vdr_proxy_ledger"))]
-use aries_vcx_core::ledger::{
-    base_ledger::IndyLedgerRead,
-    indy_vdr_ledger::{GetTxnAuthorAgreementData, TxnAuthrAgrmtOptions},
-};
+use aries_vcx_core::ledger::base_ledger::TxnAuthrAgrmtOptions;
+#[cfg(any(feature = "modular_libs", feature = "vdr_proxy_ledger"))]
+use aries_vcx_core::ledger::{base_ledger::IndyLedgerRead, indy_vdr_ledger::GetTxnAuthorAgreementData};
 
 use crate::errors::error::VcxResult;
 

--- a/aries_vcx/src/core/profile/modular_libs_profile.rs
+++ b/aries_vcx/src/core/profile/modular_libs_profile.rs
@@ -1,18 +1,23 @@
+use async_lock::RwLock;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
 use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
 use aries_vcx_core::anoncreds::credx_anoncreds::IndyCredxAnonCreds;
-use aries_vcx_core::ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite};
+use aries_vcx_core::errors::error::VcxCoreResult;
+use aries_vcx_core::ledger::base_ledger::{
+    AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite, TaaConfigurator, TxnAuthrAgrmtOptions,
+};
 use aries_vcx_core::ledger::indy_vdr_ledger::{
     IndyVdrLedgerRead, IndyVdrLedgerReadConfig, IndyVdrLedgerWrite, IndyVdrLedgerWriteConfig, ProtocolVersion,
-    TxnAuthrAgrmtOptions,
 };
 use aries_vcx_core::ledger::request_signer::base_wallet::BaseWalletRequestSigner;
 use aries_vcx_core::ledger::request_submitter::vdr_ledger::{IndyVdrLedgerPool, IndyVdrSubmitter, LedgerPoolConfig};
 use aries_vcx_core::ledger::response_cacher::in_memory::{InMemoryResponseCacher, InMemoryResponseCacherConfig};
 use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use aries_vcx_core::ResponseParser;
+use async_trait::async_trait;
 
 use crate::errors::error::VcxResult;
 
@@ -21,18 +26,125 @@ use super::profile::Profile;
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct ModularLibsProfile {
-    pub(crate) wallet: Arc<dyn BaseWallet>,
-    pub(crate) anoncreds: Arc<dyn BaseAnonCreds>,
-    pub(crate) anoncreds_ledger_read: Arc<dyn AnoncredsLedgerRead>,
-    pub(crate) anoncreds_ledger_write: Arc<dyn AnoncredsLedgerWrite>,
-    pub(crate) indy_ledger_read: Arc<dyn IndyLedgerRead>,
-    pub(crate) indy_ledger_write: Arc<dyn IndyLedgerWrite>,
+    wallet: Arc<dyn BaseWallet>,
+    anoncreds: Arc<dyn BaseAnonCreds>,
+
+    // ledger reads
+    anoncreds_ledger_read: Arc<dyn AnoncredsLedgerRead>,
+    indy_ledger_read: Arc<dyn IndyLedgerRead>,
+
+    // ledger writes
+    anoncreds_ledger_write: Arc<RwLock<dyn AnoncredsLedgerWrite + Send + Sync>>,
+    indy_ledger_write: Arc<RwLock<dyn IndyLedgerWrite + Send + Sync>>,
+    taa_configurator: Arc<RwLock<dyn TaaConfigurator + Send + Sync>>,
+}
+
+// The Proxy structs encapsulates dealing with RwLock while implementing IndyLedgerWrite trait,
+// so that rest of the codebase can call trait methods below, without being concerned about obtaining
+// read/write locks. This pattern also enabled us introduce mutability of ledger write structures
+// (setting up TAA in runtime) without having to sync up codebase across the board due to newly
+// introduced RwLock.
+#[derive(Debug)]
+pub struct IndyLedgerWriteProxy {
+    indy_ledger_write: Arc<RwLock<dyn IndyLedgerWrite + Send + Sync>>,
+}
+
+#[derive(Debug)]
+pub struct AnoncredsLedgerWriteProxy {
+    anoncreds_ledger_write: Arc<RwLock<dyn AnoncredsLedgerWrite + Send + Sync>>,
+}
+
+#[async_trait]
+impl IndyLedgerWrite for IndyLedgerWriteProxy {
+    async fn publish_nym(
+        &self,
+        submitter_did: &str,
+        target_did: &str,
+        verkey: Option<&str>,
+        data: Option<&str>,
+        role: Option<&str>,
+    ) -> VcxCoreResult<String> {
+        self.indy_ledger_write
+            .read()
+            .await
+            .publish_nym(submitter_did, target_did, verkey, data, role)
+            .await
+    }
+
+    async fn set_endorser(&self, submitter_did: &str, request: &str, endorser: &str) -> VcxCoreResult<String> {
+        self.indy_ledger_write
+            .read()
+            .await
+            .set_endorser(submitter_did, request, endorser)
+            .await
+    }
+
+    async fn endorse_transaction(&self, endorser_did: &str, request_json: &str) -> VcxCoreResult<()> {
+        self.indy_ledger_write
+            .read()
+            .await
+            .endorse_transaction(endorser_did, request_json)
+            .await
+    }
+
+    async fn add_attr(&self, target_did: &str, attrib_json: &str) -> VcxCoreResult<String> {
+        self.indy_ledger_write
+            .read()
+            .await
+            .add_attr(target_did, attrib_json)
+            .await
+    }
+}
+
+#[async_trait]
+impl AnoncredsLedgerWrite for AnoncredsLedgerWriteProxy {
+    async fn publish_schema(
+        &self,
+        schema_json: &str,
+        submitter_did: &str,
+        endorser_did: Option<String>,
+    ) -> VcxCoreResult<()> {
+        self.anoncreds_ledger_write
+            .read()
+            .await
+            .publish_schema(schema_json, submitter_did, endorser_did)
+            .await
+    }
+
+    async fn publish_cred_def(&self, cred_def_json: &str, submitter_did: &str) -> VcxCoreResult<()> {
+        self.anoncreds_ledger_write
+            .read()
+            .await
+            .publish_cred_def(cred_def_json, submitter_did)
+            .await
+    }
+
+    async fn publish_rev_reg_def(&self, rev_reg_def: &str, submitter_did: &str) -> VcxCoreResult<()> {
+        self.anoncreds_ledger_write
+            .read()
+            .await
+            .publish_rev_reg_def(rev_reg_def, submitter_did)
+            .await
+    }
+
+    async fn publish_rev_reg_delta(
+        &self,
+        rev_reg_id: &str,
+        rev_reg_entry_json: &str,
+        submitter_did: &str,
+    ) -> VcxCoreResult<()> {
+        self.anoncreds_ledger_write
+            .read()
+            .await
+            .publish_rev_reg_delta(rev_reg_id, rev_reg_entry_json, submitter_did)
+            .await
+    }
 }
 
 impl ModularLibsProfile {
-    pub fn init_ledger_read(
+    fn init_ledger_read(
         request_submitter: Arc<IndyVdrSubmitter>,
-    ) -> VcxResult<Arc<IndyVdrLedgerRead<IndyVdrSubmitter, InMemoryResponseCacher>>> {
+    ) -> VcxResult<IndyVdrLedgerRead<IndyVdrSubmitter, InMemoryResponseCacher>> {
         let response_parser = Arc::new(ResponseParser::new());
         let cacher_config = InMemoryResponseCacherConfig::builder()
             .ttl(Duration::from_secs(60))
@@ -46,15 +158,14 @@ impl ModularLibsProfile {
             response_cacher,
             protocol_version: ProtocolVersion::node_1_4(),
         };
-        let ledger_read = Arc::new(IndyVdrLedgerRead::new(config_read));
-        Ok(ledger_read)
+        Ok(IndyVdrLedgerRead::new(config_read))
     }
 
-    pub fn init_ledger_write(
+    fn init_ledger_write(
         wallet: Arc<dyn BaseWallet>,
         request_submitter: Arc<IndyVdrSubmitter>,
         taa_options: Option<TxnAuthrAgrmtOptions>,
-    ) -> VcxResult<Arc<IndyVdrLedgerWrite<IndyVdrSubmitter, BaseWalletRequestSigner>>> {
+    ) -> IndyVdrLedgerWrite<IndyVdrSubmitter, BaseWalletRequestSigner> {
         let request_signer = Arc::new(BaseWalletRequestSigner::new(wallet.clone()));
         let config_write = IndyVdrLedgerWriteConfig {
             request_signer,
@@ -62,8 +173,7 @@ impl ModularLibsProfile {
             taa_options,
             protocol_version: ProtocolVersion::node_1_4(),
         };
-        let ledger_write = Arc::new(IndyVdrLedgerWrite::new(config_write));
-        Ok(ledger_write)
+        IndyVdrLedgerWrite::new(config_write)
     }
 
     pub fn init(wallet: Arc<dyn BaseWallet>, ledger_pool_config: LedgerPoolConfig) -> VcxResult<Self> {
@@ -73,26 +183,32 @@ impl ModularLibsProfile {
         let request_submitter = Arc::new(IndyVdrSubmitter::new(ledger_pool));
 
         let ledger_read = Self::init_ledger_read(request_submitter.clone())?;
-        let ledger_write = Self::init_ledger_write(wallet.clone(), request_submitter, None)?;
+        let ledger_write = Self::init_ledger_write(wallet.clone(), request_submitter, None);
 
+        let ledger_read = Arc::new(ledger_read);
+        let ledger_write = Arc::new(RwLock::new(ledger_write));
         Ok(ModularLibsProfile {
             wallet,
             anoncreds,
             anoncreds_ledger_read: ledger_read.clone(),
-            anoncreds_ledger_write: ledger_write.clone(),
             indy_ledger_read: ledger_read.clone(),
-            indy_ledger_write: ledger_write,
+            anoncreds_ledger_write: ledger_write.clone(),
+            indy_ledger_write: ledger_write.clone(),
+            taa_configurator: ledger_write.clone(),
         })
     }
 }
 
+#[async_trait]
 impl Profile for ModularLibsProfile {
     fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead> {
         Arc::clone(&self.indy_ledger_read)
     }
 
     fn inject_indy_ledger_write(self: Arc<Self>) -> Arc<dyn IndyLedgerWrite> {
-        Arc::clone(&self.indy_ledger_write)
+        Arc::new(IndyLedgerWriteProxy {
+            indy_ledger_write: Arc::clone(&self.indy_ledger_write),
+        })
     }
 
     fn inject_anoncreds(self: Arc<Self>) -> Arc<dyn BaseAnonCreds> {
@@ -104,10 +220,19 @@ impl Profile for ModularLibsProfile {
     }
 
     fn inject_anoncreds_ledger_write(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerWrite> {
-        Arc::clone(&self.anoncreds_ledger_write)
+        Arc::new(AnoncredsLedgerWriteProxy {
+            anoncreds_ledger_write: Arc::clone(&self.anoncreds_ledger_write),
+        })
     }
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {
         Arc::clone(&self.wallet)
+    }
+
+    async fn update_taa_configuration(self: Arc<Self>, taa_options: TxnAuthrAgrmtOptions) {
+        self.taa_configurator
+            .write()
+            .await
+            .set_txn_author_agreement_options(taa_options);
     }
 }

--- a/aries_vcx/src/core/profile/profile.rs
+++ b/aries_vcx/src/core/profile/profile.rs
@@ -1,11 +1,14 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
+use aries_vcx_core::ledger::base_ledger::{TaaConfigurator, TxnAuthrAgrmtOptions};
 use aries_vcx_core::{
     anoncreds::base_anoncreds::BaseAnonCreds,
     ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
     wallet::base_wallet::BaseWallet,
 };
+use async_trait::async_trait;
 
+#[async_trait]
 pub trait Profile: std::fmt::Debug + Send + Sync {
     fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead>;
 
@@ -18,4 +21,6 @@ pub trait Profile: std::fmt::Debug + Send + Sync {
     fn inject_anoncreds_ledger_write(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerWrite>;
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet>;
+
+    async fn update_taa_configuration(self: Arc<Self>, taa_options: TxnAuthrAgrmtOptions);
 }

--- a/aries_vcx/src/core/profile/vdr_proxy_profile.rs
+++ b/aries_vcx/src/core/profile/vdr_proxy_profile.rs
@@ -1,5 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
+use crate::errors::error::VcxResult;
+use aries_vcx_core::ledger::base_ledger::TxnAuthrAgrmtOptions;
 use aries_vcx_core::{
     anoncreds::{base_anoncreds::BaseAnonCreds, indy_anoncreds::IndySdkAnonCreds},
     ledger::{
@@ -14,8 +16,7 @@ use aries_vcx_core::{
     wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
     ResponseParser, VdrProxyClient, WalletHandle,
 };
-
-use crate::errors::error::VcxResult;
+use async_trait::async_trait;
 
 use super::{prepare_taa_options, profile::Profile};
 
@@ -69,6 +70,7 @@ impl VdrProxyProfile {
     }
 }
 
+#[async_trait]
 impl Profile for VdrProxyProfile {
     fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead> {
         Arc::clone(&self.indy_ledger_read)
@@ -92,5 +94,9 @@ impl Profile for VdrProxyProfile {
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {
         Arc::clone(&self.wallet)
+    }
+
+    async fn update_taa_configuration(self: Arc<Self>, taa_options: TxnAuthrAgrmtOptions) {
+        todo!()
     }
 }

--- a/aries_vcx/src/core/profile/vdrtools_profile.rs
+++ b/aries_vcx/src/core/profile/vdrtools_profile.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use super::profile::Profile;
+use aries_vcx_core::ledger::base_ledger::{TaaConfigurator, TxnAuthrAgrmtOptions};
 use aries_vcx_core::{
     anoncreds::{base_anoncreds::BaseAnonCreds, indy_anoncreds::IndySdkAnonCreds},
     ledger::{
@@ -9,8 +11,7 @@ use aries_vcx_core::{
     wallet::{base_wallet::BaseWallet, indy_wallet::IndySdkWallet},
     PoolHandle, WalletHandle,
 };
-
-use super::profile::Profile;
+use async_trait::async_trait;
 
 #[derive(Debug)]
 pub struct VdrtoolsProfile {
@@ -39,6 +40,7 @@ impl VdrtoolsProfile {
     }
 }
 
+#[async_trait]
 impl Profile for VdrtoolsProfile {
     fn inject_indy_ledger_read(self: Arc<Self>) -> Arc<dyn IndyLedgerRead> {
         Arc::clone(&self.indy_ledger_read)
@@ -62,5 +64,9 @@ impl Profile for VdrtoolsProfile {
 
     fn inject_wallet(&self) -> Arc<dyn BaseWallet> {
         Arc::clone(&self.wallet)
+    }
+
+    async fn update_taa_configuration(self: Arc<Self>, taa_options: TxnAuthrAgrmtOptions) {
+        todo!()
     }
 }

--- a/aries_vcx/src/utils/mockdata/profile/mock_profile.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_profile.rs
@@ -1,20 +1,22 @@
 use std::sync::Arc;
 
+use aries_vcx_core::ledger::base_ledger::{TaaConfigurator, TxnAuthrAgrmtOptions};
 use aries_vcx_core::{
     anoncreds::base_anoncreds::BaseAnonCreds,
     ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite},
     wallet::base_wallet::BaseWallet,
 };
 
-use crate::core::profile::profile::Profile;
-
 use super::{mock_anoncreds::MockAnoncreds, mock_ledger::MockLedger, mock_wallet::MockWallet};
+use crate::core::profile::profile::Profile;
+use async_trait::async_trait;
 
 /// Implementation of a [Profile] which uses [MockLedger], [MockAnoncreds] and [MockWallet] to return
 /// mock data for all Profile methods. Only for unit testing purposes
 #[derive(Debug)]
 pub struct MockProfile;
 
+#[async_trait]
 impl Profile for MockProfile {
     fn inject_indy_ledger_write(self: Arc<Self>) -> Arc<dyn IndyLedgerWrite> {
         Arc::new(MockLedger {})
@@ -38,5 +40,9 @@ impl Profile for MockProfile {
 
     fn inject_anoncreds_ledger_write(self: Arc<Self>) -> Arc<dyn AnoncredsLedgerWrite> {
         Arc::new(MockLedger {})
+    }
+
+    async fn update_taa_configuration(self: Arc<Self>, taa_options: TxnAuthrAgrmtOptions) {
+        todo!()
     }
 }

--- a/aries_vcx_core/src/ledger/base_ledger.rs
+++ b/aries_vcx_core/src/ledger/base_ledger.rs
@@ -58,3 +58,13 @@ pub trait AnoncredsLedgerWrite: Debug + Send + Sync {
         submitter_did: &str,
     ) -> VcxCoreResult<()>;
 }
+
+pub trait TaaConfigurator: Debug + Send + Sync {
+    fn set_txn_author_agreement_options(&mut self, taa_options: TxnAuthrAgrmtOptions);
+}
+
+pub struct TxnAuthrAgrmtOptions {
+    pub text: String,
+    pub version: String,
+    pub aml_label: String,
+}

--- a/aries_vcx_core/src/ledger/indy_vdr_ledger.rs
+++ b/aries_vcx_core/src/ledger/indy_vdr_ledger.rs
@@ -20,6 +20,7 @@ use vdr::utils::Qualifiable;
 
 use crate::common::ledger::transactions::verify_transaction_can_be_endorsed;
 use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
+use crate::ledger::base_ledger::{TaaConfigurator, TxnAuthrAgrmtOptions};
 
 use super::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite, IndyLedgerRead, IndyLedgerWrite};
 use super::map_error_not_found_to_none;
@@ -126,6 +127,16 @@ where
         let signature = self.request_signer.sign(submitter_did, &request).await?;
         request.set_signature(&signature)?;
         self.request_submitter.submit(request).await
+    }
+}
+
+impl<T, U> TaaConfigurator for IndyVdrLedgerWrite<T, U>
+where
+    T: RequestSubmitter + Send + Sync,
+    U: RequestSigner + Send + Sync,
+{
+    fn set_txn_author_agreement_options(&mut self, taa_options: TxnAuthrAgrmtOptions) {
+        self.taa_options = Some(taa_options);
     }
 }
 
@@ -441,10 +452,4 @@ impl ProtocolVersion {
     pub fn node_1_4() -> Self {
         ProtocolVersion(VdrProtocolVersion::Node1_4)
     }
-}
-
-pub struct TxnAuthrAgrmtOptions {
-    pub text: String,
-    pub version: String,
-    pub aml_label: String,
 }


### PR DESCRIPTION
In PR https://github.com/hyperledger/aries-vcx/pull/863 we have eliminated global state used by modular profile. However:
- we didn't have way to set up TAA in runtime without having to rebuild entire Profile
- that was manifested by `ModularLibsProfile` having fields with `public(crate)` visibility so we could accommodate different initialization flow which needs indy writer with TAA (also resulting in some code duplication in `aries_vcx/src/utils/devsetup.rs`)

- This PR introduces interior mutability within `ModularLibsProfile` such that it's possible to update TAA setup for ledger writer in runtime - doing so by wrapping the `anoncreds_ledger_write`, `indy_ledger_write` in `RwLock` - note these wrapped trait objects are the same instance under the hood.
- As RwLocks has been added wrapping the ledger write trait objects, in order to prevent having to modify codebase across many files and deal with locks everywhere, obtaining locks has been encapsulated into `IndyLedgerWriteProxy`, `AnoncredsLedgerWriteProxy` which implement `IndyLedgerWriteProxy`, `AnoncredsLedgerWriteProxy` respectively. This enabled us to introduce RwLocks without surrounding code consuming Profile trait being aware of it.