### PR TITLE
Fix 877: Connection Requests with empty DIDDoc pubkey controller

### DIFF
--- a/aries_vcx/src/protocols/connection/invitee/mod.rs
+++ b/aries_vcx/src/protocols/connection/invitee/mod.rs
@@ -101,10 +101,10 @@ impl InviteeConnection<Invited> {
         let id = Uuid::new_v4().to_string();
 
         let mut did_doc = AriesDidDoc::default();
+        did_doc.id = self.pairwise_info.pw_did.to_string();
         did_doc.set_service_endpoint(service_endpoint);
         did_doc.set_routing_keys(routing_keys);
         did_doc.set_recipient_keys(recipient_keys);
-        did_doc.id = self.pairwise_info.pw_did.to_string();
 
         let con_data = ConnectionData::new(self.pairwise_info.pw_did.to_string(), did_doc);
         let content = RequestContent::new(self.source_id.to_string(), con_data);


### PR DESCRIPTION
Fixes #877 , pls see ticket for more info.

i can write a test if desired, but I've tested this fix against ACA-py 0.8.1 and confirmed the problem is resolved. this bug was likely just an oversight, as all other AriesDidDoc constructions (exception this one) involved setting the `id` first.