### PR TITLE
Inject only required components, not entire profiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -555,6 +555,7 @@ jobs:
       - name: "Run libvcx tests: pool_tests"
         run: |
           RUST_TEST_THREADS=1 cargo test --manifest-path="libvcx/Cargo.toml" -F "pool_tests";
+          RUST_TEST_THREADS=1 cargo test --manifest-path="libvcx_core/Cargo.toml" -F "pool_tests";
 
   test-integration-resolver:
     needs: workflow-setup

--- a/agents/rust/aries-vcx-agent/src/services/connection.rs
+++ b/agents/rust/aries-vcx-agent/src/services/connection.rs
@@ -45,7 +45,7 @@ impl ServiceConnections {
     pub async fn receive_invitation(&self, invite: AnyInvitation) -> AgentResult<String> {
         let pairwise_info = PairwiseInfo::create(&self.profile.inject_wallet()).await?;
         let invitee = Connection::new_invitee("".to_owned(), pairwise_info)
-            .accept_invitation(&self.profile, invite)
+            .accept_invitation(&self.profile.inject_indy_ledger_read(), invite)
             .await?;
 
         let thread_id = invitee.thread_id().to_owned();

--- a/agents/rust/aries-vcx-agent/src/services/credential_definition.rs
+++ b/agents/rust/aries-vcx-agent/src/services/credential_definition.rs
@@ -22,13 +22,25 @@ impl ServiceCredentialDefinitions {
     }
 
     pub async fn create_cred_def(&self, config: CredentialDefConfig) -> AgentResult<String> {
-        let cd = CredentialDef::create(&self.profile, "".to_string(), config, true).await?;
+        let cd = CredentialDef::create(
+            &self.profile.inject_anoncreds_ledger_read(),
+            &self.profile.inject_anoncreds(),
+            "".to_string(),
+            config,
+            true,
+        )
+        .await?;
         self.cred_defs.insert(&cd.get_cred_def_id(), cd)
     }
 
     pub async fn publish_cred_def(&self, thread_id: &str) -> AgentResult<()> {
         let cred_def = self.cred_defs.get(thread_id)?;
-        let cred_def = cred_def.publish_cred_def(&self.profile).await?;
+        let cred_def = cred_def
+            .publish_cred_def(
+                &self.profile.inject_anoncreds_ledger_read(),
+                &self.profile.inject_anoncreds_ledger_write(),
+            )
+            .await?;
         self.cred_defs.insert(thread_id, cred_def)?;
         Ok(())
     }

--- a/agents/rust/aries-vcx-agent/src/services/holder.rs
+++ b/agents/rust/aries-vcx-agent/src/services/holder.rs
@@ -99,7 +99,14 @@ impl ServiceCredentialsHolder {
             Box::pin(async move { connection.send_message(&wallet, &msg, &HttpClient).await })
         });
 
-        holder.send_request(&self.profile, pw_did, send_closure).await?;
+        holder
+            .send_request(
+                &self.profile.inject_anoncreds_ledger_read(),
+                &self.profile.inject_anoncreds(),
+                pw_did,
+                send_closure,
+            )
+            .await?;
         self.creds_holder
             .insert(&holder.get_thread_id()?, HolderWrapper::new(holder, &connection_id))
     }
@@ -115,7 +122,12 @@ impl ServiceCredentialsHolder {
         });
 
         holder
-            .process_credential(&self.profile, credential, send_closure)
+            .process_credential(
+                &self.profile.inject_anoncreds_ledger_read(),
+                &self.profile.inject_anoncreds(),
+                credential,
+                send_closure,
+            )
             .await?;
         self.creds_holder
             .insert(&holder.get_thread_id()?, HolderWrapper::new(holder, &connection_id))
@@ -127,7 +139,7 @@ impl ServiceCredentialsHolder {
 
     pub async fn is_revokable(&self, thread_id: &str) -> AgentResult<bool> {
         self.get_holder(thread_id)?
-            .is_revokable(&self.profile)
+            .is_revokable(&self.profile.inject_anoncreds_ledger_read())
             .await
             .map_err(|err| err.into())
     }

--- a/agents/rust/aries-vcx-agent/src/services/issuer.rs
+++ b/agents/rust/aries-vcx-agent/src/services/issuer.rs
@@ -75,7 +75,7 @@ impl ServiceCredentialsIssuer {
         };
         let connection = self.service_connections.get_by_id(&connection_id)?;
         issuer
-            .build_credential_offer_msg(&self.profile, offer_info, None)
+            .build_credential_offer_msg(&self.profile.inject_anoncreds(), offer_info, None)
             .await?;
 
         let wallet = self.profile.inject_wallet();
@@ -124,7 +124,9 @@ impl ServiceCredentialsIssuer {
             Box::pin(async move { connection.send_message(&wallet, &msg, &HttpClient).await })
         });
 
-        issuer.send_credential(&self.profile, send_closure).await?;
+        issuer
+            .send_credential(&self.profile.inject_anoncreds(), send_closure)
+            .await?;
         self.creds_issuer
             .insert(&issuer.get_thread_id()?, IssuerWrapper::new(issuer, &connection_id))?;
         Ok(())

--- a/agents/rust/aries-vcx-agent/src/services/prover.rs
+++ b/agents/rust/aries-vcx-agent/src/services/prover.rs
@@ -63,7 +63,7 @@ impl ServiceProver {
         prover: &Prover,
         tails_dir: Option<&str>,
     ) -> AgentResult<SelectedCredentials> {
-        let credentials = prover.retrieve_credentials(&self.profile).await?;
+        let credentials = prover.retrieve_credentials(&self.profile.inject_anoncreds()).await?;
 
         let mut res_credentials = SelectedCredentials::default();
 
@@ -118,7 +118,12 @@ impl ServiceProver {
         let connection = self.service_connections.get_by_id(&connection_id)?;
         let credentials = self.get_credentials_for_presentation(&prover, tails_dir).await?;
         prover
-            .generate_presentation(&self.profile, credentials, HashMap::new())
+            .generate_presentation(
+                &self.profile.inject_anoncreds_ledger_read(),
+                &self.profile.inject_anoncreds(),
+                credentials,
+                HashMap::new(),
+            )
             .await?;
 
         let wallet = self.profile.inject_wallet();

--- a/agents/rust/aries-vcx-agent/src/services/revocation_registry.rs
+++ b/agents/rust/aries-vcx-agent/src/services/revocation_registry.rs
@@ -33,8 +33,15 @@ impl ServiceRevocationRegistries {
     }
 
     pub async fn create_rev_reg(&self, cred_def_id: &str, max_creds: u32) -> AgentResult<String> {
-        let rev_reg =
-            RevocationRegistry::create(&self.profile, &self.issuer_did, cred_def_id, "/tmp", max_creds, 1).await?;
+        let rev_reg = RevocationRegistry::create(
+            &self.profile.inject_anoncreds(),
+            &self.issuer_did,
+            cred_def_id,
+            "/tmp",
+            max_creds,
+            1,
+        )
+        .await?;
         self.rev_regs.insert(&rev_reg.get_rev_reg_id(), rev_reg)
     }
 
@@ -53,21 +60,29 @@ impl ServiceRevocationRegistries {
 
     pub async fn publish_rev_reg(&self, thread_id: &str, tails_url: &str) -> AgentResult<()> {
         let mut rev_reg = self.rev_regs.get(thread_id)?;
-        rev_reg.publish_revocation_primitives(&self.profile, tails_url).await?;
+        rev_reg
+            .publish_revocation_primitives(&self.profile.inject_anoncreds_ledger_write(), tails_url)
+            .await?;
         self.rev_regs.insert(thread_id, rev_reg)?;
         Ok(())
     }
 
     pub async fn revoke_credential_locally(&self, id: &str, cred_rev_id: &str) -> AgentResult<()> {
         let rev_reg = self.rev_regs.get(id)?;
-        rev_reg.revoke_credential_local(&self.profile, cred_rev_id).await?;
+        rev_reg
+            .revoke_credential_local(&self.profile.inject_anoncreds(), cred_rev_id)
+            .await?;
         Ok(())
     }
 
     pub async fn publish_local_revocations(&self, id: &str) -> AgentResult<()> {
         let rev_reg = self.rev_regs.get(id)?;
         rev_reg
-            .publish_local_revocations(&self.profile, &self.issuer_did)
+            .publish_local_revocations(
+                &self.profile.inject_anoncreds(),
+                &self.profile.inject_anoncreds_ledger_write(),
+                &self.issuer_did,
+            )
             .await?;
         Ok(())
     }

--- a/agents/rust/aries-vcx-agent/src/services/schema.rs
+++ b/agents/rust/aries-vcx-agent/src/services/schema.rs
@@ -22,13 +22,23 @@ impl ServiceSchemas {
     }
 
     pub async fn create_schema(&self, name: &str, version: &str, attributes: &Vec<String>) -> AgentResult<String> {
-        let schema = Schema::create(&self.profile, "", &self.issuer_did, name, version, attributes).await?;
+        let schema = Schema::create(
+            &self.profile.inject_anoncreds(),
+            "",
+            &self.issuer_did,
+            name,
+            version,
+            attributes,
+        )
+        .await?;
         self.schemas.insert(&schema.get_schema_id(), schema)
     }
 
     pub async fn publish_schema(&self, thread_id: &str) -> AgentResult<()> {
         let schema = self.schemas.get(thread_id)?;
-        let schema = schema.publish(&self.profile, None).await?;
+        let schema = schema
+            .publish(&self.profile.inject_anoncreds_ledger_write(), None)
+            .await?;
         self.schemas.insert(thread_id, schema)?;
         Ok(())
     }

--- a/agents/rust/aries-vcx-agent/src/services/verifier.rs
+++ b/agents/rust/aries-vcx-agent/src/services/verifier.rs
@@ -90,7 +90,12 @@ impl ServiceVerifier {
         });
 
         verifier
-            .verify_presentation(&self.profile, presentation, send_closure)
+            .verify_presentation(
+                &self.profile.inject_anoncreds_ledger_read(),
+                &self.profile.inject_anoncreds(),
+                presentation,
+                send_closure,
+            )
             .await?;
         self.verifiers
             .insert(thread_id, VerifierWrapper::new(verifier, &connection_id))?;

--- a/aries_vcx/src/common/anoncreds.rs
+++ b/aries_vcx/src/common/anoncreds.rs
@@ -94,7 +94,11 @@ pub mod integration_tests {
                 .unwrap();
 
             rev_reg
-                .publish_local_revocations(&setup.profile, &setup.institution_did)
+                .publish_local_revocations(
+                    &setup.profile.inject_anoncreds(),
+                    &setup.profile.inject_anoncreds_ledger_write(),
+                    &setup.institution_did,
+                )
                 .await
                 .unwrap();
 

--- a/aries_vcx/src/common/anoncreds.rs
+++ b/aries_vcx/src/common/anoncreds.rs
@@ -62,8 +62,10 @@ pub mod integration_tests {
     async fn test_pool_revoke_credential() {
         SetupProfile::run(|setup| async move {
             let (_, _, _, _, _, _, _, _, rev_reg_id, cred_rev_id, _, rev_reg) = create_and_store_credential(
-                &setup.profile,
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 crate::utils::constants::DEFAULT_SCHEMA_ATTRS,
             )

--- a/aries_vcx/src/common/credentials/mod.rs
+++ b/aries_vcx/src/common/credentials/mod.rs
@@ -139,7 +139,11 @@ mod integration_tests {
                 .await
                 .unwrap();
             rev_reg
-                .publish_local_revocations(&setup.profile, &setup.institution_did)
+                .publish_local_revocations(
+                    &setup.profile.inject_anoncreds(),
+                    &setup.profile.inject_anoncreds_ledger_write(),
+                    &setup.institution_did,
+                )
                 .await
                 .unwrap();
 

--- a/aries_vcx/src/common/credentials/mod.rs
+++ b/aries_vcx/src/common/credentials/mod.rs
@@ -56,8 +56,10 @@ mod integration_tests {
     async fn test_pool_prover_get_credential() {
         SetupProfile::run(|setup| async move {
             let res = create_and_store_credential(
-                &setup.profile,
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -86,8 +88,10 @@ mod integration_tests {
     async fn test_pool_get_cred_rev_id() {
         SetupProfile::run(|setup| async move {
             let res = create_and_store_credential(
-                &setup.profile,
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -109,8 +113,10 @@ mod integration_tests {
     async fn test_pool_is_cred_revoked() {
         SetupProfile::run(|setup| async move {
             let res = create_and_store_credential(
-                &setup.profile,
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )

--- a/aries_vcx/src/common/credentials/mod.rs
+++ b/aries_vcx/src/common/credentials/mod.rs
@@ -120,9 +120,11 @@ mod integration_tests {
             let tails_file = res.10;
             let rev_reg = res.11;
 
-            assert!(!is_cred_revoked(&setup.profile, &rev_reg_id, &cred_rev_id)
-                .await
-                .unwrap());
+            assert!(
+                !is_cred_revoked(&setup.profile.inject_anoncreds_ledger_read(), &rev_reg_id, &cred_rev_id)
+                    .await
+                    .unwrap()
+            );
 
             let anoncreds = Arc::clone(&setup.profile).inject_anoncreds();
 
@@ -137,9 +139,11 @@ mod integration_tests {
 
             std::thread::sleep(std::time::Duration::from_millis(500));
 
-            assert!(is_cred_revoked(&setup.profile, &rev_reg_id, &cred_rev_id)
-                .await
-                .unwrap());
+            assert!(
+                is_cred_revoked(&setup.profile.inject_anoncreds_ledger_read(), &rev_reg_id, &cred_rev_id)
+                    .await
+                    .unwrap()
+            );
         })
         .await;
     }

--- a/aries_vcx/src/common/keys.rs
+++ b/aries_vcx/src/common/keys.rs
@@ -84,11 +84,11 @@ pub async fn get_verkey_from_ledger(indy_ledger: &Arc<dyn IndyLedgerRead>, did: 
 mod test {
     #[tokio::test]
     #[ignore]
-    // #[cfg(all(
-    //     not(feature = "vdr_proxy_ledger"),
-    //     not(feature = "modular_libs"),
-    //     not(feature = "mixed_breed")
-    // ))]
+    #[cfg(all(
+        not(feature = "vdr_proxy_ledger"),
+        not(feature = "modular_libs"),
+        not(feature = "mixed_breed")
+    ))]
     async fn test_pool_rotate_verkey_fails() {
         use super::*;
 

--- a/aries_vcx/src/common/keys.rs
+++ b/aries_vcx/src/common/keys.rs
@@ -84,11 +84,11 @@ pub async fn get_verkey_from_ledger(indy_ledger: &Arc<dyn IndyLedgerRead>, did: 
 mod test {
     #[tokio::test]
     #[ignore]
-    #[cfg(all(
-        not(feature = "vdr_proxy_ledger"),
-        not(feature = "modular_libs"),
-        not(feature = "mixed_breed")
-    ))]
+    // #[cfg(all(
+    //     not(feature = "vdr_proxy_ledger"),
+    //     not(feature = "modular_libs"),
+    //     not(feature = "mixed_breed")
+    // ))]
     async fn test_pool_rotate_verkey_fails() {
         use super::*;
 
@@ -110,10 +110,14 @@ mod test {
                 .await
                 .unwrap();
             assert_eq!(
-                rotate_verkey(&setup.profile, &setup.institution_did)
-                    .await
-                    .unwrap_err()
-                    .kind(),
+                rotate_verkey(
+                    &setup.profile.inject_wallet(),
+                    &setup.profile.inject_indy_ledger_write(),
+                    &setup.institution_did
+                )
+                .await
+                .unwrap_err()
+                .kind(),
                 AriesVcxErrorKind::InvalidLedgerResponse
             );
             let local_verkey_2 = setup

--- a/aries_vcx/src/common/primitives/credential_definition.rs
+++ b/aries_vcx/src/common/primitives/credential_definition.rs
@@ -125,7 +125,7 @@ async fn _try_get_cred_def_from_ledger(
 }
 impl CredentialDef {
     pub async fn create(
-        ledger: &Arc<dyn AnoncredsLedgerRead>,
+        ledger_read: &Arc<dyn AnoncredsLedgerRead>,
         anoncreds: &Arc<dyn BaseAnonCreds>,
         source_id: String,
         config: CredentialDefConfig,
@@ -141,7 +141,7 @@ impl CredentialDef {
             schema_id,
             tag,
         } = config;
-        let schema_json = ledger.get_schema(&schema_id, Some(&issuer_did)).await?;
+        let schema_json = ledger_read.get_schema(&schema_id, Some(&issuer_did)).await?;
         let (cred_def_id, cred_def_json) = generate_cred_def(
             anoncreds,
             &issuer_did,
@@ -301,7 +301,7 @@ pub mod integration_tests {
         SetupProfile::run(|setup| async move {
             let (schema_id, _) = create_and_write_test_schema(
                 &setup.profile.inject_anoncreds(),
-                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -374,7 +374,7 @@ pub mod integration_tests {
             std::fs::create_dir_all(&path).unwrap();
 
             let (rev_reg_def_id, rev_reg_def_json, rev_reg_entry_json) = generate_rev_reg(
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
                 &setup.institution_did,
                 &cred_def_id,
                 path.to_str().unwrap(),

--- a/aries_vcx/src/common/primitives/credential_definition.rs
+++ b/aries_vcx/src/common/primitives/credential_definition.rs
@@ -1,12 +1,12 @@
 use aries_vcx_core::errors::error::AriesVcxCoreErrorKind;
-use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
+use aries_vcx_core::ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite};
 
-use crate::core::profile::profile::Profile;
 use crate::errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult};
 use crate::utils::constants::{CRED_DEF_ID, CRED_DEF_JSON, DEFAULT_SERIALIZE_VERSION};
 use crate::utils::serialization::ObjectWithVersion;
 
 use crate::global::settings::{self, indy_mocks_enabled};
+use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
 use std::fmt;
 use std::sync::Arc;
 
@@ -125,7 +125,8 @@ async fn _try_get_cred_def_from_ledger(
 }
 impl CredentialDef {
     pub async fn create(
-        profile: &Arc<dyn Profile>,
+        ledger: &Arc<dyn AnoncredsLedgerRead>,
+        anoncreds: &Arc<dyn BaseAnonCreds>,
         source_id: String,
         config: CredentialDefConfig,
         support_revocation: bool,
@@ -140,10 +141,16 @@ impl CredentialDef {
             schema_id,
             tag,
         } = config;
-        let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
         let schema_json = ledger.get_schema(&schema_id, Some(&issuer_did)).await?;
-        let (cred_def_id, cred_def_json) =
-            generate_cred_def(profile, &issuer_did, &schema_json, &tag, None, Some(support_revocation)).await?;
+        let (cred_def_id, cred_def_json) = generate_cred_def(
+            anoncreds,
+            &issuer_did,
+            &schema_json,
+            &tag,
+            None,
+            Some(support_revocation),
+        )
+        .await?;
         Ok(Self {
             source_id,
             tag,
@@ -164,13 +171,16 @@ impl CredentialDef {
         self.support_revocation
     }
 
-    pub async fn publish_cred_def(self, profile: &Arc<dyn Profile>) -> VcxResult<Self> {
+    pub async fn publish_cred_def(
+        self,
+        ledger_read: &Arc<dyn AnoncredsLedgerRead>,
+        ledger_write: &Arc<dyn AnoncredsLedgerWrite>,
+    ) -> VcxResult<Self> {
         trace!(
             "publish_cred_def >>> issuer_did: {}, cred_def_id: {}",
             self.issuer_did,
             self.id
         );
-        let ledger_read = Arc::clone(profile).inject_anoncreds_ledger_read();
         if let Some(ledger_cred_def_json) =
             _try_get_cred_def_from_ledger(&ledger_read, &self.issuer_did, &self.id).await?
         {
@@ -182,8 +192,9 @@ impl CredentialDef {
                 ),
             ));
         }
-        let ledger = Arc::clone(profile).inject_anoncreds_ledger_write();
-        ledger.publish_cred_def(&self.cred_def_json, &self.issuer_did).await?;
+        ledger_write
+            .publish_cred_def(&self.cred_def_json, &self.issuer_did)
+            .await?;
         Ok(Self {
             state: PublicEntityStateType::Published,
             ..self
@@ -232,8 +243,7 @@ impl CredentialDef {
         self.source_id = source_id;
     }
 
-    pub async fn update_state(&mut self, profile: &Arc<dyn Profile>) -> VcxResult<u32> {
-        let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
+    pub async fn update_state(&mut self, ledger: &Arc<dyn AnoncredsLedgerRead>) -> VcxResult<u32> {
         if (ledger.get_cred_def(&self.id, None).await).is_ok() {
             self.state = PublicEntityStateType::Published
         }
@@ -246,7 +256,7 @@ impl CredentialDef {
 }
 
 pub async fn generate_cred_def(
-    profile: &Arc<dyn Profile>,
+    anoncreds: &Arc<dyn BaseAnonCreds>,
     issuer_did: &str,
     schema_json: &str,
     tag: &str,
@@ -261,13 +271,12 @@ pub async fn generate_cred_def(
         sig_type,
         support_revocation
     );
-    if settings::indy_mocks_enabled() {
+    if indy_mocks_enabled() {
         return Ok((CRED_DEF_ID.to_string(), CRED_DEF_JSON.to_string()));
     }
 
     let config_json = json!({"support_revocation": support_revocation.unwrap_or(false)}).to_string();
 
-    let anoncreds = Arc::clone(profile).inject_anoncreds();
     anoncreds
         .issuer_create_and_store_credential_def(issuer_did, schema_json, tag, sig_type, &config_json)
         .await
@@ -290,15 +299,20 @@ pub mod integration_tests {
     #[ignore]
     async fn test_pool_create_cred_def_real() {
         SetupProfile::run(|setup| async move {
-            let (schema_id, _) =
-                create_and_write_test_schema(&setup.profile, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
+            let (schema_id, _) = create_and_write_test_schema(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.institution_did,
+                DEFAULT_SCHEMA_ATTRS,
+            )
+            .await;
 
             let ledger_read = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let ledger_write = Arc::clone(&setup.profile).inject_anoncreds_ledger_write();
             let schema_json = ledger_read.get_schema(&schema_id, None).await.unwrap();
 
             let (cred_def_id, cred_def_json_local) = generate_cred_def(
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
                 &setup.institution_did,
                 &schema_json,
                 "tag_1",
@@ -330,14 +344,19 @@ pub mod integration_tests {
     #[ignore]
     async fn test_pool_create_rev_reg_def() {
         SetupProfile::run(|setup| async move {
-            let (schema_id, _) =
-                create_and_write_test_schema(&setup.profile, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
+            let (schema_id, _) = create_and_write_test_schema(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+                DEFAULT_SCHEMA_ATTRS,
+            )
+            .await;
             let ledger_read = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let ledger_write = Arc::clone(&setup.profile).inject_anoncreds_ledger_write();
             let schema_json = ledger_read.get_schema(&schema_id, None).await.unwrap();
 
             let (cred_def_id, cred_def_json) = generate_cred_def(
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
                 &setup.institution_did,
                 &schema_json,
                 "tag_1",

--- a/aries_vcx/src/common/primitives/mod.rs
+++ b/aries_vcx/src/common/primitives/mod.rs
@@ -25,14 +25,16 @@ pub mod integration_tests {
             // Cred def is created with support_revocation=false,
             // revoc_reg_def will fail in libindy because cred_Def doesn't have revocation keys
             let (_, _, cred_def_id, _, _) = create_and_store_nonrevocable_credential_def(
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
             .await;
 
             let rc = generate_rev_reg(
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
                 &setup.institution_did,
                 &cred_def_id,
                 get_temp_dir_path("path.txt").to_str().unwrap(),
@@ -51,8 +53,14 @@ pub mod integration_tests {
     async fn test_pool_get_rev_reg_def_json() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
-            let (_, _, _, _, rev_reg_id, _, _) =
-                create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
+            let (_, _, _, _, rev_reg_id, _, _) = create_and_store_credential_def(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+                attrs,
+            )
+            .await;
 
             let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let _json = ledger.get_rev_reg_def_json(&rev_reg_id).await.unwrap();
@@ -65,8 +73,14 @@ pub mod integration_tests {
     async fn test_pool_get_rev_reg_delta_json() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
-            let (_, _, _, _, rev_reg_id, _, _) =
-                create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
+            let (_, _, _, _, rev_reg_id, _, _) = create_and_store_credential_def(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+                attrs,
+            )
+            .await;
 
             let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let (id, _delta, _timestamp) = ledger.get_rev_reg_delta_json(&rev_reg_id, None, None).await.unwrap();
@@ -81,8 +95,14 @@ pub mod integration_tests {
     async fn test_pool_get_rev_reg() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
-            let (_, _, _, _, rev_reg_id, _, _) =
-                create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
+            let (_, _, _, _, rev_reg_id, _, _) = create_and_store_credential_def(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+                attrs,
+            )
+            .await;
 
             let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let (id, _rev_reg, _timestamp) = ledger
@@ -100,8 +120,14 @@ pub mod integration_tests {
     async fn test_pool_get_cred_def() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
-            let (_, _, cred_def_id, cred_def_json, _) =
-                create_and_store_nonrevocable_credential_def(&setup.profile, &setup.institution_did, attrs).await;
+            let (_, _, cred_def_id, cred_def_json, _) = create_and_store_nonrevocable_credential_def(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+                attrs,
+            )
+            .await;
 
             let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let cred_def = ledger.get_cred_def(&cred_def_id, None).await.unwrap();
@@ -118,8 +144,13 @@ pub mod integration_tests {
     #[ignore]
     async fn test_pool_create_and_get_schema() {
         SetupProfile::run(|setup| async move {
-            let (schema_id, _schema_json) =
-                create_and_write_test_schema(&setup.profile, &setup.institution_did, DEFAULT_SCHEMA_ATTRS).await;
+            let (schema_id, _schema_json) = create_and_write_test_schema(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+                DEFAULT_SCHEMA_ATTRS,
+            )
+            .await;
 
             let ledger = Arc::clone(&setup.profile).inject_anoncreds_ledger_read();
             let rc = ledger.get_schema(&schema_id, None).await;

--- a/aries_vcx/src/common/primitives/revocation_registry_delta.rs
+++ b/aries_vcx/src/common/primitives/revocation_registry_delta.rs
@@ -68,8 +68,14 @@ pub mod integration_tests {
     async fn test_pool_create_rev_reg_delta_from_ledger() {
         SetupProfile::run(|setup| async move {
             let attrs = r#"["address1","address2","city","state","zip"]"#;
-            let (_, _, _, _, rev_reg_id, _, _) =
-                create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
+            let (_, _, _, _, rev_reg_id, _, _) = create_and_store_credential_def(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+                attrs,
+            )
+            .await;
 
             assert!(RevocationRegistryDelta::create_from_ledger(
                 &setup.profile.inject_anoncreds_ledger_read(),

--- a/aries_vcx/src/common/primitives/revocation_registry_delta.rs
+++ b/aries_vcx/src/common/primitives/revocation_registry_delta.rs
@@ -1,3 +1,4 @@
+use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
 use std::sync::Arc;
 
 use crate::core::profile::profile::Profile;
@@ -33,12 +34,11 @@ impl RevocationRegistryDeltaValue {
 
 impl RevocationRegistryDelta {
     pub async fn create_from_ledger(
-        profile: &Arc<dyn Profile>,
+        ledger: &Arc<dyn AnoncredsLedgerRead>,
         rev_reg_id: &str,
         from: Option<u64>,
         to: Option<u64>,
     ) -> VcxResult<Self> {
-        let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
         let (_, rev_reg_delta_json, _) = ledger.get_rev_reg_delta_json(rev_reg_id, from, to).await?;
         serde_json::from_str(&rev_reg_delta_json).map_err(|err| {
             AriesVcxError::from_msg(

--- a/aries_vcx/src/common/primitives/revocation_registry_delta.rs
+++ b/aries_vcx/src/common/primitives/revocation_registry_delta.rs
@@ -71,11 +71,14 @@ pub mod integration_tests {
             let (_, _, _, _, rev_reg_id, _, _) =
                 create_and_store_credential_def(&setup.profile, &setup.institution_did, attrs).await;
 
-            assert!(
-                RevocationRegistryDelta::create_from_ledger(&setup.profile, &rev_reg_id, None, None)
-                    .await
-                    .is_ok()
-            );
+            assert!(RevocationRegistryDelta::create_from_ledger(
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &rev_reg_id,
+                None,
+                None
+            )
+            .await
+            .is_ok());
         })
         .await;
     }

--- a/aries_vcx/src/common/proofs/proof_request.rs
+++ b/aries_vcx/src/common/proofs/proof_request.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::vec::Vec;
 
+use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
 use serde_json;
 
 use crate::core::profile::profile::Profile;
@@ -27,8 +28,8 @@ pub struct ProofRequestData {
 impl ProofRequestData {
     const DEFAULT_VERSION: &'static str = "1.0";
 
-    pub async fn create(profile: &Arc<dyn Profile>, name: &str) -> VcxResult<Self> {
-        let nonce = Arc::clone(profile).inject_anoncreds().generate_nonce().await?;
+    pub async fn create(anoncreds: &Arc<dyn BaseAnonCreds>, name: &str) -> VcxResult<Self> {
+        let nonce = anoncreds.generate_nonce().await?;
         Ok(Self {
             name: name.to_string(),
             nonce,
@@ -188,7 +189,7 @@ mod unit_tests {
     async fn test_proof_request_msg() {
         let _setup = SetupDefaults::init();
 
-        let request = ProofRequestData::create(&mock_profile(), "Test")
+        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "Test")
             .await
             .unwrap()
             .set_not_revoked_interval(r#"{"from":1100000000, "to": 1600000000}"#.into())
@@ -213,7 +214,7 @@ mod unit_tests {
     async fn test_requested_attrs_constructed_correctly() {
         let _setup = SetupDefaults::init();
 
-        let request = ProofRequestData::create(&mock_profile(), "")
+        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
             .await
             .unwrap()
             .set_requested_attributes_as_string(REQUESTED_ATTRS.into())
@@ -228,7 +229,7 @@ mod unit_tests {
         let expected_req_attrs = _expected_req_attrs();
         let req_attrs_string = serde_json::to_string(&expected_req_attrs).unwrap();
 
-        let request = ProofRequestData::create(&mock_profile(), "")
+        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
             .await
             .unwrap()
             .set_requested_attributes_as_string(req_attrs_string)
@@ -269,7 +270,7 @@ mod unit_tests {
         .unwrap();
         check_predicates.insert("predicate_0".to_string(), attr_info1);
 
-        let request = ProofRequestData::create(&mock_profile(), "")
+        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
             .await
             .unwrap()
             .set_requested_predicates_as_string(REQUESTED_PREDICATES.into())
@@ -292,7 +293,7 @@ mod unit_tests {
 
         let requested_attrs = json!([attr_info, attr_info_2]).to_string();
 
-        let request = ProofRequestData::create(&mock_profile(), "")
+        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
             .await
             .unwrap()
             .set_requested_attributes_as_string(requested_attrs.into())
@@ -316,7 +317,7 @@ mod unit_tests {
 
         let requested_attrs = json!([attr_info]).to_string();
 
-        let err = ProofRequestData::create(&mock_profile(), "")
+        let err = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
             .await
             .unwrap()
             .set_requested_attributes_as_string(requested_attrs.into())

--- a/aries_vcx/src/common/proofs/proof_request.rs
+++ b/aries_vcx/src/common/proofs/proof_request.rs
@@ -165,11 +165,11 @@ pub mod test_utils {
 mod unit_tests {
     use serde_json::Value;
 
-    use crate::common::test_utils::mock_profile;
     use crate::utils;
     use crate::utils::constants::{REQUESTED_ATTRS, REQUESTED_PREDICATES};
     use crate::utils::devsetup::SetupDefaults;
     use crate::utils::mockdata::mockdata_proof;
+    use crate::utils::mockdata::profile::mock_anoncreds::MockAnoncreds;
 
     use super::*;
 
@@ -189,7 +189,8 @@ mod unit_tests {
     async fn test_proof_request_msg() {
         let _setup = SetupDefaults::init();
 
-        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "Test")
+        let anoncreds: Arc<dyn BaseAnonCreds> = Arc::new(MockAnoncreds {});
+        let request = ProofRequestData::create(&anoncreds, "Test")
             .await
             .unwrap()
             .set_not_revoked_interval(r#"{"from":1100000000, "to": 1600000000}"#.into())
@@ -214,7 +215,8 @@ mod unit_tests {
     async fn test_requested_attrs_constructed_correctly() {
         let _setup = SetupDefaults::init();
 
-        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
+        let anoncreds: Arc<dyn BaseAnonCreds> = Arc::new(MockAnoncreds {});
+        let request = ProofRequestData::create(&anoncreds, "")
             .await
             .unwrap()
             .set_requested_attributes_as_string(REQUESTED_ATTRS.into())
@@ -229,7 +231,8 @@ mod unit_tests {
         let expected_req_attrs = _expected_req_attrs();
         let req_attrs_string = serde_json::to_string(&expected_req_attrs).unwrap();
 
-        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
+        let anoncreds: Arc<dyn BaseAnonCreds> = Arc::new(MockAnoncreds {});
+        let request = ProofRequestData::create(&anoncreds, "")
             .await
             .unwrap()
             .set_requested_attributes_as_string(req_attrs_string)
@@ -270,7 +273,8 @@ mod unit_tests {
         .unwrap();
         check_predicates.insert("predicate_0".to_string(), attr_info1);
 
-        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
+        let anoncreds: Arc<dyn BaseAnonCreds> = Arc::new(MockAnoncreds {});
+        let request = ProofRequestData::create(&anoncreds, "")
             .await
             .unwrap()
             .set_requested_predicates_as_string(REQUESTED_PREDICATES.into())
@@ -293,7 +297,8 @@ mod unit_tests {
 
         let requested_attrs = json!([attr_info, attr_info_2]).to_string();
 
-        let request = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
+        let anoncreds: Arc<dyn BaseAnonCreds> = Arc::new(MockAnoncreds {});
+        let request = ProofRequestData::create(&anoncreds, "")
             .await
             .unwrap()
             .set_requested_attributes_as_string(requested_attrs.into())
@@ -317,7 +322,8 @@ mod unit_tests {
 
         let requested_attrs = json!([attr_info]).to_string();
 
-        let err = ProofRequestData::create(&mock_profile().inject_anoncreds(), "")
+        let anoncreds: Arc<dyn BaseAnonCreds> = Arc::new(MockAnoncreds {});
+        let err = ProofRequestData::create(&anoncreds, "")
             .await
             .unwrap()
             .set_requested_attributes_as_string(requested_attrs.into())

--- a/aries_vcx/src/common/proofs/prover/prover_internal.rs
+++ b/aries_vcx/src/common/proofs/prover/prover_internal.rs
@@ -305,6 +305,8 @@ pub mod unit_tests {
 
     use crate::core::profile::vdrtools_profile::VdrtoolsProfile;
     use crate::utils::devsetup::*;
+    use crate::utils::mockdata::profile::mock_anoncreds::MockAnoncreds;
+    use crate::utils::mockdata::profile::mock_ledger::MockLedger;
     use crate::utils::{
         constants::{
             ADDRESS_CRED_DEF_ID, ADDRESS_CRED_ID, ADDRESS_CRED_REV_ID, ADDRESS_REV_REG_ID, ADDRESS_SCHEMA_ID,
@@ -312,8 +314,6 @@ pub mod unit_tests {
         },
         get_temp_dir_path,
     };
-    use crate::utils::mockdata::profile::mock_anoncreds::MockAnoncreds;
-    use crate::utils::mockdata::profile::mock_ledger::MockLedger;
 
     use super::*;
 
@@ -365,9 +365,7 @@ pub mod unit_tests {
         let creds = vec![cred1, cred2];
 
         let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
-        let credential_def = build_cred_defs_json_prover(&ledger_read, &creds)
-            .await
-            .unwrap();
+        let credential_def = build_cred_defs_json_prover(&ledger_read, &creds).await.unwrap();
         assert!(credential_def.len() > 0);
         assert!(credential_def.contains(r#""id":"V4SGRU86Z58d6TV7PBUe6f:3:CL:47:tag1","schemaId":"47""#));
     }
@@ -433,9 +431,7 @@ pub mod unit_tests {
 
         let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
         assert_eq!(
-            build_schemas_json_prover(&ledger_read, &Vec::new())
-                .await
-                .unwrap(),
+            build_schemas_json_prover(&ledger_read, &Vec::new()).await.unwrap(),
             "{}".to_string()
         );
 
@@ -466,9 +462,7 @@ pub mod unit_tests {
         let creds = vec![cred1, cred2];
 
         let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
-        let schemas = build_schemas_json_prover(&ledger_read, &creds)
-            .await
-            .unwrap();
+        let schemas = build_schemas_json_prover(&ledger_read, &creds).await.unwrap();
         assert!(schemas.len() > 0);
         assert!(schemas.contains(r#""id":"2hoqvcwupRTUNkXn6ArYzs:2:test-licence:4.4.4","name":"test-licence""#));
     }
@@ -731,15 +725,11 @@ pub mod unit_tests {
             revealed: None,
         };
         let mut cred_info = vec![cred1];
-        let anoncreds: Arc<dyn BaseAnonCreds> = Arc::new( MockAnoncreds {} );
+        let anoncreds: Arc<dyn BaseAnonCreds> = Arc::new(MockAnoncreds {});
         let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
-        let states = build_rev_states_json(
-            &ledger_read,
-            &anoncreds,
-            cred_info.as_mut(),
-        )
-        .await
-        .unwrap();
+        let states = build_rev_states_json(&ledger_read, &anoncreds, cred_info.as_mut())
+            .await
+            .unwrap();
         let rev_state_json: Value = serde_json::from_str(REV_STATE_JSON).unwrap();
         let expected = json!({REV_REG_ID: {"1": rev_state_json}}).to_string();
         assert_eq!(states, expected);

--- a/aries_vcx/src/common/proofs/prover/prover_internal.rs
+++ b/aries_vcx/src/common/proofs/prover/prover_internal.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashMap, sync::Arc};
 
+use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
 use aries_vcx_core::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind};
+use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
 use serde_json::Value;
 
 use crate::errors::error::prelude::*;
@@ -25,14 +27,13 @@ pub struct CredInfoProver {
 }
 
 pub async fn build_schemas_json_prover(
-    profile: &Arc<dyn Profile>,
+    ledger: &Arc<dyn AnoncredsLedgerRead>,
     credentials_identifiers: &Vec<CredInfoProver>,
 ) -> VcxResult<String> {
     trace!(
         "build_schemas_json_prover >>> credentials_identifiers: {:?}",
         credentials_identifiers
     );
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut rtn: Value = json!({});
 
     for cred_info in credentials_identifiers {
@@ -56,14 +57,13 @@ pub async fn build_schemas_json_prover(
 }
 
 pub async fn build_cred_defs_json_prover(
-    profile: &Arc<dyn Profile>,
+    ledger: &Arc<dyn AnoncredsLedgerRead>,
     credentials_identifiers: &Vec<CredInfoProver>,
 ) -> VcxResult<String> {
     trace!(
         "build_cred_defs_json_prover >>> credentials_identifiers: {:?}",
         credentials_identifiers
     );
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut rtn: Value = json!({});
 
     for cred_info in credentials_identifiers {
@@ -133,15 +133,14 @@ fn _get_revocation_interval(attr_name: &str, proof_req: &ProofRequestData) -> Vc
 }
 
 pub async fn build_rev_states_json(
-    profile: &Arc<dyn Profile>,
+    ledger: &Arc<dyn AnoncredsLedgerRead>,
+    anoncreds: &Arc<dyn BaseAnonCreds>,
     credentials_identifiers: &mut Vec<CredInfoProver>,
 ) -> VcxResult<String> {
     trace!(
         "build_rev_states_json >> credentials_identifiers: {:?}",
         credentials_identifiers
     );
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
-    let anoncreds = Arc::clone(profile).inject_anoncreds();
     let mut rtn: Value = json!({});
     let mut timestamps: HashMap<String, u64> = HashMap::new();
 

--- a/aries_vcx/src/common/proofs/prover/prover_internal.rs
+++ b/aries_vcx/src/common/proofs/prover/prover_internal.rs
@@ -386,8 +386,7 @@ pub mod unit_tests {
                 timestamp: None,
                 revealed: None,
             }];
-            let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
-            let err_kind = build_cred_defs_json_prover(&ledger_read, &credential_ids)
+            let err_kind = build_cred_defs_json_prover(&profile.inject_anoncreds_ledger_read(), &credential_ids)
                 .await
                 .unwrap_err()
                 .kind();
@@ -413,9 +412,8 @@ pub mod unit_tests {
                 revealed: None,
             }];
 
-            let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
             assert_eq!(
-                build_schemas_json_prover(&ledger_read, &credential_ids)
+                build_schemas_json_prover(&profile.inject_anoncreds_ledger_read(), &credential_ids)
                     .await
                     .unwrap_err()
                     .kind(),

--- a/aries_vcx/src/common/proofs/prover/prover_internal.rs
+++ b/aries_vcx/src/common/proofs/prover/prover_internal.rs
@@ -257,12 +257,16 @@ pub mod pool_tests {
     #[tokio::test]
     #[ignore]
     async fn test_pool_build_rev_states_json_empty() {
-        SetupProfile::run(|_setup| async move {
+        SetupProfile::run(|setup| async move {
             // empty vector
             assert_eq!(
-                build_rev_states_json(&_setup.profile, Vec::new().as_mut())
-                    .await
-                    .unwrap(),
+                build_rev_states_json(
+                    &setup.profile.inject_anoncreds_ledger_read(),
+                    &setup.profile.inject_anoncreds(),
+                    Vec::new().as_mut()
+                )
+                .await
+                .unwrap(),
                 "{}".to_string()
             );
 
@@ -280,9 +284,13 @@ pub mod pool_tests {
                 revealed: None,
             };
             assert_eq!(
-                build_rev_states_json(&_setup.profile, vec![cred1].as_mut())
-                    .await
-                    .unwrap(),
+                build_rev_states_json(
+                    &setup.profile.inject_anoncreds_ledger_read(),
+                    &setup.profile.inject_anoncreds(),
+                    vec![cred1].as_mut()
+                )
+                .await
+                .unwrap(),
                 "{}".to_string()
             );
         })
@@ -354,7 +362,9 @@ pub mod unit_tests {
         };
         let creds = vec![cred1, cred2];
 
-        let credential_def = build_cred_defs_json_prover(&mock_profile(), &creds).await.unwrap();
+        let credential_def = build_cred_defs_json_prover(&mock_profile().inject_anoncreds_ledger_read(), &creds)
+            .await
+            .unwrap();
         assert!(credential_def.len() > 0);
         assert!(credential_def.contains(r#""id":"V4SGRU86Z58d6TV7PBUe6f:3:CL:47:tag1","schemaId":"47""#));
     }
@@ -375,7 +385,7 @@ pub mod unit_tests {
                 timestamp: None,
                 revealed: None,
             }];
-            let err_kind = build_cred_defs_json_prover(&profile, &credential_ids)
+            let err_kind = build_cred_defs_json_prover(&profile.inject_anoncreds_ledger_read(), &credential_ids)
                 .await
                 .unwrap_err()
                 .kind();
@@ -402,7 +412,7 @@ pub mod unit_tests {
             }];
 
             assert_eq!(
-                build_schemas_json_prover(&profile, &credential_ids)
+                build_schemas_json_prover(&profile.inject_anoncreds_ledger_read(), &credential_ids)
                     .await
                     .unwrap_err()
                     .kind(),
@@ -417,7 +427,9 @@ pub mod unit_tests {
         let _setup = SetupMocks::init();
 
         assert_eq!(
-            build_schemas_json_prover(&mock_profile(), &Vec::new()).await.unwrap(),
+            build_schemas_json_prover(&mock_profile().inject_anoncreds_ledger_read(), &Vec::new())
+                .await
+                .unwrap(),
             "{}".to_string()
         );
 
@@ -447,7 +459,9 @@ pub mod unit_tests {
         };
         let creds = vec![cred1, cred2];
 
-        let schemas = build_schemas_json_prover(&mock_profile(), &creds).await.unwrap();
+        let schemas = build_schemas_json_prover(&mock_profile().inject_anoncreds_ledger_read(), &creds)
+            .await
+            .unwrap();
         assert!(schemas.len() > 0);
         assert!(schemas.contains(r#""id":"2hoqvcwupRTUNkXn6ArYzs:2:test-licence:4.4.4","name":"test-licence""#));
     }
@@ -710,9 +724,13 @@ pub mod unit_tests {
             revealed: None,
         };
         let mut cred_info = vec![cred1];
-        let states = build_rev_states_json(&mock_profile(), cred_info.as_mut())
-            .await
-            .unwrap();
+        let states = build_rev_states_json(
+            &mock_profile().inject_anoncreds_ledger_read(),
+            &mock_profile().inject_anoncreds(),
+            cred_info.as_mut(),
+        )
+        .await
+        .unwrap();
         let rev_state_json: Value = serde_json::from_str(REV_STATE_JSON).unwrap();
         let expected = json!({REV_REG_ID: {"1": rev_state_json}}).to_string();
         assert_eq!(states, expected);

--- a/aries_vcx/src/common/proofs/prover/prover_internal.rs
+++ b/aries_vcx/src/common/proofs/prover/prover_internal.rs
@@ -303,7 +303,8 @@ pub mod pool_tests {
 pub mod unit_tests {
     use aries_vcx_core::INVALID_POOL_HANDLE;
 
-    use crate::common::test_utils::{indy_handles_to_profile, mock_profile};
+    use crate::common::test_utils::mock_profile;
+    use crate::core::profile::vdrtools_profile::VdrtoolsProfile;
     use crate::utils::devsetup::*;
     use crate::utils::{
         constants::{
@@ -372,7 +373,7 @@ pub mod unit_tests {
     #[tokio::test]
     async fn test_find_credential_def_fails() {
         SetupLibraryWallet::run(|setup| async move {
-            let profile = indy_handles_to_profile(setup.wallet_handle, INVALID_POOL_HANDLE);
+            let profile = Arc::new(VdrtoolsProfile::init(setup.wallet_handle, INVALID_POOL_HANDLE));
             let credential_ids = vec![CredInfoProver {
                 referent: "1".to_string(),
                 credential_referent: "2".to_string(),
@@ -397,7 +398,7 @@ pub mod unit_tests {
     #[tokio::test]
     async fn test_find_schemas_fails() {
         SetupLibraryWallet::run(|setup| async move {
-            let profile = indy_handles_to_profile(setup.wallet_handle, INVALID_POOL_HANDLE);
+            let profile = Arc::new(VdrtoolsProfile::init(setup.wallet_handle, INVALID_POOL_HANDLE));
             let credential_ids = vec![CredInfoProver {
                 referent: "1".to_string(),
                 credential_referent: "2".to_string(),

--- a/aries_vcx/src/common/proofs/verifier/verifier.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier.rs
@@ -83,7 +83,7 @@ pub mod unit_tests {
             let revocation_details = r#"{"support_revocation":false}"#.to_string();
             let name = "Optional".to_owned();
 
-            let proof_req_json = ProofRequestData::create(&setup.profile, &name)
+            let proof_req_json = ProofRequestData::create(&setup.profile.inject_anoncreds(), &name)
                 .await
                 .unwrap()
                 .set_requested_attributes_as_string(requested_attrs)
@@ -153,7 +153,7 @@ pub mod unit_tests {
             let revocation_details = r#"{"support_revocation":true}"#.to_string();
             let name = "Optional".to_owned();
 
-            let proof_req_json = ProofRequestData::create(&setup.profile, &name)
+            let proof_req_json = ProofRequestData::create(&setup.profile.inject_anoncreds(), &name)
                 .await
                 .unwrap()
                 .set_requested_attributes_as_string(requested_attrs)
@@ -251,7 +251,7 @@ pub mod unit_tests {
             let revocation_details = r#"{"support_revocation":true}"#.to_string();
             let name = "Optional".to_owned();
 
-            let proof_req_json = ProofRequestData::create(&setup.profile, &name)
+            let proof_req_json = ProofRequestData::create(&setup.profile.inject_anoncreds(), &name)
                 .await
                 .unwrap()
                 .set_requested_attributes_as_string(requested_attrs)

--- a/aries_vcx/src/common/proofs/verifier/verifier.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier.rs
@@ -167,8 +167,10 @@ pub mod unit_tests {
 
             let (schema_id, schema_json, cred_def_id, cred_def_json, _offer, _req, _req_meta, cred_id) =
                 create_and_store_nonrevocable_credential(
-                    &setup.profile,
-                    &setup.profile,
+                    &setup.profile.inject_anoncreds(),
+                    &setup.profile.inject_anoncreds(),
+                    &setup.profile.inject_anoncreds_ledger_read(),
+                    &setup.profile.inject_anoncreds_ledger_write(),
                     &setup.institution_did,
                     utils::constants::DEFAULT_SCHEMA_ATTRS,
                 )
@@ -265,8 +267,10 @@ pub mod unit_tests {
 
             let (schema_id, schema_json, cred_def_id, cred_def_json, _offer, _req, _req_meta, cred_id) =
                 create_and_store_nonrevocable_credential(
-                    &setup.profile,
-                    &setup.profile,
+                    &setup.profile.inject_anoncreds(),
+                    &setup.profile.inject_anoncreds(),
+                    &setup.profile.inject_anoncreds_ledger_read(),
+                    &setup.profile.inject_anoncreds_ledger_write(),
                     &setup.institution_did,
                     utils::constants::DEFAULT_SCHEMA_ATTRS,
                 )
@@ -379,8 +383,15 @@ pub mod integration_tests {
     #[ignore]
     async fn test_pool_prover_verify_proof_with_predicate_success_case() {
         SetupProfile::run(|setup| async move {
-            let (schemas, cred_defs, proof_req, proof) =
-                create_proof_with_predicate(&setup.profile, &setup.profile, &setup.institution_did, true).await;
+            let (schemas, cred_defs, proof_req, proof) = create_proof_with_predicate(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+                true,
+            )
+            .await;
 
             let anoncreds = Arc::clone(&setup.profile).inject_anoncreds();
             let proof_validation = anoncreds
@@ -397,8 +408,15 @@ pub mod integration_tests {
     #[ignore]
     async fn test_pool_prover_verify_proof_with_predicate_fail_case() {
         SetupProfile::run(|setup| async move {
-            let (schemas, cred_defs, proof_req, proof) =
-                create_proof_with_predicate(&setup.profile, &setup.profile, &setup.institution_did, false).await;
+            let (schemas, cred_defs, proof_req, proof) = create_proof_with_predicate(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+                false,
+            )
+            .await;
 
             let anoncreds = Arc::clone(&setup.profile).inject_anoncreds();
             anoncreds

--- a/aries_vcx/src/common/proofs/verifier/verifier.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier.rs
@@ -365,8 +365,14 @@ pub mod integration_tests {
     #[ignore]
     async fn test_pool_prover_verify_proof() {
         SetupProfile::run(|setup| async move {
-            let (schemas, cred_defs, proof_req, proof) =
-                create_indy_proof(&setup.profile, &setup.profile, &setup.institution_did).await;
+            let (schemas, cred_defs, proof_req, proof) = create_indy_proof(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+            )
+            .await;
 
             let anoncreds = Arc::clone(&setup.profile).inject_anoncreds();
             let proof_validation = anoncreds

--- a/aries_vcx/src/common/proofs/verifier/verifier.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier.rs
@@ -118,7 +118,7 @@ pub mod unit_tests {
 
             assert_eq!(
                 validate_indy_proof(
-                    &setup.profile.inject_indy_ledger_read(),
+                    &setup.profile.inject_anoncreds_ledger_read(),
                     &setup.profile.inject_anoncreds(),
                     &prover_proof_json,
                     &proof_req_json

--- a/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
@@ -214,10 +214,10 @@ pub async fn build_rev_reg_json(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 pub mod unit_tests {
-    use crate::utils::mockdata::profile::mock_anoncreds::MockAnoncreds;
-    use crate::utils::mockdata::profile::mock_ledger::MockLedger;
     use crate::utils::constants::*;
     use crate::utils::devsetup::*;
+    use crate::utils::mockdata::profile::mock_anoncreds::MockAnoncreds;
+    use crate::utils::mockdata::profile::mock_ledger::MockLedger;
 
     use super::*;
 
@@ -239,10 +239,7 @@ pub mod unit_tests {
         };
         let credentials = vec![cred1, cred2];
         let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
-        let credential_json =
-            build_cred_defs_json_verifier(&ledger_read, &credentials)
-                .await
-                .unwrap();
+        let credential_json = build_cred_defs_json_verifier(&ledger_read, &credentials).await.unwrap();
 
         let json: Value = serde_json::from_str(CRED_DEF_JSON).unwrap();
         let expected = json!({ CRED_DEF_ID: json }).to_string();
@@ -267,9 +264,7 @@ pub mod unit_tests {
         };
         let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
         let credentials = vec![cred1, cred2];
-        let schema_json = build_schemas_json_verifier(&ledger_read, &credentials)
-            .await
-            .unwrap();
+        let schema_json = build_schemas_json_verifier(&ledger_read, &credentials).await.unwrap();
 
         let json: Value = serde_json::from_str(SCHEMA_JSON).unwrap();
         let expected = json!({ SCHEMA_ID: json }).to_string();
@@ -294,9 +289,7 @@ pub mod unit_tests {
         };
         let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
         let credentials = vec![cred1, cred2];
-        let rev_reg_defs_json = build_rev_reg_defs_json(&ledger_read, &credentials)
-            .await
-            .unwrap();
+        let rev_reg_defs_json = build_rev_reg_defs_json(&ledger_read, &credentials).await.unwrap();
 
         let json: Value = serde_json::from_str(&rev_def_json()).unwrap();
         let expected = json!({ REV_REG_ID: json }).to_string();
@@ -321,9 +314,7 @@ pub mod unit_tests {
         };
         let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
         let credentials = vec![cred1, cred2];
-        let rev_reg_json = build_rev_reg_json(&ledger_read, &credentials)
-            .await
-            .unwrap();
+        let rev_reg_json = build_rev_reg_json(&ledger_read, &credentials).await.unwrap();
 
         let json: Value = serde_json::from_str(REV_REG_JSON).unwrap();
         let expected = json!({REV_REG_ID:{"1":json}}).to_string();

--- a/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
@@ -237,9 +237,10 @@ pub mod unit_tests {
             timestamp: None,
         };
         let credentials = vec![cred1, cred2];
-        let credential_json = build_cred_defs_json_verifier(&mock_profile(), &credentials)
-            .await
-            .unwrap();
+        let credential_json =
+            build_cred_defs_json_verifier(&mock_profile().inject_anoncreds_ledger_read(), &credentials)
+                .await
+                .unwrap();
 
         let json: Value = serde_json::from_str(CRED_DEF_JSON).unwrap();
         let expected = json!({ CRED_DEF_ID: json }).to_string();
@@ -263,7 +264,7 @@ pub mod unit_tests {
             timestamp: None,
         };
         let credentials = vec![cred1, cred2];
-        let schema_json = build_schemas_json_verifier(&mock_profile(), &credentials)
+        let schema_json = build_schemas_json_verifier(&mock_profile().inject_anoncreds_ledger_read(), &credentials)
             .await
             .unwrap();
 
@@ -289,7 +290,9 @@ pub mod unit_tests {
             timestamp: None,
         };
         let credentials = vec![cred1, cred2];
-        let rev_reg_defs_json = build_rev_reg_defs_json(&mock_profile(), &credentials).await.unwrap();
+        let rev_reg_defs_json = build_rev_reg_defs_json(&mock_profile().inject_anoncreds_ledger_read(), &credentials)
+            .await
+            .unwrap();
 
         let json: Value = serde_json::from_str(&rev_def_json()).unwrap();
         let expected = json!({ REV_REG_ID: json }).to_string();
@@ -313,7 +316,9 @@ pub mod unit_tests {
             timestamp: Some(2),
         };
         let credentials = vec![cred1, cred2];
-        let rev_reg_json = build_rev_reg_json(&mock_profile(), &credentials).await.unwrap();
+        let rev_reg_json = build_rev_reg_json(&mock_profile().inject_anoncreds_ledger_read(), &credentials)
+            .await
+            .unwrap();
 
         let json: Value = serde_json::from_str(REV_REG_JSON).unwrap();
         let expected = json!({REV_REG_ID:{"1":json}}).to_string();

--- a/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
@@ -214,7 +214,8 @@ pub async fn build_rev_reg_json(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 pub mod unit_tests {
-    use crate::common::test_utils::mock_profile;
+    use crate::utils::mockdata::profile::mock_anoncreds::MockAnoncreds;
+    use crate::utils::mockdata::profile::mock_ledger::MockLedger;
     use crate::utils::constants::*;
     use crate::utils::devsetup::*;
 
@@ -237,8 +238,9 @@ pub mod unit_tests {
             timestamp: None,
         };
         let credentials = vec![cred1, cred2];
+        let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
         let credential_json =
-            build_cred_defs_json_verifier(&mock_profile().inject_anoncreds_ledger_read(), &credentials)
+            build_cred_defs_json_verifier(&ledger_read, &credentials)
                 .await
                 .unwrap();
 
@@ -263,8 +265,9 @@ pub mod unit_tests {
             rev_reg_id: None,
             timestamp: None,
         };
+        let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
         let credentials = vec![cred1, cred2];
-        let schema_json = build_schemas_json_verifier(&mock_profile().inject_anoncreds_ledger_read(), &credentials)
+        let schema_json = build_schemas_json_verifier(&ledger_read, &credentials)
             .await
             .unwrap();
 
@@ -289,8 +292,9 @@ pub mod unit_tests {
             rev_reg_id: Some(REV_REG_ID.to_string()),
             timestamp: None,
         };
+        let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
         let credentials = vec![cred1, cred2];
-        let rev_reg_defs_json = build_rev_reg_defs_json(&mock_profile().inject_anoncreds_ledger_read(), &credentials)
+        let rev_reg_defs_json = build_rev_reg_defs_json(&ledger_read, &credentials)
             .await
             .unwrap();
 
@@ -315,8 +319,9 @@ pub mod unit_tests {
             rev_reg_id: Some("id2".to_string()),
             timestamp: Some(2),
         };
+        let ledger_read: Arc<dyn AnoncredsLedgerRead> = Arc::new(MockLedger {});
         let credentials = vec![cred1, cred2];
-        let rev_reg_json = build_rev_reg_json(&mock_profile().inject_anoncreds_ledger_read(), &credentials)
+        let rev_reg_json = build_rev_reg_json(&ledger_read, &credentials)
             .await
             .unwrap();
 

--- a/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier_internal.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use aries_vcx_core::errors::error::AriesVcxCoreErrorKind;
+use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
 use serde_json;
 use serde_json::Value;
 
@@ -97,11 +98,10 @@ pub fn validate_proof_revealed_attributes(proof_json: &str) -> VcxResult<()> {
 }
 
 pub async fn build_cred_defs_json_verifier(
-    profile: &Arc<dyn Profile>,
+    ledger: &Arc<dyn AnoncredsLedgerRead>,
     credential_data: &[CredInfoVerifier],
 ) -> VcxResult<String> {
     debug!("building credential_def_json for proof validation");
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut credential_json = json!({});
 
     for cred_info in credential_data.iter() {
@@ -124,12 +124,11 @@ pub async fn build_cred_defs_json_verifier(
 }
 
 pub async fn build_schemas_json_verifier(
-    profile: &Arc<dyn Profile>,
+    ledger: &Arc<dyn AnoncredsLedgerRead>,
     credential_data: &[CredInfoVerifier],
 ) -> VcxResult<String> {
     debug!("building schemas json for proof validation");
 
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut schemas_json = json!({});
 
     for cred_info in credential_data.iter() {
@@ -153,12 +152,11 @@ pub async fn build_schemas_json_verifier(
 }
 
 pub async fn build_rev_reg_defs_json(
-    profile: &Arc<dyn Profile>,
+    ledger: &Arc<dyn AnoncredsLedgerRead>,
     credential_data: &[CredInfoVerifier],
 ) -> VcxResult<String> {
     debug!("building rev_reg_def_json for proof validation");
 
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut rev_reg_defs_json = json!({});
 
     for cred_info in credential_data.iter() {
@@ -180,10 +178,12 @@ pub async fn build_rev_reg_defs_json(
     Ok(rev_reg_defs_json.to_string())
 }
 
-pub async fn build_rev_reg_json(profile: &Arc<dyn Profile>, credential_data: &[CredInfoVerifier]) -> VcxResult<String> {
+pub async fn build_rev_reg_json(
+    ledger: &Arc<dyn AnoncredsLedgerRead>,
+    credential_data: &[CredInfoVerifier],
+) -> VcxResult<String> {
     debug!("building rev_reg_json for proof validation");
 
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
     let mut rev_regs_json = json!({});
 
     for cred_info in credential_data.iter() {

--- a/aries_vcx/src/common/test_utils.rs
+++ b/aries_vcx/src/common/test_utils.rs
@@ -37,12 +37,15 @@ pub async fn create_schema(
 
 pub async fn create_and_write_test_schema(
     anoncreds: &Arc<dyn BaseAnonCreds>,
-    ledger: &Arc<dyn AnoncredsLedgerWrite>,
+    ledger_write: &Arc<dyn AnoncredsLedgerWrite>,
     submitter_did: &str,
     attr_list: &str,
 ) -> (String, String) {
     let (schema_id, schema_json) = create_schema(anoncreds, attr_list, submitter_did).await;
-    let _response = ledger.publish_schema(&schema_json, submitter_did, None).await.unwrap();
+    let _response = ledger_write
+        .publish_schema(&schema_json, submitter_did, None)
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(1000)).await;
     (schema_id, schema_json)
 }

--- a/aries_vcx/src/common/test_utils.rs
+++ b/aries_vcx/src/common/test_utils.rs
@@ -1,9 +1,12 @@
 #![allow(clippy::unwrap_used)]
 
+use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
+use aries_vcx_core::ledger::base_ledger::{AnoncredsLedgerRead, AnoncredsLedgerWrite};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use aries_vcx_core::PoolHandle;
 use aries_vcx_core::WalletHandle;
 
@@ -12,19 +15,20 @@ use crate::common::primitives::credential_definition::CredentialDef;
 use crate::common::primitives::credential_definition::CredentialDefConfigBuilder;
 use crate::common::primitives::revocation_registry::RevocationRegistry;
 use crate::core::profile::profile::Profile;
-#[cfg(feature = "vdrtools")]
-use crate::core::profile::vdrtools_profile::VdrtoolsProfile;
 use crate::global::settings;
 use crate::utils::constants::{DEFAULT_SCHEMA_ATTRS, TAILS_DIR, TEST_TAILS_URL, TRUSTEE_SEED};
 use crate::utils::get_temp_dir_path;
 use crate::utils::mockdata::profile::mock_profile::MockProfile;
 
-pub async fn create_schema(profile: &Arc<dyn Profile>, attr_list: &str, submitter_did: &str) -> (String, String) {
+pub async fn create_schema(
+    anoncreds: &Arc<dyn BaseAnonCreds>,
+    attr_list: &str,
+    submitter_did: &str,
+) -> (String, String) {
     let data = attr_list.to_string();
     let schema_name: String = crate::utils::random::generate_random_schema_name();
     let schema_version: String = crate::utils::random::generate_random_schema_version();
 
-    let anoncreds = Arc::clone(profile).inject_anoncreds();
     anoncreds
         .issuer_create_schema(&submitter_did, &schema_name, &schema_version, &data)
         .await
@@ -32,46 +36,49 @@ pub async fn create_schema(profile: &Arc<dyn Profile>, attr_list: &str, submitte
 }
 
 pub async fn create_and_write_test_schema(
-    profile: &Arc<dyn Profile>,
+    anoncreds: &Arc<dyn BaseAnonCreds>,
+    ledger: &Arc<dyn AnoncredsLedgerWrite>,
     submitter_did: &str,
     attr_list: &str,
 ) -> (String, String) {
-    let (schema_id, schema_json) = create_schema(profile, attr_list, submitter_did).await;
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_write();
+    let (schema_id, schema_json) = create_schema(anoncreds, attr_list, submitter_did).await;
     let _response = ledger.publish_schema(&schema_json, submitter_did, None).await.unwrap();
     tokio::time::sleep(Duration::from_millis(1000)).await;
     (schema_id, schema_json)
 }
 
 pub async fn create_and_store_nonrevocable_credential_def(
-    profile: &Arc<dyn Profile>,
+    anoncreds: &Arc<dyn BaseAnonCreds>,
+    ledger_read: &Arc<dyn AnoncredsLedgerRead>,
+    ledger_write: &Arc<dyn AnoncredsLedgerWrite>,
     issuer_did: &str,
     attr_list: &str,
 ) -> (String, String, String, String, CredentialDef) {
-    let (schema_id, schema_json) = create_and_write_test_schema(profile, issuer_did, attr_list).await;
+    let (schema_id, schema_json) = create_and_write_test_schema(anoncreds, ledger_write, issuer_did, attr_list).await;
     let config = CredentialDefConfigBuilder::default()
         .issuer_did(issuer_did)
         .schema_id(&schema_id)
         .tag("1")
         .build()
         .unwrap();
-    let cred_def = CredentialDef::create(profile, "1".to_string(), config, false)
+    let cred_def = CredentialDef::create(ledger_read, anoncreds, "1".to_string(), config, false)
         .await
         .unwrap()
-        .publish_cred_def(profile)
+        .publish_cred_def(ledger_read, ledger_write)
         .await
         .unwrap();
     tokio::time::sleep(Duration::from_millis(1000)).await;
     let cred_def_id = cred_def.get_cred_def_id();
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
-    let cred_def_json = ledger.get_cred_def(&cred_def_id, None).await.unwrap();
+    let cred_def_json = ledger_read.get_cred_def(&cred_def_id, None).await.unwrap();
     (schema_id, schema_json, cred_def_id, cred_def_json, cred_def)
 }
 
 pub async fn create_and_store_credential_def(
-    profile: &Arc<dyn Profile>,
+    anoncreds: &Arc<dyn BaseAnonCreds>,
+    ledger_read: &Arc<dyn AnoncredsLedgerRead>,
+    ledger_write: &Arc<dyn AnoncredsLedgerWrite>,
     issuer_did: &str,
     attr_list: &str,
 ) -> (
@@ -83,7 +90,7 @@ pub async fn create_and_store_credential_def(
     CredentialDef,
     RevocationRegistry,
 ) {
-    let (schema_id, schema_json) = create_and_write_test_schema(profile, issuer_did, attr_list).await;
+    let (schema_id, schema_json) = create_and_write_test_schema(anoncreds, ledger_write, issuer_did, attr_list).await;
     thread::sleep(Duration::from_millis(500));
     let config = CredentialDefConfigBuilder::default()
         .issuer_did(issuer_did)
@@ -91,10 +98,10 @@ pub async fn create_and_store_credential_def(
         .tag("1")
         .build()
         .unwrap();
-    let cred_def = CredentialDef::create(profile, "1".to_string(), config, true)
+    let cred_def = CredentialDef::create(ledger_read, anoncreds, "1".to_string(), config, true)
         .await
         .unwrap()
-        .publish_cred_def(profile)
+        .publish_cred_def(ledger_read, ledger_write)
         .await
         .unwrap();
 
@@ -102,7 +109,7 @@ pub async fn create_and_store_credential_def(
     std::fs::create_dir_all(&path).unwrap();
 
     let mut rev_reg = RevocationRegistry::create(
-        profile,
+        anoncreds,
         issuer_did,
         &cred_def.get_cred_def_id(),
         path.to_str().unwrap(),
@@ -112,15 +119,14 @@ pub async fn create_and_store_credential_def(
     .await
     .unwrap();
     rev_reg
-        .publish_revocation_primitives(profile, TEST_TAILS_URL)
+        .publish_revocation_primitives(ledger_write, TEST_TAILS_URL)
         .await
         .unwrap();
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
     let cred_def_id = cred_def.get_cred_def_id();
     tokio::time::sleep(Duration::from_millis(1000)).await;
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
-    let cred_def_json = ledger.get_cred_def(&cred_def_id, None).await.unwrap();
+    let cred_def_json = ledger_read.get_cred_def(&cred_def_id, None).await.unwrap();
     (
         schema_id,
         schema_json,
@@ -133,20 +139,18 @@ pub async fn create_and_store_credential_def(
 }
 
 pub async fn create_credential_req(
-    issuer: &Arc<dyn Profile>, // FUTURE - issuer and holder seperation only needed whilst modular deps not fully implemented
-    holder: &Arc<dyn Profile>,
+    anoncreds_issuer: &Arc<dyn BaseAnonCreds>,
+    anoncreds_holder: &Arc<dyn BaseAnonCreds>,
     did: &str,
     cred_def_id: &str,
     cred_def_json: &str,
 ) -> (String, String, String) {
-    let offer = Arc::clone(issuer)
-        .inject_anoncreds()
+    let offer = anoncreds_issuer
         .issuer_create_credential_offer(cred_def_id)
         .await
         .unwrap();
     let master_secret_name = settings::DEFAULT_LINK_SECRET_ALIAS;
-    let (req, req_meta) = Arc::clone(holder)
-        .inject_anoncreds()
+    let (req, req_meta) = anoncreds_holder
         .prover_create_credential_req(&did, &offer, cred_def_json, master_secret_name)
         .await
         .unwrap();
@@ -155,8 +159,10 @@ pub async fn create_credential_req(
 
 // todo: extract create_and_store_credential_def into caller functions
 pub async fn create_and_store_credential(
-    issuer: &Arc<dyn Profile>, // FUTURE - issuer and holder seperation only needed whilst modular deps not fully implemented
-    holder: &Arc<dyn Profile>,
+    anoncreds_issuer: &Arc<dyn BaseAnonCreds>,
+    anoncreds_holder: &Arc<dyn BaseAnonCreds>,
+    ledger_read: &Arc<dyn AnoncredsLedgerRead>,
+    ledger_write: &Arc<dyn AnoncredsLedgerWrite>,
     institution_did: &str,
     attr_list: &str,
 ) -> (
@@ -174,20 +180,24 @@ pub async fn create_and_store_credential(
     RevocationRegistry,
 ) {
     let (schema_id, schema_json, cred_def_id, cred_def_json, rev_reg_id, _, rev_reg) =
-        create_and_store_credential_def(issuer, institution_did, attr_list).await;
+        create_and_store_credential_def(anoncreds_issuer, ledger_read, ledger_write, institution_did, attr_list).await;
 
-    let (offer, req, req_meta) =
-        create_credential_req(issuer, holder, institution_did, &cred_def_id, &cred_def_json).await;
+    let (offer, req, req_meta) = create_credential_req(
+        anoncreds_issuer,
+        anoncreds_holder,
+        institution_did,
+        &cred_def_id,
+        &cred_def_json,
+    )
+    .await;
 
     /* create cred */
     let credential_data = r#"{"address1": ["123 Main St"], "address2": ["Suite 3"], "city": ["Draper"], "state": ["UT"], "zip": ["84000"]}"#;
     let encoded_attributes = encode_attributes(&credential_data).unwrap();
-    let ledger = Arc::clone(issuer).inject_anoncreds_ledger_read();
-    let rev_def_json = ledger.get_rev_reg_def_json(&rev_reg_id).await.unwrap();
+    let rev_def_json = ledger_read.get_rev_reg_def_json(&rev_reg_id).await.unwrap();
     let tails_file = get_temp_dir_path(TAILS_DIR).to_str().unwrap().to_string();
 
-    let (cred, cred_rev_id, _) = Arc::clone(issuer)
-        .inject_anoncreds()
+    let (cred, cred_rev_id, _) = anoncreds_issuer
         .issuer_create_credential(
             &offer,
             &req,
@@ -198,8 +208,7 @@ pub async fn create_and_store_credential(
         .await
         .unwrap();
     /* store cred */
-    let cred_id = Arc::clone(holder)
-        .inject_anoncreds()
+    let cred_id = anoncreds_holder
         .prover_store_credential(None, &req_meta, &cred, &cred_def_json, Some(&rev_def_json))
         .await
         .unwrap();
@@ -221,28 +230,41 @@ pub async fn create_and_store_credential(
 
 // todo: extract create_and_store_nonrevocable_credential_def into caller functions
 pub async fn create_and_store_nonrevocable_credential(
-    issuer: &Arc<dyn Profile>, // FUTURE - issuer and holder seperation only needed whilst modular deps not fully implemented
-    holder: &Arc<dyn Profile>,
+    anoncreds_issuer: &Arc<dyn BaseAnonCreds>,
+    anoncreds_holder: &Arc<dyn BaseAnonCreds>,
+    ledger_read: &Arc<dyn AnoncredsLedgerRead>,
+    ledger_write: &Arc<dyn AnoncredsLedgerWrite>,
     issuer_did: &str,
     attr_list: &str,
 ) -> (String, String, String, String, String, String, String, String) {
-    let (schema_id, schema_json, cred_def_id, cred_def_json, _) =
-        create_and_store_nonrevocable_credential_def(issuer, issuer_did, attr_list).await;
+    let (schema_id, schema_json, cred_def_id, cred_def_json, _) = create_and_store_nonrevocable_credential_def(
+        anoncreds_issuer,
+        ledger_read,
+        ledger_write,
+        issuer_did,
+        attr_list,
+    )
+    .await;
 
-    let (offer, req, req_meta) = create_credential_req(issuer, holder, issuer_did, &cred_def_id, &cred_def_json).await;
+    let (offer, req, req_meta) = create_credential_req(
+        anoncreds_issuer,
+        anoncreds_holder,
+        issuer_did,
+        &cred_def_id,
+        &cred_def_json,
+    )
+    .await;
 
     /* create cred */
     let credential_data = r#"{"address1": ["123 Main St"], "address2": ["Suite 3"], "city": ["Draper"], "state": ["UT"], "zip": ["84000"]}"#;
     let encoded_attributes = encode_attributes(&credential_data).unwrap();
 
-    let (cred, _, _) = Arc::clone(issuer)
-        .inject_anoncreds()
+    let (cred, _, _) = anoncreds_issuer
         .issuer_create_credential(&offer, &req, &encoded_attributes, None, None)
         .await
         .unwrap();
     /* store cred */
-    let cred_id = Arc::clone(holder)
-        .inject_anoncreds()
+    let cred_id = anoncreds_holder
         .prover_store_credential(None, &req_meta, &cred, &cred_def_json, None)
         .await
         .unwrap();
@@ -260,12 +282,22 @@ pub async fn create_and_store_nonrevocable_credential(
 
 // FUTURE - issuer and holder seperation only needed whilst modular deps not fully implemented
 pub async fn create_indy_proof(
-    issuer: &Arc<dyn Profile>,
-    prover: &Arc<dyn Profile>,
+    anoncreds_issuer: &Arc<dyn BaseAnonCreds>,
+    anoncreds_holder: &Arc<dyn BaseAnonCreds>,
+    ledger_read: &Arc<dyn AnoncredsLedgerRead>,
+    ledger_write: &Arc<dyn AnoncredsLedgerWrite>,
     did: &str,
 ) -> (String, String, String, String) {
     let (schema_id, schema_json, cred_def_id, cred_def_json, _offer, _req, _req_meta, cred_id) =
-        create_and_store_nonrevocable_credential(issuer, prover, &did, DEFAULT_SCHEMA_ATTRS).await;
+        create_and_store_nonrevocable_credential(
+            anoncreds_issuer,
+            anoncreds_holder,
+            ledger_read,
+            ledger_write,
+            &did,
+            DEFAULT_SCHEMA_ATTRS,
+        )
+        .await;
     let proof_req = json!({
        "nonce":"123432421212",
        "name":"proof_req_1",
@@ -310,14 +342,12 @@ pub async fn create_indy_proof(
     })
     .to_string();
 
-    let anoncreds = Arc::clone(prover).inject_anoncreds();
-
-    anoncreds
+    anoncreds_holder
         .prover_get_credentials_for_proof_req(&proof_req)
         .await
         .unwrap();
 
-    let proof = anoncreds
+    let proof = anoncreds_holder
         .prover_create_proof(
             &proof_req,
             &requested_credentials_json,
@@ -332,13 +362,23 @@ pub async fn create_indy_proof(
 }
 
 pub async fn create_proof_with_predicate(
-    issuer: &Arc<dyn Profile>, // FUTURE - issuer and holder seperation only needed whilst modular deps not fully implemented
-    prover: &Arc<dyn Profile>,
+    anoncreds_issuer: &Arc<dyn BaseAnonCreds>,
+    anoncreds_holder: &Arc<dyn BaseAnonCreds>,
+    ledger_read: &Arc<dyn AnoncredsLedgerRead>,
+    ledger_write: &Arc<dyn AnoncredsLedgerWrite>,
     did: &str,
     include_predicate_cred: bool,
 ) -> (String, String, String, String) {
     let (schema_id, schema_json, cred_def_id, cred_def_json, _offer, _req, _req_meta, cred_id) =
-        create_and_store_nonrevocable_credential(issuer, prover, &did, DEFAULT_SCHEMA_ATTRS).await;
+        create_and_store_nonrevocable_credential(
+            anoncreds_issuer,
+            anoncreds_holder,
+            ledger_read,
+            ledger_write,
+            &did,
+            DEFAULT_SCHEMA_ATTRS,
+        )
+        .await;
 
     let proof_req = json!({
        "nonce":"123432421212",
@@ -399,14 +439,12 @@ pub async fn create_proof_with_predicate(
     })
     .to_string();
 
-    let anoncreds = Arc::clone(prover).inject_anoncreds();
-
-    anoncreds
+    anoncreds_holder
         .prover_get_credentials_for_proof_req(&proof_req)
         .await
         .unwrap();
 
-    let proof = anoncreds
+    let proof = anoncreds_holder
         .prover_create_proof(
             &proof_req,
             &requested_credentials_json,
@@ -420,9 +458,8 @@ pub async fn create_proof_with_predicate(
     (schemas, cred_defs, proof_req, proof)
 }
 
-pub async fn create_trustee_key(profile: &Arc<dyn Profile>) -> String {
-    Arc::clone(profile)
-        .inject_wallet()
+pub async fn create_trustee_key(wallet: &Arc<dyn BaseWallet>) -> String {
+    wallet
         .create_and_store_my_did(Some(TRUSTEE_SEED), None)
         .await
         .unwrap()
@@ -430,23 +467,12 @@ pub async fn create_trustee_key(profile: &Arc<dyn Profile>) -> String {
 }
 
 // TODO - FUTURE - should be a standalone method within wallet - not depending on create did
-pub async fn create_key(profile: &Arc<dyn Profile>) -> String {
+pub async fn create_key(wallet: &Arc<dyn BaseWallet>) -> String {
     let seed: String = crate::utils::random::generate_random_seed();
-    Arc::clone(profile)
-        .inject_wallet()
-        .create_and_store_my_did(Some(&seed), None)
-        .await
-        .unwrap()
-        .1
+    wallet.create_and_store_my_did(Some(&seed), None).await.unwrap().1
 }
 
 // used for mocking profile
 pub fn mock_profile() -> Arc<dyn Profile> {
     Arc::new(MockProfile {})
-}
-
-// TODO - FUTURE - should only be used for quick mock setups, should be removable after full detachment from vdrtools dep
-#[cfg(feature = "vdrtools")]
-pub fn indy_handles_to_profile(wallet_handle: WalletHandle, pool_handle: PoolHandle) -> Arc<dyn Profile> {
-    Arc::new(VdrtoolsProfile::init(wallet_handle, pool_handle))
 }

--- a/aries_vcx/src/common/test_utils.rs
+++ b/aries_vcx/src/common/test_utils.rs
@@ -474,8 +474,3 @@ pub async fn create_key(wallet: &Arc<dyn BaseWallet>) -> String {
     let seed: String = crate::utils::random::generate_random_seed();
     wallet.create_and_store_my_did(Some(&seed), None).await.unwrap().1
 }
-
-// used for mocking profile
-pub fn mock_profile() -> Arc<dyn Profile> {
-    Arc::new(MockProfile {})
-}

--- a/aries_vcx/src/handlers/issuance/holder.rs
+++ b/aries_vcx/src/handlers/issuance/holder.rs
@@ -169,7 +169,7 @@ impl Holder {
         notification: Revoke,
     ) -> VcxResult<()> {
         if self.holder_sm.is_revokable(profile).await? {
-            let send_message = connection.send_message_closure(profile).await?;
+            let send_message = connection.send_message_closure(profile.inject_wallet()).await?;
             // TODO: Store to remember notification was received along with details
             RevocationNotificationReceiver::build(self.get_rev_reg_id()?, self.get_cred_rev_id(profile).await?)
                 .handle_revocation_notification(notification, send_message)
@@ -207,7 +207,7 @@ impl Holder {
         if self.is_terminal_state() {
             return Ok(self.get_state());
         }
-        let send_message = connection.send_message_closure(profile).await?;
+        let send_message = connection.send_message_closure(profile.inject_wallet()).await?;
 
         let messages = connection.get_messages(agency_client).await?;
         if let Some((uid, msg)) = self.find_message_to_handle(messages) {

--- a/aries_vcx/src/handlers/issuance/issuer.rs
+++ b/aries_vcx/src/handlers/issuance/issuer.rs
@@ -311,7 +311,7 @@ impl Issuer {
         if self.is_terminal_state() {
             return Ok(self.get_state());
         }
-        let send_message = connection.send_message_closure(profile).await?;
+        let send_message = connection.send_message_closure(profile.inject_wallet()).await?;
         let messages = connection.get_messages(agency_client).await?;
         if let Some((uid, msg)) = self.find_message_to_handle(messages) {
             self.step(profile, msg.into(), Some(send_message)).await?;

--- a/aries_vcx/src/handlers/proof_presentation/prover.rs
+++ b/aries_vcx/src/handlers/proof_presentation/prover.rs
@@ -237,7 +237,7 @@ impl Prover {
         if !self.progressable_by_message() {
             return Ok(self.get_state());
         }
-        let send_message = connection.send_message_closure(profile).await?;
+        let send_message = connection.send_message_closure(profile.inject_wallet()).await?;
 
         let messages = connection.get_messages(agency_client).await?;
         if let Some((uid, msg)) = self.find_message_to_handle(messages) {

--- a/aries_vcx/src/handlers/proof_presentation/prover.rs
+++ b/aries_vcx/src/handlers/proof_presentation/prover.rs
@@ -3,6 +3,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use agency_client::agency_client::AgencyClient;
+use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
+use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
+use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use messages::msg_fields::protocols::present_proof::ack::AckPresentation;
 use messages::msg_fields::protocols::present_proof::present::Presentation;
 use messages::msg_fields::protocols::present_proof::propose::PresentationPreview;
@@ -51,10 +54,9 @@ impl Prover {
         self.prover_sm.get_presentation_status()
     }
 
-    pub async fn retrieve_credentials(&self, profile: &Arc<dyn Profile>) -> VcxResult<RetrievedCredentials> {
+    pub async fn retrieve_credentials(&self, anoncreds: &Arc<dyn BaseAnonCreds>) -> VcxResult<RetrievedCredentials> {
         trace!("Prover::retrieve_credentials >>>");
         let presentation_request = self.presentation_request_data()?;
-        let anoncreds = Arc::clone(profile).inject_anoncreds();
         let json_retrieved_credentials = anoncreds
             .prover_get_credentials_for_proof_req(&presentation_request)
             .await?;
@@ -64,7 +66,8 @@ impl Prover {
 
     pub async fn generate_presentation(
         &mut self,
-        profile: &Arc<dyn Profile>,
+        ledger: &Arc<dyn AnoncredsLedgerRead>,
+        anoncreds: &Arc<dyn BaseAnonCreds>,
         credentials: SelectedCredentials,
         self_attested_attrs: HashMap<String, String>,
     ) -> VcxResult<()> {
@@ -76,7 +79,7 @@ impl Prover {
         self.prover_sm = self
             .prover_sm
             .clone()
-            .generate_presentation(profile, credentials, self_attested_attrs)
+            .generate_presentation(ledger, anoncreds, credentials, self_attested_attrs)
             .await?;
         Ok(())
     }
@@ -127,12 +130,13 @@ impl Prover {
 
     pub async fn handle_message(
         &mut self,
-        profile: &Arc<dyn Profile>,
+        ledger: &Arc<dyn AnoncredsLedgerRead>,
+        anoncreds: &Arc<dyn BaseAnonCreds>,
         message: ProverMessages,
         send_message: Option<SendClosure>,
     ) -> VcxResult<()> {
         trace!("Prover::handle_message >>> message: {:?}", message);
-        self.step(profile, message, send_message).await
+        self.step(ledger, anoncreds, message, send_message).await
     }
 
     pub fn presentation_request_data(&self) -> VcxResult<String> {
@@ -173,11 +177,16 @@ impl Prover {
 
     pub async fn step(
         &mut self,
-        profile: &Arc<dyn Profile>,
+        ledger: &Arc<dyn AnoncredsLedgerRead>,
+        anoncreds: &Arc<dyn BaseAnonCreds>,
         message: ProverMessages,
         send_message: Option<SendClosure>,
     ) -> VcxResult<()> {
-        self.prover_sm = self.prover_sm.clone().step(profile, message, send_message).await?;
+        self.prover_sm = self
+            .prover_sm
+            .clone()
+            .step(ledger, anoncreds, message, send_message)
+            .await?;
         Ok(())
     }
 
@@ -229,7 +238,9 @@ impl Prover {
 
     pub async fn update_state(
         &mut self,
-        profile: &Arc<dyn Profile>,
+        ledger: &Arc<dyn AnoncredsLedgerRead>,
+        anoncreds: &Arc<dyn BaseAnonCreds>,
+        wallet: &Arc<dyn BaseWallet>,
         agency_client: &AgencyClient,
         connection: &MediatedConnection,
     ) -> VcxResult<ProverState> {
@@ -237,11 +248,11 @@ impl Prover {
         if !self.progressable_by_message() {
             return Ok(self.get_state());
         }
-        let send_message = connection.send_message_closure(profile.inject_wallet()).await?;
+        let send_message = connection.send_message_closure(Arc::clone(wallet)).await?;
 
         let messages = connection.get_messages(agency_client).await?;
         if let Some((uid, msg)) = self.find_message_to_handle(messages) {
-            self.step(profile, msg.into(), Some(send_message)).await?;
+            self.step(ledger, anoncreds, msg.into(), Some(send_message)).await?;
             connection.update_message_status(&uid, agency_client).await?;
         }
         Ok(self.get_state())

--- a/aries_vcx/src/handlers/proof_presentation/verifier.rs
+++ b/aries_vcx/src/handlers/proof_presentation/verifier.rs
@@ -236,10 +236,6 @@ impl Verifier {
 
 //     use super::*;
 
-//     fn _dummy_profile() -> Arc<dyn Profile> {
-//         Arc::new(VdrtoolsProfile::new(INVALID_WALLET_HANDLE, INVALID_POOL_HANDLE))
-//     }
-
 //     async fn _verifier() -> Verifier {
 //         let presentation_request_data = PresentationRequestData::create(&_dummy_profile(), "1")
 //             .await

--- a/aries_vcx/src/protocols/connection/invitee/mod.rs
+++ b/aries_vcx/src/protocols/connection/invitee/mod.rs
@@ -2,6 +2,7 @@ pub mod states;
 
 use std::sync::Arc;
 
+use aries_vcx_core::ledger::base_ledger::IndyLedgerRead;
 use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use chrono::Utc;
 use diddoc_legacy::aries::diddoc::AriesDidDoc;
@@ -60,12 +61,12 @@ impl InviteeConnection<Initial> {
     /// Will error out if a DidDoc could not be resolved from the [`Invitation`].
     pub async fn accept_invitation(
         self,
-        profile: &Arc<dyn Profile>,
+        indy_ledger: &Arc<dyn IndyLedgerRead>,
         invitation: AnyInvitation,
     ) -> VcxResult<InviteeConnection<Invited>> {
         trace!("Connection::accept_invitation >>> invitation: {:?}", &invitation);
 
-        let did_doc = into_did_doc(profile, &invitation).await?;
+        let did_doc = into_did_doc(indy_ledger, &invitation).await?;
         let state = Invited::new(did_doc, invitation);
 
         // Convert to `InvitedState`

--- a/aries_vcx/src/protocols/issuance/holder/states/offer_received.rs
+++ b/aries_vcx/src/protocols/issuance/holder/states/offer_received.rs
@@ -1,3 +1,4 @@
+use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
 use std::sync::Arc;
 
 use crate::core::profile::profile::Profile;
@@ -45,7 +46,7 @@ impl OfferReceivedState {
         Ok(serde_json::Value::Object(new_map).to_string())
     }
 
-    pub async fn is_revokable(&self, profile: &Arc<dyn Profile>) -> VcxResult<bool> {
+    pub async fn is_revokable(&self, ledger: &Arc<dyn AnoncredsLedgerRead>) -> VcxResult<bool> {
         let offer = self.get_attachment()?;
 
         let cred_def_id = parse_cred_def_id_from_cred_offer(&offer).map_err(|err| {
@@ -57,7 +58,7 @@ impl OfferReceivedState {
                 ),
             )
         })?;
-        is_cred_def_revokable(profile, &cred_def_id).await
+        is_cred_def_revokable(ledger, &cred_def_id).await
     }
 
     pub fn get_attachment(&self) -> VcxResult<String> {

--- a/aries_vcx/src/protocols/issuance/holder/states/proposal_sent.rs
+++ b/aries_vcx/src/protocols/issuance/holder/states/proposal_sent.rs
@@ -1,3 +1,4 @@
+use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
 use std::sync::Arc;
 
 use messages::msg_fields::protocols::cred_issuance::propose_credential::ProposeCredential;
@@ -16,7 +17,7 @@ impl ProposalSentState {
         Self { credential_proposal }
     }
 
-    pub async fn is_revokable(&self, profile: &Arc<dyn Profile>) -> VcxResult<bool> {
-        is_cred_def_revokable(profile, &self.credential_proposal.content.cred_def_id).await
+    pub async fn is_revokable(&self, ledger: &Arc<dyn AnoncredsLedgerRead>) -> VcxResult<bool> {
+        is_cred_def_revokable(ledger, &self.credential_proposal.content.cred_def_id).await
     }
 }

--- a/aries_vcx/src/protocols/issuance/mod.rs
+++ b/aries_vcx/src/protocols/issuance/mod.rs
@@ -1,3 +1,5 @@
+use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
+use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
 use std::sync::Arc;
 
 use crate::core::profile::profile::Profile;
@@ -22,8 +24,7 @@ pub fn verify_thread_id(thread_id: &str, message: &CredentialIssuanceAction) -> 
     Ok(())
 }
 
-pub async fn is_cred_def_revokable(profile: &Arc<dyn Profile>, cred_def_id: &str) -> VcxResult<bool> {
-    let ledger = Arc::clone(profile).inject_anoncreds_ledger_read();
+pub async fn is_cred_def_revokable(ledger: &Arc<dyn AnoncredsLedgerRead>, cred_def_id: &str) -> VcxResult<bool> {
     let cred_def_json = ledger.get_cred_def(cred_def_id, None).await.map_err(|err| {
         AriesVcxError::from_msg(
             AriesVcxErrorKind::InvalidLedgerResponse,

--- a/aries_vcx/src/protocols/mediated_connection/inviter/state_machine.rs
+++ b/aries_vcx/src/protocols/mediated_connection/inviter/state_machine.rs
@@ -228,11 +228,11 @@ impl SmConnectionInviter {
         Ok(Self { state, ..self })
     }
 
-    pub async fn handle_connection_request(
+    pub async fn handle_connection_request<'a>(
         self,
-        wallet: Arc<dyn BaseWallet>,
+        wallet: &'a Arc<dyn BaseWallet>,
         request: Request,
-        new_pairwise_info: &PairwiseInfo,
+        new_pairwise_info: &'a PairwiseInfo,
         new_routing_keys: Vec<String>,
         new_service_endpoint: Url,
         send_message: SendClosureConnection,
@@ -276,7 +276,7 @@ impl SmConnectionInviter {
 
                 let signed_response = self
                     .build_response(
-                        &wallet,
+                        wallet,
                         thread_id.clone(),
                         new_pairwise_info,
                         new_routing_keys,

--- a/aries_vcx/src/protocols/proof_presentation/prover/states/presentation_request_received.rs
+++ b/aries_vcx/src/protocols/proof_presentation/prover/states/presentation_request_received.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
+use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
 use messages::msg_fields::protocols::present_proof::present::Presentation;
 use messages::msg_fields::protocols::present_proof::request::{
     RequestPresentation, RequestPresentationContent, RequestPresentationDecorators,
@@ -41,14 +43,22 @@ impl PresentationRequestReceived {
 
     pub async fn build_presentation(
         &self,
-        profile: &Arc<dyn Profile>,
+        ledger: &Arc<dyn AnoncredsLedgerRead>,
+        anoncreds: &Arc<dyn BaseAnonCreds>,
         credentials: &SelectedCredentials,
         self_attested_attrs: &HashMap<String, String>,
     ) -> VcxResult<String> {
         let proof_req_data_json =
             get_attach_as_string!(&self.presentation_request.content.request_presentations_attach);
 
-        generate_indy_proof(profile, credentials, self_attested_attrs, &proof_req_data_json).await
+        generate_indy_proof(
+            ledger,
+            anoncreds,
+            credentials,
+            self_attested_attrs,
+            &proof_req_data_json,
+        )
+        .await
     }
 }
 

--- a/aries_vcx/src/protocols/proof_presentation/verifier/states/presentation_request_sent.rs
+++ b/aries_vcx/src/protocols/proof_presentation/verifier/states/presentation_request_sent.rs
@@ -1,3 +1,5 @@
+use aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
+use aries_vcx_core::ledger::base_ledger::AnoncredsLedgerRead;
 use std::sync::Arc;
 
 use messages::msg_fields::protocols::present_proof::present::Presentation;
@@ -20,7 +22,8 @@ pub struct PresentationRequestSentState {
 impl PresentationRequestSentState {
     pub async fn verify_presentation(
         &self,
-        profile: &Arc<dyn Profile>,
+        ledger: &Arc<dyn AnoncredsLedgerRead>,
+        anoncreds: &Arc<dyn BaseAnonCreds>,
         presentation: &Presentation,
         thread_id: &str,
     ) -> VcxResult<()> {
@@ -37,7 +40,7 @@ impl PresentationRequestSentState {
         let proof_json = get_attach_as_string!(&presentation.content.presentations_attach);
         let proof_req_json = get_attach_as_string!(&self.presentation_request.content.request_presentations_attach);
 
-        let valid = validate_indy_proof(profile, &proof_json, &proof_req_json).await?;
+        let valid = validate_indy_proof(ledger, anoncreds, &proof_json, &proof_req_json).await?;
 
         if !valid {
             return Err(AriesVcxError::from_msg(

--- a/aries_vcx/tests/test_agency.rs
+++ b/aries_vcx/tests/test_agency.rs
@@ -36,16 +36,16 @@ mod integration_tests {
             let (alice_to_faber, faber_to_alice) = create_connected_connections(&mut consumer, &mut institution).await;
 
             faber_to_alice
-                .send_generic_message(&institution.profile, "Hello Alice")
+                .send_generic_message(&institution.profile.inject_wallet(), "Hello Alice")
                 .await
                 .unwrap();
             faber_to_alice
-                .send_generic_message(&institution.profile, "How are you Alice?")
+                .send_generic_message(&institution.profile.inject_wallet(), "How are you Alice?")
                 .await
                 .unwrap();
 
             alice_to_faber
-                .send_generic_message(&consumer.profile, "Hello Faber")
+                .send_generic_message(&institution.profile.inject_wallet(), "Hello Faber")
                 .await
                 .unwrap();
 
@@ -207,7 +207,7 @@ mod integration_tests {
                 let basic_message = r#"Hi there"#;
                 faber
                     .connection
-                    .send_generic_message(&faber.profile, basic_message)
+                    .send_generic_message(&faber.profile.inject_wallet(), basic_message)
                     .await
                     .unwrap();
 
@@ -291,11 +291,11 @@ mod integration_tests {
                 create_connected_connections(&mut consumer2, &mut institution).await;
 
             consumer1_to_institution
-                .send_generic_message(&consumer1.profile, "Hello Institution from consumer1")
+                .send_generic_message(&consumer1.profile.inject_wallet(), "Hello Institution from consumer1")
                 .await
                 .unwrap();
             consumer2_to_institution
-                .send_generic_message(&consumer2.profile, "Hello Institution from consumer2")
+                .send_generic_message(&consumer2.profile.inject_wallet(), "Hello Institution from consumer2")
                 .await
                 .unwrap();
 
@@ -344,15 +344,15 @@ mod integration_tests {
             let (alice_to_faber, faber_to_alice) = create_connected_connections(&mut alice, &mut faber).await;
 
             faber_to_alice
-                .send_generic_message(&faber.profile, "Hello 1")
+                .send_generic_message(&faber.profile.inject_wallet(), "Hello 1")
                 .await
                 .unwrap();
             faber_to_alice
-                .send_generic_message(&faber.profile, "Hello 2")
+                .send_generic_message(&faber.profile.inject_wallet(), "Hello 2")
                 .await
                 .unwrap();
             faber_to_alice
-                .send_generic_message(&faber.profile, "Hello 3")
+                .send_generic_message(&faber.profile.inject_wallet(), "Hello 3")
                 .await
                 .unwrap();
 
@@ -424,11 +424,11 @@ mod integration_tests {
                 create_connected_connections(&mut consumer2, &mut institution).await;
 
             consumer1_to_institution
-                .send_generic_message(&consumer1.profile, "Hello Institution from consumer1")
+                .send_generic_message(&consumer1.profile.inject_wallet(), "Hello Institution from consumer1")
                 .await
                 .unwrap();
             consumer2_to_institution
-                .send_generic_message(&consumer2.profile, "Hello Institution from consumer2")
+                .send_generic_message(&consumer2.profile.inject_wallet(), "Hello Institution from consumer2")
                 .await
                 .unwrap();
 

--- a/aries_vcx/tests/test_agency.rs
+++ b/aries_vcx/tests/test_agency.rs
@@ -45,7 +45,7 @@ mod integration_tests {
                 .unwrap();
 
             alice_to_faber
-                .send_generic_message(&institution.profile.inject_wallet(), "Hello Faber")
+                .send_generic_message(&consumer.profile.inject_wallet(), "Hello Faber")
                 .await
                 .unwrap();
 

--- a/aries_vcx/tests/test_agency.rs
+++ b/aries_vcx/tests/test_agency.rs
@@ -145,9 +145,11 @@ mod integration_tests {
 
             info!("test_connection_send_works:: Test if Send Message works");
             {
-                faber.connection.send_message_closure(&faber.profile).await.unwrap()(AriesMessage::from(
-                    message.clone(),
-                ))
+                faber
+                    .connection
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap()(AriesMessage::from(message.clone()))
                 .await
                 .unwrap();
             }
@@ -249,9 +251,11 @@ mod integration_tests {
 
                 let credential_offer = OfferCredential::with_decorators(id, content, decorators);
 
-                faber.connection.send_message_closure(&faber.profile).await.unwrap()(AriesMessage::from(
-                    credential_offer,
-                ))
+                faber
+                    .connection
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap()(AriesMessage::from(credential_offer))
                 .await
                 .unwrap();
 

--- a/aries_vcx/tests/test_connection.rs
+++ b/aries_vcx/tests/test_connection.rs
@@ -166,7 +166,7 @@ mod integration_tests {
                 .unwrap();
             conn_receiver
                 .send_generic_message(
-                    &institution.profile.inject_wallet(),
+                    &consumer.profile.inject_wallet(),
                     "Hello oob sender, from oob receiver",
                 )
                 .await
@@ -212,7 +212,7 @@ mod integration_tests {
             assert!(conn.is_some());
             conn.unwrap()
                 .send_generic_message(
-                    &institution.profile.inject_wallet(),
+                    &consumer.profile.inject_wallet(),
                     "Hello oob sender, from oob receiver",
                 )
                 .await

--- a/aries_vcx/tests/test_connection.rs
+++ b/aries_vcx/tests/test_connection.rs
@@ -45,7 +45,7 @@ mod integration_tests {
                 create_connected_connections_via_public_invite(&mut consumer, &mut institution).await;
 
             institution_to_consumer
-                .send_generic_message(&institution.profile, "Hello Alice, Faber here")
+                .send_generic_message(&institution.profile.inject_wallet(), "Hello Alice, Faber here")
                 .await
                 .unwrap();
 
@@ -81,19 +81,28 @@ mod integration_tests {
                 .append_a2a_message(AriesMessage::from(request_sender.clone()))
                 .unwrap();
             let invitation = AnyInvitation::Oob(oob_sender.oob.clone());
-            let ddo = into_did_doc(&consumer.profile, &invitation).await.unwrap();
+            let ddo = into_did_doc(&consumer.profile.inject_indy_ledger_read(), &invitation)
+                .await
+                .unwrap();
             let oob_msg = AriesMessage::from(oob_sender.oob.clone());
 
             let oob_receiver = OutOfBandReceiver::create_from_a2a_msg(&oob_msg).unwrap();
             let conns = vec![];
-            let conn = oob_receiver.connection_exists(&consumer.profile, &conns).await.unwrap();
+            let conn = oob_receiver
+                .connection_exists(&consumer.profile.inject_indy_ledger_read(), &conns)
+                .await
+                .unwrap();
             assert!(conn.is_none());
             let mut conn_receiver = oob_receiver
-                .build_connection(&consumer.profile, &consumer.agency_client, ddo, true)
+                .build_connection(&consumer.profile.inject_wallet(), &consumer.agency_client, ddo, true)
                 .await
                 .unwrap();
             conn_receiver
-                .connect(&consumer.profile, &consumer.agency_client, _send_message(sender))
+                .connect(
+                    &consumer.profile.inject_wallet(),
+                    &consumer.agency_client,
+                    _send_message(sender),
+                )
                 .await
                 .unwrap();
             assert_eq!(
@@ -122,12 +131,18 @@ mod integration_tests {
                 create_connected_connections(&mut consumer, &mut institution).await;
 
             let conns = vec![&conn_receiver, &conn_receiver_pw1, &conn_receiver_pw2];
-            let conn = oob_receiver.connection_exists(&consumer.profile, &conns).await.unwrap();
+            let conn = oob_receiver
+                .connection_exists(&consumer.profile.inject_indy_ledger_read(), &conns)
+                .await
+                .unwrap();
             assert!(conn.is_some());
             assert!(*conn.unwrap() == conn_receiver);
 
             let conns = vec![&conn_receiver_pw1, &conn_receiver_pw2];
-            let conn = oob_receiver.connection_exists(&consumer.profile, &conns).await.unwrap();
+            let conn = oob_receiver
+                .connection_exists(&consumer.profile.inject_indy_ledger_read(), &conns)
+                .await
+                .unwrap();
             assert!(conn.is_none());
 
             let a2a_msg = oob_receiver.extract_a2a_message().unwrap().unwrap();
@@ -143,11 +158,17 @@ mod integration_tests {
             }
 
             conn_sender
-                .send_generic_message(&institution.profile, "Hello oob receiver, from oob sender")
+                .send_generic_message(
+                    &institution.profile.inject_wallet(),
+                    "Hello oob receiver, from oob sender",
+                )
                 .await
                 .unwrap();
             conn_receiver
-                .send_generic_message(&consumer.profile, "Hello oob sender, from oob receiver")
+                .send_generic_message(
+                    &institution.profile.inject_wallet(),
+                    "Hello oob sender, from oob receiver",
+                )
                 .await
                 .unwrap();
             let sender_msgs = conn_sender
@@ -184,10 +205,16 @@ mod integration_tests {
 
             let oob_receiver = OutOfBandReceiver::create_from_a2a_msg(&oob_msg).unwrap();
             let conns = vec![&consumer_to_institution];
-            let conn = oob_receiver.connection_exists(&consumer.profile, &conns).await.unwrap();
+            let conn = oob_receiver
+                .connection_exists(&consumer.profile.inject_indy_ledger_read(), &conns)
+                .await
+                .unwrap();
             assert!(conn.is_some());
             conn.unwrap()
-                .send_generic_message(&consumer.profile, "Hello oob sender, from oob receiver")
+                .send_generic_message(
+                    &institution.profile.inject_wallet(),
+                    "Hello oob sender, from oob receiver",
+                )
                 .await
                 .unwrap();
 
@@ -221,12 +248,15 @@ mod integration_tests {
 
             let oob_receiver = OutOfBandReceiver::create_from_a2a_msg(&oob_msg).unwrap();
             let conns = vec![&consumer_to_institution];
-            let conn = oob_receiver.connection_exists(&consumer.profile, &conns).await.unwrap();
+            let conn = oob_receiver
+                .connection_exists(&consumer.profile.inject_indy_ledger_read(), &conns)
+                .await
+                .unwrap();
             assert!(conn.is_some());
             let receiver_oob_id = oob_receiver.get_id();
             let receiver_msg = serde_json::to_string(&AriesMessage::from(oob_receiver.oob.clone())).unwrap();
             conn.unwrap()
-                .send_handshake_reuse(&consumer.profile, &receiver_msg)
+                .send_handshake_reuse(&consumer.profile.inject_wallet(), &receiver_msg)
                 .await
                 .unwrap();
 
@@ -259,7 +289,7 @@ mod integration_tests {
             institution_to_consumer
                 .handle_message(
                     AriesMessage::OutOfBand(OutOfBand::HandshakeReuse(reuse_msg.clone())),
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
                 )
                 .await
                 .unwrap();
@@ -288,7 +318,7 @@ mod integration_tests {
                 }
             };
             consumer_to_institution
-                .find_and_handle_message(&consumer.profile, &consumer.agency_client)
+                .find_and_handle_message(&consumer.profile.inject_wallet(), &consumer.agency_client)
                 .await
                 .unwrap();
             assert_eq!(

--- a/aries_vcx/tests/test_connection.rs
+++ b/aries_vcx/tests/test_connection.rs
@@ -165,10 +165,7 @@ mod integration_tests {
                 .await
                 .unwrap();
             conn_receiver
-                .send_generic_message(
-                    &consumer.profile.inject_wallet(),
-                    "Hello oob sender, from oob receiver",
-                )
+                .send_generic_message(&consumer.profile.inject_wallet(), "Hello oob sender, from oob receiver")
                 .await
                 .unwrap();
             let sender_msgs = conn_sender
@@ -211,10 +208,7 @@ mod integration_tests {
                 .unwrap();
             assert!(conn.is_some());
             conn.unwrap()
-                .send_generic_message(
-                    &consumer.profile.inject_wallet(),
-                    "Hello oob sender, from oob receiver",
-                )
+                .send_generic_message(&consumer.profile.inject_wallet(), "Hello oob sender, from oob receiver")
                 .await
                 .unwrap();
 

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -472,7 +472,8 @@ mod integration_tests {
             // verifier receives the presentation
             verifier
                 .verify_presentation(
-                    &setup.profile,
+                    &setup.profile.inject_anoncreds_ledger_read(),
+                    &setup.profile.inject_anoncreds(),
                     presentation,
                     Box::new(|_: AriesMessage| Box::pin(async { Ok(()) })),
                 )
@@ -568,7 +569,9 @@ mod tests {
             info!("test_proof_should_be_validated :: verifier :: going to verify proof");
             verifier
                 .update_state(
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
                     &institution.agency_client,
                     &institution_to_consumer,
                 )
@@ -625,7 +628,9 @@ mod tests {
             info!("test_proof_with_predicates_should_be_validated :: verifier :: going to verify proof");
             verifier
                 .update_state(
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
                     &institution.agency_client,
                     &institution_to_consumer,
                 )
@@ -744,7 +749,8 @@ mod tests {
                 .await;
             prover_select_credentials_and_send_proof(&mut consumer1, &consumer1_to_verifier, None, None).await;
             proof_verifier
-                .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer1)
+                .update_state(
+                    &institution.profile.inject_wallet(), &institution.profile.inject_anoncreds_ledger_read(), &institution.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer1)
                 .await
                 .unwrap();
             assert_eq!(
@@ -763,7 +769,8 @@ mod tests {
                 .await;
             prover_select_credentials_and_send_proof(&mut consumer2, &consumer2_to_verifier, None, None).await;
             proof_verifier
-                .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer2)
+                .update_state(
+                    &institution.profile.inject_wallet(), &institution.profile.inject_anoncreds_ledger_read(), &institution.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer2)
                 .await
                 .unwrap();
             assert_eq!(
@@ -799,7 +806,13 @@ mod tests {
             .await;
             prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, request_name1, None).await;
             proof_verifier
-                .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+                .update_state(
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
+                    &verifier.agency_client,
+                    &verifier_to_consumer,
+                )
                 .await
                 .unwrap();
             assert_eq!(
@@ -818,7 +831,13 @@ mod tests {
             .await;
             prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, request_name2, None).await;
             proof_verifier
-                .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+                .update_state(
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
+                    &verifier.agency_client,
+                    &verifier_to_consumer,
+                )
                 .await
                 .unwrap();
             assert_eq!(
@@ -867,7 +886,9 @@ mod tests {
             prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_institution, request_name1, None).await;
             verifier
                 .update_state(
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
                     &institution.agency_client,
                     &institution_to_consumer,
                 )
@@ -890,7 +911,9 @@ mod tests {
             prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_institution, request_name2, None).await;
             verifier
                 .update_state(
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
                     &institution.agency_client,
                     &institution_to_consumer,
                 )
@@ -1006,7 +1029,13 @@ mod tests {
 
             info!("test_real_proof :: AS INSTITUTION VALIDATE PROOF");
             verifier
-                .update_state(&institution.profile, &institution.agency_client, &issuer_to_consumer)
+                .update_state(
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
+                    &institution.agency_client,
+                    &issuer_to_consumer,
+                )
                 .await
                 .unwrap();
             assert_eq!(
@@ -1070,7 +1099,8 @@ mod tests {
             prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
                 .await;
             proof_verifier
-                .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+                .update_state(
+                    &institution.profile.inject_wallet(), &institution.profile.inject_anoncreds_ledger_read(), &institution.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
                 .await
                 .unwrap();
             assert_eq!(
@@ -1089,7 +1119,8 @@ mod tests {
             prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
                 .await;
             proof_verifier
-                .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+                .update_state(
+                    &institution.profile.inject_wallet(), &institution.profile.inject_anoncreds_ledger_read(), &institution.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
                 .await
                 .unwrap();
             assert_eq!(

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -33,8 +33,10 @@ mod integration_tests {
     async fn test_agency_pool_retrieve_credentials() {
         SetupProfile::run(|setup| async move {
             create_and_store_nonrevocable_credential(
-                &setup.profile,
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -172,8 +174,10 @@ mod integration_tests {
     async fn test_agency_pool_case_for_proof_req_doesnt_matter_for_retrieve_creds() {
         SetupProfile::run(|setup| async move {
             create_and_store_nonrevocable_credential(
-                &setup.profile,
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -285,8 +289,10 @@ mod integration_tests {
     async fn test_agency_pool_generate_proof() {
         SetupProfile::run(|setup| async move {
             create_and_store_credential(
-                &setup.profile,
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -369,8 +375,10 @@ mod integration_tests {
     async fn test_agency_pool_generate_proof_with_predicates() {
         SetupProfile::run(|setup| async move {
             create_and_store_credential(
-                &setup.profile,
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -58,7 +58,10 @@ mod integration_tests {
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
 
-            let retrieved_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
+            let retrieved_creds = proof
+                .retrieve_credentials(&setup.profile.inject_anoncreds())
+                .await
+                .unwrap();
             // assert number of cred matches for different requested referents
             assert_eq!(retrieved_creds.credentials_by_referent["address1_1"].len(), 2);
             assert_eq!(retrieved_creds.credentials_by_referent["zip_2"].len(), 2);
@@ -119,7 +122,10 @@ mod integration_tests {
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
 
-            let retrieved_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
+            let retrieved_creds = proof
+                .retrieve_credentials(&setup.profile.inject_anoncreds())
+                .await
+                .unwrap();
             assert_eq!(serde_json::to_string(&retrieved_creds).unwrap(), "{}".to_string());
             assert!(retrieved_creds.credentials_by_referent.is_empty());
 
@@ -143,7 +149,10 @@ mod integration_tests {
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let proof: Prover = Prover::create_from_request("2", proof_req).unwrap();
 
-            let retrieved_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
+            let retrieved_creds = proof
+                .retrieve_credentials(&setup.profile.inject_anoncreds())
+                .await
+                .unwrap();
             assert_eq!(
                 serde_json::to_string(&retrieved_creds).unwrap(),
                 json!({"attrs":{"address1_1":[]}}).to_string()
@@ -201,7 +210,10 @@ mod integration_tests {
             let proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
 
             // All lower case
-            let retrieved_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
+            let retrieved_creds = proof
+                .retrieve_credentials(&setup.profile.inject_anoncreds())
+                .await
+                .unwrap();
             assert_eq!(
                 retrieved_creds.credentials_by_referent["zip_1"][0].cred_info.attributes["zip"],
                 "84000"
@@ -225,7 +237,10 @@ mod integration_tests {
 
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let proof: Prover = Prover::create_from_request("2", proof_req).unwrap();
-            let retrieved_creds2 = proof.retrieve_credentials(&setup.profile).await.unwrap();
+            let retrieved_creds2 = proof
+                .retrieve_credentials(&setup.profile.inject_anoncreds())
+                .await
+                .unwrap();
             assert_eq!(
                 retrieved_creds2.credentials_by_referent["zip_1"][0]
                     .cred_info
@@ -251,7 +266,10 @@ mod integration_tests {
 
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
-            let retrieved_creds3 = proof.retrieve_credentials(&setup.profile).await.unwrap();
+            let retrieved_creds3 = proof
+                .retrieve_credentials(&setup.profile.inject_anoncreds())
+                .await
+                .unwrap();
             assert_eq!(
                 retrieved_creds3.credentials_by_referent["zip_1"][0]
                     .cred_info
@@ -311,7 +329,10 @@ mod integration_tests {
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let mut proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
 
-            let all_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
+            let all_creds = proof
+                .retrieve_credentials(&setup.profile.inject_anoncreds())
+                .await
+                .unwrap();
             let selected_credentials: serde_json::Value = json!({
                "attrs":{
                   "address1_1": {
@@ -331,7 +352,8 @@ mod integration_tests {
 
             let generated_proof = proof
                 .generate_presentation(
-                    &setup.profile,
+                    &setup.profile.inject_anoncreds_ledger_read(),
+                    &setup.profile.inject_anoncreds(),
                     serde_json::from_value(selected_credentials).unwrap(),
                     serde_json::from_value(self_attested).unwrap(),
                 )
@@ -393,7 +415,10 @@ mod integration_tests {
             let proof_req = RequestPresentation::with_decorators(id, content, decorators);
             let mut proof: Prover = Prover::create_from_request("1", proof_req).unwrap();
 
-            let all_creds = proof.retrieve_credentials(&setup.profile).await.unwrap();
+            let all_creds = proof
+                .retrieve_credentials(&setup.profile.inject_anoncreds())
+                .await
+                .unwrap();
             let selected_credentials: serde_json::Value = json!({
                "attrs":{
                   "address1_1": {
@@ -415,7 +440,8 @@ mod integration_tests {
             });
             let generated_proof = proof
                 .generate_presentation(
-                    &setup.profile,
+                    &setup.profile.inject_anoncreds_ledger_read(),
+                    &setup.profile.inject_anoncreds(),
                     serde_json::from_value(selected_credentials).unwrap(),
                     serde_json::from_value(self_attested).unwrap(),
                 )
@@ -461,7 +487,8 @@ mod integration_tests {
             });
             proof
                 .generate_presentation(
-                    &setup.profile,
+                    &setup.profile.inject_anoncreds_ledger_read(),
+                    &setup.profile.inject_anoncreds(),
                     serde_json::from_value(selected_credentials).unwrap(),
                     serde_json::from_value(self_attested).unwrap(),
                 )
@@ -1187,7 +1214,8 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(1000)).await;
             issuer
                 .update_state(
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds(),
                     &institution.agency_client,
                     &institution_to_consumer,
                 )
@@ -1455,9 +1483,14 @@ mod tests {
                 alice
                     .credential
                     .send_request(
-                        &alice.profile,
+                        &alice.profile.inject_anoncreds_ledger_read(),
+                        &alice.profile.inject_anoncreds(),
                         pw_did,
-                        alice.connection.send_message_closure(&alice.profile).await.unwrap(),
+                        alice
+                            .connection
+                            .send_message_closure(alice.profile.inject_wallet())
+                            .await
+                            .unwrap(),
                     )
                     .await
                     .unwrap();
@@ -1480,14 +1513,25 @@ mod tests {
 
                 alice
                     .prover
-                    .generate_presentation(&alice.profile, credentials, HashMap::new())
+                    .generate_presentation(
+                        &alice.profile.inject_anoncreds_ledger_read(),
+                        &alice.profile.inject_anoncreds(),
+                        credentials,
+                        HashMap::new(),
+                    )
                     .await
                     .unwrap();
                 assert_eq!(ProverState::PresentationPrepared, alice.prover.get_state());
 
                 alice
                     .prover
-                    .send_presentation(alice.connection.send_message_closure(&alice.profile).await.unwrap())
+                    .send_presentation(
+                        alice
+                            .connection
+                            .send_message_closure(alice.profile.inject_wallet())
+                            .await
+                            .unwrap(),
+                    )
                     .await
                     .unwrap();
                 assert_eq!(ProverState::PresentationSent, alice.prover.get_state());
@@ -1545,9 +1589,14 @@ mod tests {
                 alice
                     .credential
                     .send_request(
-                        &alice.profile,
+                        &alice.profile.inject_anoncreds_ledger_read(),
+                        &alice.profile.inject_anoncreds(),
                         pw_did,
-                        alice.connection.send_message_closure(&alice.profile).await.unwrap(),
+                        alice
+                            .connection
+                            .send_message_closure(alice.profile.inject_wallet())
+                            .await
+                            .unwrap(),
                     )
                     .await
                     .unwrap();
@@ -1578,14 +1627,25 @@ mod tests {
 
                 alice
                     .prover
-                    .generate_presentation(&alice.profile, credentials, HashMap::new())
+                    .generate_presentation(
+                        &alice.profile.inject_anoncreds_ledger_read(),
+                        &alice.profile.inject_anoncreds(),
+                        credentials,
+                        HashMap::new(),
+                    )
                     .await
                     .unwrap();
                 assert_eq!(ProverState::PresentationPrepared, alice.prover.get_state());
 
                 alice
                     .prover
-                    .send_presentation(alice.connection.send_message_closure(&alice.profile).await.unwrap())
+                    .send_presentation(
+                        alice
+                            .connection
+                            .send_message_closure(alice.profile.inject_wallet())
+                            .await
+                            .unwrap(),
+                    )
                     .await
                     .unwrap();
                 assert_eq!(ProverState::PresentationSent, alice.prover.get_state());

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -41,7 +41,14 @@ mod integration_tests {
                 DEFAULT_SCHEMA_ATTRS,
             )
             .await;
-            let (_, _, req, _) = create_indy_proof(&setup.profile, &setup.profile, &setup.institution_did).await;
+            let (_, _, req, _) = create_indy_proof(
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
+                &setup.institution_did,
+            )
+            .await;
 
             let pres_req_data: PresentationRequestData = serde_json::from_str(&req).unwrap();
             let id = "test_id".to_owned();
@@ -77,7 +84,9 @@ mod integration_tests {
     async fn test_agency_pool_get_credential_def() {
         SetupProfile::run(|setup| async move {
             let (_, _, cred_def_id, cred_def_json, _) = create_and_store_nonrevocable_credential_def(
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )
@@ -987,7 +996,9 @@ mod tests {
             let attrs_list = attrs_list.to_string();
             let (schema_id, _schema_json, cred_def_id, _cred_def_json, cred_def) =
                 create_and_store_nonrevocable_credential_def(
-                    &institution.profile,
+                    &institution.profile.inject_anoncreds(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds_ledger_write(),
                     &institution.config_issuer.institution_did,
                     &attrs_list,
                 )

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -777,7 +777,7 @@ mod tests {
             prover_select_credentials_and_send_proof(&mut consumer1, &consumer1_to_verifier, None, None).await;
             proof_verifier
                 .update_state(
-                    &institution.profile.inject_wallet(), &institution.profile.inject_anoncreds_ledger_read(), &institution.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer1)
+                    &verifier.profile.inject_wallet(), &verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer1)
                 .await
                 .unwrap();
             assert_eq!(
@@ -797,7 +797,12 @@ mod tests {
             prover_select_credentials_and_send_proof(&mut consumer2, &consumer2_to_verifier, None, None).await;
             proof_verifier
                 .update_state(
-                    &institution.profile.inject_wallet(), &institution.profile.inject_anoncreds_ledger_read(), &institution.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer2)
+                    &verifier.profile.inject_wallet(),
+                    &verifier.profile.inject_anoncreds_ledger_read(),
+                    &verifier.profile.inject_anoncreds(),
+                    &verifier.agency_client,
+                    &verifier_to_consumer2
+                )
                 .await
                 .unwrap();
             assert_eq!(
@@ -834,9 +839,9 @@ mod tests {
             prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, request_name1, None).await;
             proof_verifier
                 .update_state(
-                    &institution.profile.inject_wallet(),
-                    &institution.profile.inject_anoncreds_ledger_read(),
-                    &institution.profile.inject_anoncreds(),
+                    &verifier.profile.inject_wallet(),
+                    &verifier.profile.inject_anoncreds_ledger_read(),
+                    &verifier.profile.inject_anoncreds(),
                     &verifier.agency_client,
                     &verifier_to_consumer,
                 )
@@ -859,9 +864,9 @@ mod tests {
             prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, request_name2, None).await;
             proof_verifier
                 .update_state(
-                    &institution.profile.inject_wallet(),
-                    &institution.profile.inject_anoncreds_ledger_read(),
-                    &institution.profile.inject_anoncreds(),
+                    &verifier.profile.inject_wallet(),
+                    &verifier.profile.inject_anoncreds_ledger_read(),
+                    &verifier.profile.inject_anoncreds(),
                     &verifier.agency_client,
                     &verifier_to_consumer,
                 )
@@ -1045,7 +1050,10 @@ mod tests {
             let mut prover = create_proof(&mut consumer, &consumer_to_issuer, None).await;
             info!("test_real_proof :: retrieving matching credentials");
 
-            let retrieved_credentials = prover.retrieve_credentials(&consumer.profile).await.unwrap();
+            let retrieved_credentials = prover
+                .retrieve_credentials(&consumer.profile.inject_anoncreds())
+                .await
+                .unwrap();
             let selected_credentials = retrieved_to_selected_credentials_simple(&retrieved_credentials, false);
 
             info!("test_real_proof :: generating and sending proof");
@@ -1127,7 +1135,7 @@ mod tests {
                 .await;
             proof_verifier
                 .update_state(
-                    &institution.profile.inject_wallet(), &institution.profile.inject_anoncreds_ledger_read(), &institution.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+                    &verifier.profile.inject_wallet(), &verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
                 .await
                 .unwrap();
             assert_eq!(
@@ -1147,7 +1155,7 @@ mod tests {
                 .await;
             proof_verifier
                 .update_state(
-                    &institution.profile.inject_wallet(), &institution.profile.inject_anoncreds_ledger_read(), &institution.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+                    &verifier.profile.inject_wallet(), &verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
                 .await
                 .unwrap();
             assert_eq!(

--- a/aries_vcx/tests/test_creds_proofs_revocations.rs
+++ b/aries_vcx/tests/test_creds_proofs_revocations.rs
@@ -82,7 +82,9 @@ mod integration_tests {
             info!("test_basic_revocation :: verifier :: going to verify proof");
             verifier
                 .update_state(
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
                     &institution.agency_client,
                     &institution_to_consumer,
                 )
@@ -190,7 +192,9 @@ mod integration_tests {
 
             verifier
                 .update_state(
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
                     &institution.agency_client,
                     &institution_to_consumer,
                 )
@@ -219,7 +223,9 @@ mod integration_tests {
 
             verifier
                 .update_state(
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
                     &institution.agency_client,
                     &institution_to_consumer,
                 )
@@ -331,7 +337,8 @@ mod integration_tests {
 
         verifier1
             .update_state(
-                &institution.profile,
+                &institution.profile.inject_anoncreds_ledger_read(),
+                &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
                 &institution_to_consumer1,
             )
@@ -339,7 +346,8 @@ mod integration_tests {
             .unwrap();
         verifier2
             .update_state(
-                &institution.profile,
+                &institution.profile.inject_anoncreds_ledger_read(),
+                &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
                 &institution_to_consumer2,
             )
@@ -347,7 +355,8 @@ mod integration_tests {
             .unwrap();
         verifier3
             .update_state(
-                &institution.profile,
+                &institution.profile.inject_anoncreds_ledger_read(),
+                &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
                 &institution_to_consumer3,
             )
@@ -408,7 +417,8 @@ mod integration_tests {
 
         verifier1
             .update_state(
-                &institution.profile,
+                &institution.profile.inject_anoncreds_ledger_read(),
+                &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
                 &institution_to_consumer1,
             )
@@ -416,7 +426,8 @@ mod integration_tests {
             .unwrap();
         verifier2
             .update_state(
-                &institution.profile,
+                &institution.profile.inject_anoncreds_ledger_read(),
+                &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
                 &institution_to_consumer2,
             )
@@ -424,7 +435,8 @@ mod integration_tests {
             .unwrap();
         verifier3
             .update_state(
-                &institution.profile,
+                &institution.profile.inject_anoncreds_ledger_read(),
+                &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
                 &institution_to_consumer3,
             )
@@ -526,7 +538,9 @@ mod integration_tests {
             info!("test_revoked_credential_might_still_work :: verifier :: going to verify proof");
             verifier
                 .update_state(
-                    &institution.profile,
+                    &institution.profile.inject_wallet(),
+                    &institution.profile.inject_anoncreds_ledger_read(),
+                    &institution.profile.inject_anoncreds(),
                     &institution.agency_client,
                     &institution_to_consumer,
                 )
@@ -598,7 +612,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
             assert_eq!(
@@ -621,7 +635,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -691,7 +705,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -710,7 +724,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -776,7 +790,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -796,7 +810,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -867,7 +881,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -886,7 +900,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -957,7 +971,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -976,7 +990,7 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile, &verifier.agency_client, &verifier_to_consumer)
+            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(

--- a/aries_vcx/tests/test_creds_proofs_revocations.rs
+++ b/aries_vcx/tests/test_creds_proofs_revocations.rs
@@ -42,7 +42,10 @@ mod integration_tests {
             )
             .await;
 
-            assert!(!issuer_credential.is_revoked(&institution.profile).await.unwrap());
+            assert!(!issuer_credential
+                .is_revoked(&institution.profile.inject_anoncreds_ledger_read())
+                .await
+                .unwrap());
 
             let time_before_revocation = time::OffsetDateTime::now_utc().unix_timestamp() as u64;
             info!("test_basic_revocation :: verifier :: Going to revoke credential");
@@ -51,7 +54,10 @@ mod integration_tests {
             tokio::time::sleep(Duration::from_millis(1000)).await;
             let time_after_revocation = time::OffsetDateTime::now_utc().unix_timestamp() as u64;
 
-            assert!(issuer_credential.is_revoked(&institution.profile).await.unwrap());
+            assert!(issuer_credential
+                .is_revoked(&institution.profile.inject_anoncreds_ledger_read())
+                .await
+                .unwrap());
 
             let _requested_attrs = requested_attrs(
                 &institution.config_issuer.institution_did,
@@ -118,13 +124,19 @@ mod integration_tests {
             )
             .await;
 
-            assert!(!issuer_credential.is_revoked(&institution.profile).await.unwrap());
+            assert!(!issuer_credential
+                .is_revoked(&institution.profile.inject_anoncreds_ledger_read())
+                .await
+                .unwrap());
 
             info!("test_revocation_notification :: verifier :: Going to revoke credential");
             revoke_credential_and_publish_accumulator(&mut institution, &issuer_credential, &rev_reg).await;
             tokio::time::sleep(Duration::from_millis(1000)).await;
 
-            assert!(issuer_credential.is_revoked(&institution.profile).await.unwrap());
+            assert!(issuer_credential
+                .is_revoked(&institution.profile.inject_anoncreds_ledger_read())
+                .await
+                .unwrap());
             let config =
                 aries_vcx::protocols::revocation_notification::sender::state_machine::SenderConfigBuilder::default()
                     .ack_on(vec![AckOn::Receipt])
@@ -177,7 +189,10 @@ mod integration_tests {
             .await;
 
             revoke_credential_local(&mut institution, &issuer_credential, &rev_reg.rev_reg_id).await;
-            assert!(!issuer_credential.is_revoked(&institution.profile).await.unwrap());
+            assert!(!issuer_credential
+                .is_revoked(&institution.profile.inject_anoncreds_ledger_read())
+                .await
+                .unwrap());
             let request_name1 = Some("request1");
             let mut verifier = verifier_create_proof_and_send_request(
                 &mut institution,
@@ -206,7 +221,10 @@ mod integration_tests {
                 PresentationVerificationStatus::Valid
             );
 
-            assert!(!issuer_credential.is_revoked(&institution.profile).await.unwrap());
+            assert!(!issuer_credential
+                .is_revoked(&institution.profile.inject_anoncreds_ledger_read())
+                .await
+                .unwrap());
 
             publish_revocation(&mut institution, &rev_reg).await;
             let request_name2 = Some("request2");
@@ -237,7 +255,10 @@ mod integration_tests {
                 PresentationVerificationStatus::Invalid
             );
 
-            assert!(issuer_credential.is_revoked(&institution.profile).await.unwrap());
+            assert!(issuer_credential
+                .is_revoked(&institution.profile.inject_anoncreds_ledger_read())
+                .await
+                .unwrap());
         })
         .await;
     }
@@ -301,9 +322,9 @@ mod integration_tests {
 
         revoke_credential_local(&mut institution, &issuer_credential1, &rev_reg.rev_reg_id).await;
         revoke_credential_local(&mut institution, &issuer_credential2, &rev_reg.rev_reg_id).await;
-        assert!(!issuer_credential1.is_revoked(&institution.profile).await.unwrap());
-        assert!(!issuer_credential2.is_revoked(&institution.profile).await.unwrap());
-        assert!(!issuer_credential3.is_revoked(&institution.profile).await.unwrap());
+        assert!(!issuer_credential1.is_revoked(&institution.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential2.is_revoked(&institution.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential3.is_revoked(&institution.profile.inject_anoncreds_ledger_read()).await.unwrap());
 
         // Revoke two locally and verify their are all still valid
         let request_name1 = Some("request1");
@@ -337,6 +358,7 @@ mod integration_tests {
 
         verifier1
             .update_state(
+                &institution.profile.inject_wallet(),
                 &institution.profile.inject_anoncreds_ledger_read(),
                 &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
@@ -346,6 +368,7 @@ mod integration_tests {
             .unwrap();
         verifier2
             .update_state(
+                &institution.profile.inject_wallet(),
                 &institution.profile.inject_anoncreds_ledger_read(),
                 &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
@@ -355,6 +378,7 @@ mod integration_tests {
             .unwrap();
         verifier3
             .update_state(
+                &institution.profile.inject_wallet(),
                 &institution.profile.inject_anoncreds_ledger_read(),
                 &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
@@ -379,9 +403,9 @@ mod integration_tests {
         publish_revocation(&mut institution, &rev_reg).await;
         tokio::time::sleep(Duration::from_millis(1000)).await;
 
-        assert!(issuer_credential1.is_revoked(&institution.profile).await.unwrap());
-        assert!(issuer_credential2.is_revoked(&institution.profile).await.unwrap());
-        assert!(!issuer_credential3.is_revoked(&institution.profile).await.unwrap());
+        assert!(issuer_credential1.is_revoked(&institution.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(issuer_credential2.is_revoked(&institution.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential3.is_revoked(&institution.profile.inject_anoncreds_ledger_read()).await.unwrap());
 
         let request_name2 = Some("request2");
         let mut verifier1 = verifier_create_proof_and_send_request(
@@ -417,6 +441,7 @@ mod integration_tests {
 
         verifier1
             .update_state(
+                &institution.profile.inject_wallet(),
                 &institution.profile.inject_anoncreds_ledger_read(),
                 &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
@@ -426,6 +451,7 @@ mod integration_tests {
             .unwrap();
         verifier2
             .update_state(
+                &institution.profile.inject_wallet(),
                 &institution.profile.inject_anoncreds_ledger_read(),
                 &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
@@ -435,6 +461,7 @@ mod integration_tests {
             .unwrap();
         verifier3
             .update_state(
+                &institution.profile.inject_wallet(),
                 &institution.profile.inject_anoncreds_ledger_read(),
                 &institution.profile.inject_anoncreds(),
                 &institution.agency_client,
@@ -476,7 +503,7 @@ mod integration_tests {
             )
             .await;
 
-            assert!(!issuer_credential.is_revoked(&institution.profile).await.unwrap());
+            assert!(!issuer_credential.is_revoked(&institution.profile.inject_anoncreds_ledger_read()).await.unwrap());
 
             tokio::time::sleep(Duration::from_millis(1000)).await;
             let time_before_revocation = time::OffsetDateTime::now_utc().unix_timestamp() as u64;
@@ -612,7 +639,12 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer)
             .await
             .unwrap();
             assert_eq!(
@@ -635,7 +667,13 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -705,7 +743,13 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -724,7 +768,13 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -790,7 +840,13 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -810,7 +866,12 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -881,7 +942,12 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer)
             .await
             .unwrap();
         assert_eq!(
@@ -900,7 +966,13 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -971,7 +1043,13 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req1, Some(&credential_data1))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -990,7 +1068,13 @@ mod integration_tests {
         prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_verifier, req2, Some(&credential_data2))
             .await;
         proof_verifier
-            .update_state(&verifier.profile.inject_anoncreds_ledger_read(), &verifier.profile.inject_anoncreds(), &verifier.agency_client, &verifier_to_consumer)
+            .update_state(
+                &verifier.profile.inject_wallet(),
+                &verifier.profile.inject_anoncreds_ledger_read(),
+                &verifier.profile.inject_anoncreds(),
+                &verifier.agency_client,
+                &verifier_to_consumer
+            )
             .await
             .unwrap();
         assert_eq!(

--- a/aries_vcx/tests/test_creds_proofs_revocations.rs
+++ b/aries_vcx/tests/test_creds_proofs_revocations.rs
@@ -146,7 +146,7 @@ mod integration_tests {
                     .build()
                     .unwrap();
             let send_message = institution_to_consumer
-                .send_message_closure(&institution.profile)
+                .send_message_closure(institution.profile.inject_wallet())
                 .await
                 .unwrap();
             aries_vcx::handlers::revocation_notification::sender::RevocationNotificationSender::build()
@@ -542,7 +542,7 @@ mod integration_tests {
             let mut prover = create_proof(&mut consumer, &consumer_to_institution, None).await;
             info!("test_revoked_credential_might_still_work :: retrieving matching credentials");
 
-            let retrieved_credentials = prover.retrieve_credentials(&consumer.profile).await.unwrap();
+            let retrieved_credentials = prover.retrieve_credentials(&consumer.profile.inject_anoncreds()).await.unwrap();
             info!(
                 "test_revoked_credential_might_still_work :: prover :: based on proof, retrieved credentials: {:?}",
                 &retrieved_credentials
@@ -623,8 +623,8 @@ mod integration_tests {
         )
         .await;
 
-        assert!(!issuer_credential1.is_revoked(&issuer.profile).await.unwrap());
-        assert!(!issuer_credential2.is_revoked(&issuer.profile).await.unwrap());
+        assert!(!issuer_credential1.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential2.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
 
         revoke_credential_and_publish_accumulator(&mut issuer, &issuer_credential1, &rev_reg).await;
 
@@ -681,8 +681,8 @@ mod integration_tests {
             PresentationVerificationStatus::Valid
         );
 
-        assert!(issuer_credential1.is_revoked(&issuer.profile).await.unwrap());
-        assert!(!issuer_credential2.is_revoked(&issuer.profile).await.unwrap());
+        assert!(issuer_credential1.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential2.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
         }).await;
     }
 
@@ -727,8 +727,8 @@ mod integration_tests {
         )
         .await;
 
-        assert!(!issuer_credential1.is_revoked(&issuer.profile).await.unwrap());
-        assert!(!issuer_credential2.is_revoked(&issuer.profile).await.unwrap());
+        assert!(!issuer_credential1.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential2.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
 
         revoke_credential_and_publish_accumulator(&mut issuer, &issuer_credential2, &rev_reg).await;
 
@@ -782,8 +782,8 @@ mod integration_tests {
             PresentationVerificationStatus::Invalid
         );
 
-        assert!(!issuer_credential1.is_revoked(&issuer.profile).await.unwrap());
-        assert!(issuer_credential2.is_revoked(&issuer.profile).await.unwrap());
+        assert!(!issuer_credential1.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(issuer_credential2.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
         }).await;
     }
 
@@ -879,8 +879,8 @@ mod integration_tests {
             PresentationVerificationStatus::Valid
         );
 
-        assert!(!issuer_credential1.is_revoked(&issuer.profile).await.unwrap());
-        assert!(!issuer_credential2.is_revoked(&issuer.profile).await.unwrap());
+        assert!(!issuer_credential1.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential2.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
         }).await;
     }
 
@@ -926,8 +926,8 @@ mod integration_tests {
         )
         .await;
 
-        assert!(!issuer_credential1.is_revoked(&issuer.profile).await.unwrap());
-        assert!(!issuer_credential2.is_revoked(&issuer.profile).await.unwrap());
+        assert!(!issuer_credential1.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential2.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
 
         revoke_credential_and_publish_accumulator(&mut issuer, &issuer_credential1, &rev_reg).await;
 
@@ -980,8 +980,8 @@ mod integration_tests {
             PresentationVerificationStatus::Valid
         );
 
-        assert!(issuer_credential1.is_revoked(&issuer.profile).await.unwrap());
-        assert!(!issuer_credential2.is_revoked(&issuer.profile).await.unwrap());
+        assert!(issuer_credential1.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential2.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
         }).await;
     }
 
@@ -1027,8 +1027,8 @@ mod integration_tests {
         )
         .await;
 
-        assert!(!issuer_credential1.is_revoked(&issuer.profile).await.unwrap());
-        assert!(!issuer_credential2.is_revoked(&issuer.profile).await.unwrap());
+        assert!(!issuer_credential1.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(!issuer_credential2.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
 
         revoke_credential_and_publish_accumulator(&mut issuer, &issuer_credential2, &rev_reg_2).await;
 
@@ -1082,8 +1082,8 @@ mod integration_tests {
             PresentationVerificationStatus::Invalid
         );
 
-        assert!(!issuer_credential1.is_revoked(&issuer.profile).await.unwrap());
-        assert!(issuer_credential2.is_revoked(&issuer.profile).await.unwrap());
+        assert!(!issuer_credential1.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
+        assert!(issuer_credential2.is_revoked(&issuer.profile.inject_anoncreds_ledger_read()).await.unwrap());
         }).await;
     }
 }

--- a/aries_vcx/tests/test_pool.rs
+++ b/aries_vcx/tests/test_pool.rs
@@ -34,7 +34,9 @@ mod integration_tests {
     async fn test_pool_get_credential_def() {
         SetupProfile::run(|setup| async move {
             let (_, _, cred_def_id, cred_def_json, _) = create_and_store_nonrevocable_credential_def(
-                &setup.profile,
+                &setup.profile.inject_anoncreds(),
+                &setup.profile.inject_anoncreds_ledger_read(),
+                &setup.profile.inject_anoncreds_ledger_write(),
                 &setup.institution_did,
                 DEFAULT_SCHEMA_ATTRS,
             )

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -241,12 +241,21 @@ pub mod test_utils {
                 .build()
                 .unwrap();
 
-            self.cred_def = CredentialDef::create(&self.profile, String::from("test_cred_def"), config, false)
-                .await
-                .unwrap()
-                .publish_cred_def(&self.profile)
-                .await
-                .unwrap();
+            self.cred_def = CredentialDef::create(
+                &self.profile.inject_anoncreds_ledger_read(),
+                &self.profile.inject_anoncreds(),
+                String::from("test_cred_def"),
+                config,
+                false,
+            )
+            .await
+            .unwrap()
+            .publish_cred_def(
+                &self.profile.inject_anoncreds_ledger_read(),
+                &self.profile.inject_anoncreds_ledger_write(),
+            )
+            .await
+            .unwrap();
         }
 
         pub async fn create_presentation_request(&self) -> Verifier {

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -219,7 +219,7 @@ pub mod test_utils {
             let version: String = String::from("1.0");
 
             self.schema = Schema::create(
-                &self.profile,
+                &self.profile.inject_anoncreds(),
                 "",
                 &self.config_issuer.institution_did,
                 &name,
@@ -228,7 +228,7 @@ pub mod test_utils {
             )
             .await
             .unwrap()
-            .publish(&self.profile, None)
+            .publish(&self.profile.inject_anoncreds_ledger_write(), None)
             .await
             .unwrap();
         }

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -341,7 +341,7 @@ pub mod test_utils {
             };
             self.issuer_credential = Issuer::create("alice_degree").unwrap();
             self.issuer_credential
-                .build_credential_offer_msg(&self.profile, offer_info, None)
+                .build_credential_offer_msg(&self.profile.inject_anoncreds(), offer_info, None)
                 .await
                 .unwrap();
             self.issuer_credential
@@ -414,7 +414,7 @@ pub mod test_utils {
                 .unwrap();
             self.verifier
                 .update_state(
-                    &institution.profile.inject_wallet(),
+                    &self.profile.inject_wallet(),
                     &self.profile.inject_anoncreds_ledger_read(),
                     &self.profile.inject_anoncreds(),
                     &self.agency_client,
@@ -438,7 +438,7 @@ pub mod test_utils {
         ) {
             self.verifier
                 .update_state(
-                    &institution.profile.inject_wallet(),
+                    &self.profile.inject_wallet(),
                     &self.profile.inject_anoncreds_ledger_read(),
                     &self.profile.inject_anoncreds(),
                     &self.agency_client,

--- a/aries_vcx/tests/utils/devsetup_agent.rs
+++ b/aries_vcx/tests/utils/devsetup_agent.rs
@@ -385,7 +385,13 @@ pub mod test_utils {
                 .await
                 .unwrap();
             self.verifier
-                .update_state(&self.profile, &self.agency_client, &self.connection)
+                .update_state(
+                    &institution.profile.inject_wallet(),
+                    &self.profile.inject_anoncreds_ledger_read(),
+                    &self.profile.inject_anoncreds(),
+                    &self.agency_client,
+                    &self.connection,
+                )
                 .await
                 .unwrap();
 
@@ -403,7 +409,13 @@ pub mod test_utils {
             expected_verification_status: PresentationVerificationStatus,
         ) {
             self.verifier
-                .update_state(&self.profile, &self.agency_client, &self.connection)
+                .update_state(
+                    &institution.profile.inject_wallet(),
+                    &self.profile.inject_anoncreds_ledger_read(),
+                    &self.profile.inject_anoncreds(),
+                    &self.agency_client,
+                    &self.connection,
+                )
                 .await
                 .unwrap();
             assert_eq!(expected_state, self.verifier.get_state());

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -919,7 +919,11 @@ pub mod test_utils {
     ) {
         revoke_credential_local(faber, issuer_credential, &rev_reg.rev_reg_id).await;
         rev_reg
-            .publish_local_revocations(&faber.profile, &faber.config_issuer.institution_did)
+            .publish_local_revocations(
+                &faber.profile.inject_anoncreds(),
+                &faber.profile.inject_anoncreds_ledger_write(),
+                &faber.config_issuer.institution_did,
+            )
             .await
             .unwrap();
     }
@@ -945,7 +949,7 @@ pub mod test_utils {
         rev_reg: &RevocationRegistry,
     ) -> RevocationRegistry {
         let mut rev_reg_new = RevocationRegistry::create(
-            &faber.profile,
+            &faber.profile.inject_anoncreds(),
             &faber.config_issuer.institution_did,
             &credential_def.get_cred_def_id(),
             &rev_reg.get_tails_dir(),
@@ -955,7 +959,7 @@ pub mod test_utils {
         .await
         .unwrap();
         rev_reg_new
-            .publish_revocation_primitives(&faber.profile, TEST_TAILS_URL)
+            .publish_revocation_primitives(&faber.profile.inject_anoncreds_ledger_write(), TEST_TAILS_URL)
             .await
             .unwrap();
         rev_reg_new
@@ -963,7 +967,11 @@ pub mod test_utils {
 
     pub async fn publish_revocation(institution: &mut Faber, rev_reg: &RevocationRegistry) {
         rev_reg
-            .publish_local_revocations(&institution.profile, &institution.config_issuer.institution_did)
+            .publish_local_revocations(
+                &institution.profile.inject_anoncreds(),
+                &institution.profile.inject_anoncreds_ledger_write(),
+                &institution.config_issuer.institution_did,
+            )
             .await
             .unwrap();
     }
@@ -983,7 +991,14 @@ pub mod test_utils {
         info!("_create_address_schema >>> ");
         let attrs_list = json!(["address1", "address2", "city", "state", "zip"]).to_string();
         let (schema_id, schema_json, cred_def_id, cred_def_json, rev_reg_id, cred_def, rev_reg) =
-            create_and_store_credential_def(profile, &institution_did, &attrs_list).await;
+            create_and_store_credential_def(
+                &profile.inject_anoncreds(),
+                &profile.inject_anoncreds_ledger_read(),
+                &profile.inject_anoncreds_ledger_write(),
+                &institution_did,
+                &attrs_list,
+            )
+            .await;
         (
             schema_id,
             schema_json,

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -199,7 +199,12 @@ pub mod test_utils {
             .await
             .unwrap();
         issuer
-            .send_credential_offer(connection.send_message_closure(&faber.profile).await.unwrap())
+            .send_credential_offer(
+                connection
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
         info!("create_and_send_nonrevocable_cred_offer :: credential offer was sent");
@@ -229,7 +234,12 @@ pub mod test_utils {
             .await
             .unwrap();
         issuer
-            .send_credential_offer(connection.send_message_closure(&faber.profile).await.unwrap())
+            .send_credential_offer(
+                connection
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
         info!("create_and_send_cred_offer :: credential offer was sent");
@@ -266,9 +276,13 @@ pub mod test_utils {
         let my_pw_did = connection.pairwise_info().pw_did.to_string();
         holder
             .send_request(
-                &alice.profile,
+                &alice.profile.inject_anoncreds_ledger_read(),
+                &alice.profile.inject_anoncreds(),
                 my_pw_did,
-                connection.send_message_closure(&alice.profile).await.unwrap(),
+                connection
+                    .send_message_closure(alice.profile.inject_wallet())
+                    .await
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -317,7 +331,13 @@ pub mod test_utils {
         let mut holder = Holder::create("TEST_CREDENTIAL").unwrap();
         assert_eq!(HolderState::Initial, holder.get_state());
         holder
-            .send_proposal(proposal, connection.send_message_closure(&alice.profile).await.unwrap())
+            .send_proposal(
+                proposal,
+                connection
+                    .send_message_closure(alice.profile.inject_wallet())
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(HolderState::ProposalSent, holder.get_state());
@@ -334,7 +354,13 @@ pub mod test_utils {
         comment: &str,
     ) {
         holder
-            .update_state(&alice.profile, &alice.agency_client, connection)
+            .update_state(
+                &alice.profile.inject_anoncreds_ledger_read(),
+                &alice.profile.inject_anoncreds(),
+                &alice.profile.inject_wallet(),
+                &alice.agency_client,
+                connection,
+            )
             .await
             .unwrap();
         assert_eq!(HolderState::OfferReceived, holder.get_state());
@@ -371,7 +397,13 @@ pub mod test_utils {
 
         let proposal = ProposeCredential::with_decorators(id, content, decorators);
         holder
-            .send_proposal(proposal, connection.send_message_closure(&alice.profile).await.unwrap())
+            .send_proposal(
+                proposal,
+                connection
+                    .send_message_closure(alice.profile.inject_wallet())
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(HolderState::ProposalSent, holder.get_state());
@@ -408,7 +440,12 @@ pub mod test_utils {
             .await
             .unwrap();
         issuer
-            .send_credential_offer(connection.send_message_closure(&faber.profile).await.unwrap())
+            .send_credential_offer(
+                connection
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
@@ -425,7 +462,12 @@ pub mod test_utils {
     ) {
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
         issuer
-            .update_state(&faber.profile, &faber.agency_client, connection)
+            .update_state(
+                &faber.profile.inject_wallet(),
+                &faber.profile.inject_anoncreds(),
+                &faber.agency_client,
+                connection,
+            )
             .await
             .unwrap();
         assert_eq!(IssuerState::ProposalReceived, issuer.get_state());
@@ -441,7 +483,12 @@ pub mod test_utils {
             .await
             .unwrap();
         issuer
-            .send_credential_offer(connection.send_message_closure(&faber.profile).await.unwrap())
+            .send_credential_offer(
+                connection
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(IssuerState::OfferSent, issuer.get_state());
@@ -450,7 +497,13 @@ pub mod test_utils {
 
     pub async fn accept_offer(alice: &mut Alice, connection: &MediatedConnection, holder: &mut Holder) {
         holder
-            .update_state(&alice.profile, &alice.agency_client, connection)
+            .update_state(
+                &alice.profile.inject_anoncreds_ledger_read(),
+                &alice.profile.inject_anoncreds(),
+                &alice.profile.inject_wallet(),
+                &alice.agency_client,
+                connection,
+            )
             .await
             .unwrap();
         assert_eq!(HolderState::OfferReceived, holder.get_state());
@@ -458,9 +511,13 @@ pub mod test_utils {
         let my_pw_did = connection.pairwise_info().pw_did.to_string();
         holder
             .send_request(
-                &alice.profile,
+                &alice.profile.inject_anoncreds_ledger_read(),
+                &alice.profile.inject_anoncreds(),
                 my_pw_did,
-                connection.send_message_closure(&alice.profile).await.unwrap(),
+                connection
+                    .send_message_closure(alice.profile.inject_wallet())
+                    .await
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -469,14 +526,23 @@ pub mod test_utils {
 
     pub async fn decline_offer(alice: &mut Alice, connection: &MediatedConnection, holder: &mut Holder) {
         holder
-            .update_state(&alice.profile, &alice.agency_client, connection)
+            .update_state(
+                &alice.profile.inject_anoncreds_ledger_read(),
+                &alice.profile.inject_anoncreds(),
+                &alice.profile.inject_wallet(),
+                &alice.agency_client,
+                connection,
+            )
             .await
             .unwrap();
         assert_eq!(HolderState::OfferReceived, holder.get_state());
         holder
             .decline_offer(
                 Some("Have a nice day"),
-                connection.send_message_closure(&alice.profile).await.unwrap(),
+                connection
+                    .send_message_closure(alice.profile.inject_wallet())
+                    .await
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -498,7 +564,12 @@ pub mod test_utils {
         assert_eq!(issuer_credential.is_revokable(), false);
 
         issuer_credential
-            .update_state(&faber.profile, &faber.agency_client, issuer_to_consumer)
+            .update_state(
+                &faber.profile.inject_wallet(),
+                &faber.profile.inject_anoncreds(),
+                &faber.agency_client,
+                issuer_to_consumer,
+            )
             .await
             .unwrap();
         assert_eq!(IssuerState::RequestReceived, issuer_credential.get_state());
@@ -508,8 +579,11 @@ pub mod test_utils {
         info!("send_credential >>> sending credential");
         issuer_credential
             .send_credential(
-                &faber.profile,
-                issuer_to_consumer.send_message_closure(&faber.profile).await.unwrap(),
+                &faber.profile.inject_anoncreds(),
+                issuer_to_consumer
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -520,7 +594,13 @@ pub mod test_utils {
         assert_eq!(thread_id, holder_credential.get_thread_id().unwrap());
         assert_eq!(holder_credential.is_revokable(&alice.profile).await.unwrap(), revokable);
         holder_credential
-            .update_state(&alice.profile, &alice.agency_client, consumer_to_issuer)
+            .update_state(
+                &alice.profile.inject_anoncreds_ledger_read(),
+                &alice.profile.inject_anoncreds(),
+                &alice.profile.inject_wallet(),
+                &alice.agency_client,
+                consumer_to_issuer,
+            )
             .await
             .unwrap();
         assert_eq!(HolderState::Finished, holder_credential.get_state());
@@ -546,7 +626,10 @@ pub mod test_utils {
         prover
             .send_proposal(
                 proposal_data,
-                connection.send_message_closure(&alice.profile).await.unwrap(),
+                connection
+                    .send_message_closure(alice.profile.inject_wallet())
+                    .await
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -562,7 +645,7 @@ pub mod test_utils {
         cred_def_id: &str,
     ) {
         prover
-            .update_state(&alice.profile, &alice.agency_client, connection)
+            .update_state(&alice.profile.inject_wallet(), &alice.agency_client, connection)
             .await
             .unwrap();
         assert_eq!(prover.get_state(), ProverState::PresentationRequestReceived);
@@ -574,7 +657,10 @@ pub mod test_utils {
         prover
             .send_proposal(
                 proposal_data,
-                connection.send_message_closure(&alice.profile).await.unwrap(),
+                connection
+                    .send_message_closure(alice.profile.inject_wallet())
+                    .await
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -584,7 +670,13 @@ pub mod test_utils {
 
     pub async fn accept_proof_proposal(faber: &mut Faber, verifier: &mut Verifier, connection: &MediatedConnection) {
         verifier
-            .update_state(&faber.profile, &faber.agency_client, connection)
+            .update_state(
+                &faber.profile.inject_wallet(),
+                &faber.profile.inject_anoncreds_ledger_read(),
+                &faber.profile.inject_anoncreds(),
+                &faber.agency_client,
+                connection,
+            )
             .await
             .unwrap();
         assert_eq!(verifier.get_state(), VerifierState::PresentationProposalReceived);
@@ -606,7 +698,12 @@ pub mod test_utils {
             .unwrap();
         verifier.set_request(presentation_request_data, None).unwrap();
         verifier
-            .send_presentation_request(connection.send_message_closure(&faber.profile).await.unwrap())
+            .send_presentation_request(
+                connection
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
     }
@@ -614,13 +711,22 @@ pub mod test_utils {
     pub async fn reject_proof_proposal(faber: &mut Faber, connection: &MediatedConnection) -> Verifier {
         let mut verifier = Verifier::create("1").unwrap();
         verifier
-            .update_state(&faber.profile, &faber.agency_client, connection)
+            .update_state(
+                &faber.profile.inject_wallet(),
+                &faber.profile.inject_anoncreds_ledger_read(),
+                &faber.profile.inject_anoncreds(),
+                &faber.agency_client,
+                connection,
+            )
             .await
             .unwrap();
         assert_eq!(verifier.get_state(), VerifierState::PresentationProposalReceived);
         verifier
             .decline_presentation_proposal(
-                connection.send_message_closure(&faber.profile).await.unwrap(),
+                connection
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap(),
                 "I don't like Alices",
             )
             .await
@@ -636,7 +742,7 @@ pub mod test_utils {
     ) {
         assert_eq!(prover.get_state(), ProverState::PresentationProposalSent);
         prover
-            .update_state(&alice.profile, &alice.agency_client, connection)
+            .update_state(&alice.profile.inject_wallet(), &alice.agency_client, connection)
             .await
             .unwrap();
         assert_eq!(prover.get_state(), ProverState::Failed);
@@ -661,7 +767,12 @@ pub mod test_utils {
             .unwrap();
         let mut verifier = Verifier::create_from_request("1".to_string(), &presentation_request_data).unwrap();
         verifier
-            .send_presentation_request(connection.send_message_closure(&faber.profile).await.unwrap())
+            .send_presentation_request(
+                connection
+                    .send_message_closure(faber.profile.inject_wallet())
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
         tokio::time::sleep(Duration::from_millis(1000)).await;
@@ -738,7 +849,12 @@ pub mod test_utils {
         if ProverState::PresentationPrepared == prover.get_state() {
             info!("generate_and_send_proof :: proof generated, sending proof");
             prover
-                .send_presentation(connection.send_message_closure(&alice.profile).await.unwrap())
+                .send_presentation(
+                    connection
+                        .send_message_closure(alice.profile.inject_wallet())
+                        .await
+                        .unwrap(),
+                )
                 .await
                 .unwrap();
             info!("generate_and_send_proof :: proof sent");
@@ -749,7 +865,13 @@ pub mod test_utils {
 
     pub async fn verify_proof(faber: &mut Faber, verifier: &mut Verifier, connection: &MediatedConnection) {
         verifier
-            .update_state(&faber.profile, &faber.agency_client, &connection)
+            .update_state(
+                &faber.profile.inject_wallet(),
+                &faber.profile.inject_anoncreds_ledger_read(),
+                &faber.profile.inject_anoncreds(),
+                &faber.agency_client,
+                &connection,
+            )
             .await
             .unwrap();
         assert_eq!(verifier.get_state(), VerifierState::Finished);
@@ -775,7 +897,10 @@ pub mod test_utils {
         let ledger = Arc::clone(&faber.profile).inject_anoncreds_ledger_read();
         let (_, delta, timestamp) = ledger.get_rev_reg_delta_json(&rev_reg_id, None, None).await.unwrap();
         info!("revoking credential locally");
-        issuer_credential.revoke_credential_local(&faber.profile).await.unwrap();
+        issuer_credential
+            .revoke_credential_local(&faber.profile.inject_anoncreds())
+            .await
+            .unwrap();
         let (_, delta_after_revoke, _) = ledger
             .get_rev_reg_delta_json(rev_reg_id, Some(timestamp + 1), None)
             .await
@@ -872,7 +997,13 @@ pub mod test_utils {
             true,
         )
         .await;
-        assert!(!holder_credential.is_revoked(&consumer.profile).await.unwrap());
+        assert!(!holder_credential
+            .is_revoked(
+                &consumer.profile.inject_anoncreds_ledger_read(),
+                &consumer.profile.inject_anoncreds(),
+            )
+            .await
+            .unwrap());
         issuer_credential
     }
 
@@ -973,7 +1104,7 @@ pub mod test_utils {
         requested_values: Option<&str>,
     ) -> SelectedCredentials {
         prover
-            .update_state(&alice.profile, &alice.agency_client, connection)
+            .update_state(&alice.profile.inject_wallet(), &alice.agency_client, connection)
             .await
             .unwrap();
         assert_eq!(prover.get_state(), ProverState::PresentationRequestReceived);

--- a/did_resolver_sov/tests/resolution.rs
+++ b/did_resolver_sov/tests/resolution.rs
@@ -20,7 +20,9 @@ async fn write_test_endpoint(profile: &Arc<dyn Profile>, did: &str) {
         .set_service_endpoint("http://localhost:8080".parse().unwrap())
         .set_routing_keys(Some(vec!["key1".to_string(), "key2".to_string()]))
         .set_types(Some(vec![DidSovServiceType::Endpoint]));
-    write_endpoint(profile, did, &endpoint).await.unwrap();
+    write_endpoint(&profile.inject_indy_ledger_write(), did, &endpoint)
+        .await
+        .unwrap();
     thread::sleep(Duration::from_millis(50));
 }
 

--- a/libvcx_core/src/api_vcx/api_global/ledger.rs
+++ b/libvcx_core/src/api_vcx/api_global/ledger.rs
@@ -30,12 +30,15 @@ pub async fn get_ledger_txn(seq_no: i32, submitter_did: Option<String>) -> Libvc
 
 pub async fn rotate_verkey(did: &str) -> LibvcxResult<()> {
     let profile = get_main_profile()?;
-    map_ariesvcx_result(aries_vcx::common::keys::rotate_verkey(&profile, did).await)
+    map_ariesvcx_result(
+        aries_vcx::common::keys::rotate_verkey(&profile.inject_wallet(), &profile.inject_indy_ledger_write(), did)
+            .await,
+    )
 }
 
 pub async fn get_verkey_from_ledger(did: &str) -> LibvcxResult<String> {
-    let profile = get_main_profile()?;
-    map_ariesvcx_result(aries_vcx::common::keys::get_verkey_from_ledger(&profile, did).await)
+    let indy_ledger = get_main_profile()?.inject_indy_ledger_read();
+    map_ariesvcx_result(aries_vcx::common::keys::get_verkey_from_ledger(&indy_ledger, did).await)
 }
 
 pub async fn ledger_write_endpoint_legacy(
@@ -52,7 +55,7 @@ pub async fn ledger_write_endpoint_legacy(
         .set_recipient_keys(recipient_keys)
         .set_routing_keys(routing_keys);
     let profile = get_main_profile()?;
-    write_endpoint_legacy(&profile, target_did, &service).await?;
+    write_endpoint_legacy(&profile.inject_indy_ledger_write(), target_did, &service).await?;
     Ok(service)
 }
 
@@ -72,24 +75,24 @@ pub async fn ledger_write_endpoint(
         ]))
         .set_routing_keys(Some(routing_keys));
     let profile = get_main_profile()?;
-    write_endpoint(&profile, target_did, &service).await?;
+    write_endpoint(&profile.inject_indy_ledger_write(), target_did, &service).await?;
     Ok(service)
 }
 
 pub async fn ledger_get_service(target_did: &str) -> LibvcxResult<AriesService> {
     let target_did = target_did.to_owned();
     let profile = get_main_profile()?;
-    map_ariesvcx_result(get_service(&profile, &target_did).await)
+    map_ariesvcx_result(get_service(&profile.inject_indy_ledger_read(), &target_did).await)
 }
 
 pub async fn ledger_get_attr(target_did: &str, attr: &str) -> LibvcxResult<String> {
     let profile = get_main_profile()?;
-    map_ariesvcx_result(get_attr(&profile, &target_did, attr).await)
+    map_ariesvcx_result(get_attr(&profile.inject_indy_ledger_read(), &target_did, attr).await)
 }
 
 pub async fn ledger_clear_attr(target_did: &str, attr: &str) -> LibvcxResult<String> {
     let profile = get_main_profile()?;
-    map_ariesvcx_result(clear_attr(&profile, &target_did, attr).await)
+    map_ariesvcx_result(clear_attr(&profile.inject_indy_ledger_write(), &target_did, attr).await)
 }
 
 pub async fn ledger_get_txn_author_agreement() -> LibvcxResult<String> {

--- a/libvcx_core/src/api_vcx/api_global/wallet.rs
+++ b/libvcx_core/src/api_vcx/api_global/wallet.rs
@@ -94,7 +94,15 @@ pub async fn replace_did_keys_start(did: &str) -> LibvcxResult<String> {
 
 pub async fn rotate_verkey_apply(did: &str, temp_vk: &str) -> LibvcxResult<()> {
     let profile = get_main_profile()?;
-    map_ariesvcx_result(aries_vcx::common::keys::rotate_verkey_apply(&profile, did, temp_vk).await)
+    map_ariesvcx_result(
+        aries_vcx::common::keys::rotate_verkey_apply(
+            &profile.inject_wallet(),
+            &profile.inject_indy_ledger_write(),
+            did,
+            temp_vk,
+        )
+        .await,
+    )
 }
 
 pub async fn wallet_unpack_message_to_string(payload: &[u8]) -> LibvcxResult<String> {

--- a/libvcx_core/src/api_vcx/api_handle/connection.rs
+++ b/libvcx_core/src/api_vcx/api_handle/connection.rs
@@ -237,10 +237,10 @@ pub fn get_invitation(handle: u32) -> LibvcxResult<String> {
 pub async fn process_invite(handle: u32, invitation: &str) -> LibvcxResult<()> {
     trace!("process_invite >>>");
 
-    let profile = get_main_profile()?;
+    let ledger = get_main_profile()?.inject_indy_ledger_read();
     let invitation = deserialize(invitation)?;
     let con = get_cloned_connection(&handle)?
-        .accept_invitation(&profile, invitation)
+        .accept_invitation(&ledger, invitation)
         .await?;
 
     insert_connection(handle, con)

--- a/libvcx_core/src/api_vcx/api_handle/credential_def.rs
+++ b/libvcx_core/src/api_vcx/api_handle/credential_def.rs
@@ -177,7 +177,8 @@ pub mod tests {
         SetupGlobalsWalletPoolAgency::run(|setup| async move {
             let profile = get_main_profile().unwrap();
             let (schema_id, _) = create_and_write_test_schema(
-                &profile,
+                &profile.inject_anoncreds(),
+                &profile.inject_anoncreds_ledger_write(),
                 &setup.setup.institution_did,
                 utils::constants::DEFAULT_SCHEMA_ATTRS,
             )

--- a/libvcx_core/src/api_vcx/api_handle/credential_def.rs
+++ b/libvcx_core/src/api_vcx/api_handle/credential_def.rs
@@ -27,7 +27,14 @@ pub async fn create(source_id: String, schema_id: String, tag: String, support_r
             )
         })?;
     let profile = get_main_profile()?;
-    let cred_def = CredentialDef::create(&profile, source_id, config, support_revocation).await?;
+    let cred_def = CredentialDef::create(
+        &profile.inject_anoncreds_ledger_read(),
+        &profile.inject_anoncreds(),
+        source_id,
+        config,
+        support_revocation,
+    )
+    .await?;
     let handle = CREDENTIALDEF_MAP.add(cred_def)?;
     Ok(handle)
 }
@@ -36,7 +43,12 @@ pub async fn publish(handle: u32) -> LibvcxResult<()> {
     let mut cd = CREDENTIALDEF_MAP.get_cloned(handle)?;
     if !cd.was_published() {
         let profile = get_main_profile()?;
-        cd = cd.publish_cred_def(&profile).await?;
+        cd = cd
+            .publish_cred_def(
+                &profile.inject_anoncreds_ledger_read(),
+                &profile.inject_anoncreds_ledger_write(),
+            )
+            .await?;
     } else {
         info!("publish >>> Credential definition was already published")
     }
@@ -78,7 +90,7 @@ pub fn release_all() {
 pub async fn update_state(handle: u32) -> LibvcxResult<u32> {
     let mut cd = CREDENTIALDEF_MAP.get_cloned(handle)?;
     let profile = get_main_profile()?;
-    let res = cd.update_state(&profile).await?;
+    let res = cd.update_state(&profile.inject_anoncreds_ledger_read()).await?;
     CREDENTIALDEF_MAP.insert(handle, cd)?;
     Ok(res)
 }

--- a/libvcx_core/src/api_vcx/api_handle/mediated_connection.rs
+++ b/libvcx_core/src/api_vcx/api_handle/mediated_connection.rs
@@ -348,7 +348,7 @@ pub async fn send_message_closure(handle: u32) -> LibvcxResult<SendClosure> {
     let connection = CONNECTION_MAP.get_cloned(handle)?;
     let profile = get_main_profile_optional_pool(); // do not throw if pool is not open
     connection
-        .send_message_closure(&profile)
+        .send_message_closure(profile.inject_wallet())
         .await
         .map_err(|err| err.into())
 }

--- a/libvcx_core/src/api_vcx/api_handle/proof.rs
+++ b/libvcx_core/src/api_vcx/api_handle/proof.rs
@@ -70,14 +70,24 @@ pub async fn update_state(handle: u32, message: Option<&str>, connection_handle:
         })?;
         trace!("proof::update_state >>> updating using message {:?}", message);
         proof
-            .handle_message(&profile, message.into(), Some(send_message))
+            .handle_message(
+                &profile.inject_anoncreds_ledger_read(),
+                &profile.inject_anoncreds(),
+                message.into(),
+                Some(send_message),
+            )
             .await?;
     } else {
         let messages = mediated_connection::get_messages(connection_handle).await?;
         trace!("proof::update_state >>> found messages: {:?}", messages);
         if let Some((uid, message)) = proof.find_message_to_handle(messages) {
             proof
-                .handle_message(&profile, message.into(), Some(send_message))
+                .handle_message(
+                    &profile.inject_anoncreds_ledger_read(),
+                    &profile.inject_anoncreds(),
+                    message.into(),
+                    Some(send_message),
+                )
                 .await?;
             mediated_connection::update_message_status(connection_handle, &uid).await?;
         };
@@ -116,7 +126,12 @@ pub async fn update_state_nonmediated(handle: u32, connection_handle: u32, messa
         )
     })?;
     proof
-        .handle_message(&profile, message.into(), Some(send_message))
+        .handle_message(
+            &profile.inject_anoncreds_ledger_read(),
+            &profile.inject_anoncreds(),
+            message.into(),
+            Some(send_message),
+        )
         .await?;
 
     let state: u32 = proof.get_state().into();

--- a/libvcx_core/src/api_vcx/api_handle/proof.rs
+++ b/libvcx_core/src/api_vcx/api_handle/proof.rs
@@ -31,7 +31,7 @@ pub async fn create_proof(
     name: String,
 ) -> LibvcxResult<u32> {
     let profile = get_main_profile()?;
-    let presentation_request = PresentationRequestData::create(&profile, &name)
+    let presentation_request = PresentationRequestData::create(&profile.inject_anoncreds(), &name)
         .await?
         .set_requested_attributes_as_string(requested_attrs)?
         .set_requested_predicates_as_string(requested_predicates)?

--- a/libvcx_core/src/api_vcx/api_handle/schema.rs
+++ b/libvcx_core/src/api_vcx/api_handle/schema.rs
@@ -167,8 +167,6 @@ pub mod test_utils {
 #[cfg(test)]
 pub mod tests {
     #[cfg(feature = "pool_tests")]
-    use aries_vcx::common::ledger::transactions::add_new_did;
-    #[cfg(feature = "pool_tests")]
     use aries_vcx::common::test_utils::create_and_write_test_schema;
     #[cfg(feature = "pool_tests")]
     use aries_vcx::utils::constants;

--- a/libvcx_core/src/api_vcx/api_handle/schema.rs
+++ b/libvcx_core/src/api_vcx/api_handle/schema.rs
@@ -270,7 +270,12 @@ pub mod tests {
             let profile = get_main_profile().unwrap();
 
             let (schema_id, _) =
-                create_and_write_test_schema(&profile, &setup.setup.institution_did, constants::DEFAULT_SCHEMA_ATTRS)
+                create_and_write_test_schema(
+                    &profile.inject_anoncreds(),
+                    &profile.inject_anoncreds_ledger_write(),
+                    &setup.setup.institution_did,
+                    constants::DEFAULT_SCHEMA_ATTRS
+                )
                     .await;
 
             let (schema_handle, schema_attrs) = get_schema_attrs("id".to_string(), schema_id.clone()).await.unwrap();

--- a/libvcx_core/src/api_vcx/api_handle/schema.rs
+++ b/libvcx_core/src/api_vcx/api_handle/schema.rs
@@ -269,14 +269,13 @@ pub mod tests {
         SetupGlobalsWalletPoolAgency::run(|setup| async move {
             let profile = get_main_profile().unwrap();
 
-            let (schema_id, _) =
-                create_and_write_test_schema(
-                    &profile.inject_anoncreds(),
-                    &profile.inject_anoncreds_ledger_write(),
-                    &setup.setup.institution_did,
-                    constants::DEFAULT_SCHEMA_ATTRS
-                )
-                    .await;
+            let (schema_id, _) = create_and_write_test_schema(
+                &profile.inject_anoncreds(),
+                &profile.inject_anoncreds_ledger_write(),
+                &setup.setup.institution_did,
+                constants::DEFAULT_SCHEMA_ATTRS,
+            )
+            .await;
 
             let (schema_handle, schema_attrs) = get_schema_attrs("id".to_string(), schema_id.clone()).await.unwrap();
 

--- a/libvcx_core/src/api_vcx/api_handle/schema.rs
+++ b/libvcx_core/src/api_vcx/api_handle/schema.rs
@@ -44,10 +44,17 @@ pub async fn create_and_publish_schema(
         )
     })?;
     let profile = get_main_profile()?;
-    let schema = Schema::create(&profile, source_id, &issuer_did, &name, &version, &data)
-        .await?
-        .publish(&profile, None)
-        .await?;
+    let schema = Schema::create(
+        &profile.inject_anoncreds(),
+        source_id,
+        &issuer_did,
+        &name,
+        &version,
+        &data,
+    )
+    .await?
+    .publish(&profile.inject_anoncreds_ledger_write(), None)
+    .await?;
     std::thread::sleep(std::time::Duration::from_millis(100));
     debug!("created schema on ledger with id: {}", schema.get_schema_id());
 
@@ -63,7 +70,8 @@ pub async fn get_schema_attrs(source_id: String, schema_id: String) -> LibvcxRes
         schema_id
     );
     let profile = get_main_profile()?;
-    let schema = Schema::create_from_ledger_json(&profile, &source_id, &schema_id).await?;
+    let schema =
+        Schema::create_from_ledger_json(&profile.inject_anoncreds_ledger_read(), &source_id, &schema_id).await?;
     let schema_json = schema.to_string_versioned()?;
 
     let handle = SCHEMA_MAP
@@ -109,7 +117,7 @@ pub async fn update_state(schema_handle: u32) -> LibvcxResult<u32> {
     let pool_handle = get_main_pool_handle()?;
     let mut schema = SCHEMA_MAP.get_cloned(schema_handle)?;
     let profile = indy_handles_to_profile(wallet_handle, pool_handle);
-    let res = schema.update_state(&profile).await?;
+    let res = schema.update_state(&profile.inject_anoncreds_ledger_read()).await?;
     SCHEMA_MAP.insert(schema_handle, schema)?;
     Ok(res)
 }

--- a/uniffi_aries_vcx/core/src/handlers/connection/connection.rs
+++ b/uniffi_aries_vcx/core/src/handlers/connection/connection.rs
@@ -64,7 +64,9 @@ impl Connection {
         let connection = VcxConnection::try_from(handler.clone())?;
 
         block_on(async {
-            let new_conn = connection.accept_invitation(&profile.inner, invitation).await?;
+            let new_conn = connection
+                .accept_invitation(&profile.inner.inject_indy_ledger_read(), invitation)
+                .await?;
             *handler = VcxGenericConnection::from(new_conn);
             Ok(())
         })


### PR DESCRIPTION
`Profile` abstraction has been introduced to enable smooth transition from `vdrtools` to modular libs (credx/anoncreds, indy-vdr, askar). `Profile` represents basket of trait objects to perform variety of operations.

Previously `Profile` was widely present in `aries-vcx` codebase as a convenient way to access various lower-level APIs. However this was at the price of:
- passing references to objects down the stack, even though they were never used,
- requiring `aries-vcx` consumers to build entire "Profile", even though the APIs they've consequently used only used limited number of profile's components (eg, you don't need access to ledger in order to build credential proposal, for example)
- forcing `aries-vcx` to store building blocks in particular way (Profiles) - but consuming applications might want to store/handle things differntly.

This PR modifies `aries-vcx` and `aries-vcx-core` method signatures to be unaware of `Profile` abstraction - the APIs now only speak in terms of individual components such as `dyn BaseAnoncreds`, `dyn AnoncredsLedgerRead` - so the APIs ask only for what they really need.
Additional extra benefit is that it's now much easier to spot fishy stuff, like "oh, this method requires access to ledger? That's weird, why is that???"

