### PR TITLE
Implementation of did:peer:2 DID method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "did_peer"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "base64 0.21.2",
+ "bs58 0.5.0",
+ "did_doc",
+ "did_doc_sov",
+ "did_parser",
+ "did_resolver",
+ "multibase",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "did_resolver"
 version = "0.1.0"
 dependencies = [
@@ -3134,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -3699,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3710,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
@@ -3992,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -4010,9 +4031,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4959,6 +4980,12 @@ dependencies = [
  "generic-array 0.14.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "aries_vcx_core",
     "uniffi_aries_vcx/core",
     "did_doc",
+    "did_peer",
     "did_doc_sov",
     "did_parser",
     "did_resolver",

--- a/did_doc/src/schema/verification_method/mod.rs
+++ b/did_doc/src/schema/verification_method/mod.rs
@@ -1,0 +1,11 @@
+mod public_key;
+mod verification_method;
+mod verification_method_kind;
+mod verification_method_type;
+
+pub use public_key::PublicKeyField;
+pub use verification_method::{
+    CompleteVerificationMethodBuilder, IncompleteVerificationMethodBuilder, VerificationMethod,
+};
+pub use verification_method_kind::VerificationMethodKind;
+pub use verification_method_type::VerificationMethodType;

--- a/did_doc/src/schema/verification_method/public_key.rs
+++ b/did_doc/src/schema/verification_method/public_key.rs
@@ -1,0 +1,112 @@
+use std::str::FromStr;
+
+use base64::{engine::general_purpose, Engine};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::DidDocumentBuilderError,
+    schema::types::{jsonwebkey::JsonWebKey, multibase::Multibase},
+};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(untagged)]
+#[serde(deny_unknown_fields)]
+pub enum PublicKeyField {
+    #[serde(rename_all = "camelCase")]
+    Multibase { public_key_multibase: String },
+    #[serde(rename_all = "camelCase")]
+    Jwk { public_key_jwk: JsonWebKey },
+    #[serde(rename_all = "camelCase")]
+    Base58 { public_key_base58: String },
+    #[serde(rename_all = "camelCase")]
+    Base64 { public_key_base64: String },
+    #[serde(rename_all = "camelCase")]
+    Hex { public_key_hex: String },
+    #[serde(rename_all = "camelCase")]
+    Pem { public_key_pem: String },
+    #[serde(rename_all = "camelCase")]
+    Pgp { public_key_pgp: String },
+}
+
+impl PublicKeyField {
+    pub fn key_decoded(&self) -> Result<Vec<u8>, DidDocumentBuilderError> {
+        match self {
+            PublicKeyField::Multibase {
+                public_key_multibase,
+            } => {
+                let multibase = Multibase::from_str(public_key_multibase)?;
+                Ok(multibase.as_ref().to_vec())
+            }
+            PublicKeyField::Jwk { public_key_jwk } => public_key_jwk.to_vec(),
+            PublicKeyField::Base58 { public_key_base58 } => {
+                Ok(bs58::decode(public_key_base58).into_vec()?)
+            }
+            PublicKeyField::Base64 { public_key_base64 } => {
+                Ok(general_purpose::STANDARD_NO_PAD.decode(public_key_base64.as_bytes())?)
+            }
+            PublicKeyField::Hex { public_key_hex } => Ok(hex::decode(public_key_hex)?),
+            PublicKeyField::Pem { public_key_pem } => {
+                Ok(pem::parse(public_key_pem.as_bytes())?.contents().to_vec())
+            }
+            PublicKeyField::Pgp { public_key_pgp: _ } => Err(
+                DidDocumentBuilderError::UnsupportedPublicKeyField("publicKeyPgp"),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static PUBLIC_KEY_MULTIBASE: &str = "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc";
+    static PUBLIC_KEY_BASE58: &str = "6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc";
+    static PUBLIC_KEY_BASE64: &str = "7AEEiIVxASfd1+8HamOWE5BCi6vqNfL13mzYUoQk1M4mKQ";
+    static PUBLIC_KEY_HEX: &str =
+        "ec01048885710127ddd7ef076a63961390428babea35f2f5de6cd8528424d4ce2629";
+    static PUBLIC_KEY_BYTES: [u8; 34] = [
+        236, 1, 4, 136, 133, 113, 1, 39, 221, 215, 239, 7, 106, 99, 150, 19, 144, 66, 139, 171,
+        234, 53, 242, 245, 222, 108, 216, 82, 132, 36, 212, 206, 38, 41,
+    ];
+
+    #[test]
+    fn test_multibase() {
+        let public_key_field = PublicKeyField::Multibase {
+            public_key_multibase: PUBLIC_KEY_MULTIBASE.to_string(),
+        };
+        assert_eq!(public_key_field.key_decoded().unwrap(), PUBLIC_KEY_BYTES);
+    }
+
+    #[test]
+    fn test_base58() {
+        let public_key_field = PublicKeyField::Base58 {
+            public_key_base58: PUBLIC_KEY_BASE58.to_string(),
+        };
+        assert_eq!(
+            public_key_field.key_decoded().unwrap(),
+            PUBLIC_KEY_BYTES.to_vec()
+        );
+    }
+
+    #[test]
+    fn test_base64() {
+        let public_key_field = PublicKeyField::Base64 {
+            public_key_base64: PUBLIC_KEY_BASE64.to_string(),
+        };
+        assert_eq!(
+            public_key_field.key_decoded().unwrap(),
+            PUBLIC_KEY_BYTES.to_vec()
+        );
+    }
+
+    #[test]
+    fn test_hex() {
+        let public_key_field = PublicKeyField::Hex {
+            public_key_hex: PUBLIC_KEY_HEX.to_string(),
+        };
+        assert_eq!(
+            public_key_field.key_decoded().unwrap(),
+            PUBLIC_KEY_BYTES.to_vec()
+        );
+    }
+}

--- a/did_doc/src/schema/verification_method/verification_method_kind.rs
+++ b/did_doc/src/schema/verification_method/verification_method_kind.rs
@@ -1,0 +1,13 @@
+use did_parser::DidUrl;
+use serde::{Deserialize, Serialize};
+
+use super::VerificationMethod;
+
+// Either a set of verification methods maps or DID URLs
+// https://www.w3.org/TR/did-core/#did-document-properties
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(untagged)]
+pub enum VerificationMethodKind {
+    Resolved(VerificationMethod),
+    Resolvable(DidUrl),
+}

--- a/did_doc/src/schema/verification_method/verification_method_type.rs
+++ b/did_doc/src/schema/verification_method/verification_method_type.rs
@@ -1,0 +1,48 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum VerificationMethodType {
+    JsonWebKey2020,
+    EcdsaSecp256k1VerificationKey2019,
+    Ed25519VerificationKey2018,
+    Ed25519VerificationKey2020,
+    Bls12381G1Key2020,
+    Bls12381G2Key2020,
+    PgpVerificationKey2021,
+    RsaVerificationKey2018,
+    X25519KeyAgreementKey2019,
+    X25519KeyAgreementKey2020,
+    EcdsaSecp256k1RecoveryMethod2020,
+}
+
+impl Display for VerificationMethodType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VerificationMethodType::JsonWebKey2020 => write!(f, "JsonWebKey2020"),
+            VerificationMethodType::EcdsaSecp256k1VerificationKey2019 => {
+                write!(f, "EcdsaSecp256k1VerificationKey2019")
+            }
+            VerificationMethodType::Ed25519VerificationKey2018 => {
+                write!(f, "Ed25519VerificationKey2018")
+            }
+            VerificationMethodType::Ed25519VerificationKey2020 => {
+                write!(f, "Ed25519VerificationKey2020")
+            }
+            VerificationMethodType::Bls12381G1Key2020 => write!(f, "Bls12381G1Key2020"),
+            VerificationMethodType::Bls12381G2Key2020 => write!(f, "Bls12381G2Key2020"),
+            VerificationMethodType::PgpVerificationKey2021 => write!(f, "PgpVerificationKey2021"),
+            VerificationMethodType::RsaVerificationKey2018 => write!(f, "RsaVerificationKey2018"),
+            VerificationMethodType::X25519KeyAgreementKey2019 => {
+                write!(f, "X25519KeyAgreementKey2019")
+            }
+            VerificationMethodType::X25519KeyAgreementKey2020 => {
+                write!(f, "X25519KeyAgreementKey2020")
+            }
+            VerificationMethodType::EcdsaSecp256k1RecoveryMethod2020 => {
+                write!(f, "EcdsaSecp256k1RecoveryMethod2020")
+            }
+        }
+    }
+}

--- a/did_doc_sov/src/extra_fields/didcommv1.rs
+++ b/did_doc_sov/src/extra_fields/didcommv1.rs
@@ -68,11 +68,8 @@ impl ExtraFieldsDidCommV1Builder {
         self
     }
 
-    pub fn set_accept<I>(mut self, accept: I) -> Self
-    where
-        I: IntoIterator<Item = AcceptType>,
-    {
-        self.accept = accept.into_iter().collect();
+    pub fn set_accept(mut self, accept: Vec<AcceptType>) -> Self {
+        self.accept = accept;
         self
     }
 
@@ -86,7 +83,7 @@ impl ExtraFieldsDidCommV1Builder {
             priority: self.priority,
             recipient_keys: self.recipient_keys,
             routing_keys: self.routing_keys,
-            accept: self.accept.into_iter().collect(),
+            accept: self.accept,
         }
     }
 }

--- a/did_doc_sov/src/extra_fields/didcommv1.rs
+++ b/did_doc_sov/src/extra_fields/didcommv1.rs
@@ -8,6 +8,7 @@ pub struct ExtraFieldsDidCommV1 {
     priority: u32,
     recipient_keys: Vec<KeyKind>,
     routing_keys: Vec<KeyKind>,
+    #[serde(default)]
     accept: Vec<AcceptType>,
 }
 
@@ -33,11 +34,22 @@ impl ExtraFieldsDidCommV1 {
     }
 }
 
-#[derive(Default)]
 pub struct ExtraFieldsDidCommV1Builder {
     priority: u32,
     recipient_keys: Vec<KeyKind>,
     routing_keys: Vec<KeyKind>,
+    accept: Vec<AcceptType>,
+}
+
+impl Default for ExtraFieldsDidCommV1Builder {
+    fn default() -> Self {
+        Self {
+            priority: 0,
+            recipient_keys: Vec::new(),
+            routing_keys: Vec::new(),
+            accept: vec![AcceptType::DIDCommV1],
+        }
+    }
 }
 
 impl ExtraFieldsDidCommV1Builder {
@@ -56,12 +68,25 @@ impl ExtraFieldsDidCommV1Builder {
         self
     }
 
+    pub fn set_accept<I>(mut self, accept: I) -> Self
+    where
+        I: IntoIterator<Item = AcceptType>,
+    {
+        self.accept = accept.into_iter().collect();
+        self
+    }
+
+    pub fn add_accept(mut self, accept: AcceptType) -> Self {
+        self.accept.push(accept);
+        self
+    }
+
     pub fn build(self) -> ExtraFieldsDidCommV1 {
         ExtraFieldsDidCommV1 {
             priority: self.priority,
             recipient_keys: self.recipient_keys,
             routing_keys: self.routing_keys,
-            accept: vec![AcceptType::DIDCommV1],
+            accept: self.accept.into_iter().collect(),
         }
     }
 }

--- a/did_doc_sov/src/extra_fields/didcommv2.rs
+++ b/did_doc_sov/src/extra_fields/didcommv2.rs
@@ -44,11 +44,8 @@ impl ExtraFieldsDidCommV2Builder {
         self
     }
 
-    pub fn set_accept<I>(mut self, accept: I) -> Self
-    where
-        I: IntoIterator<Item = AcceptType>,
-    {
-        self.accept = accept.into_iter().collect();
+    pub fn set_accept(mut self, accept: Vec<AcceptType>) -> Self {
+        self.accept = accept;
         self
     }
 
@@ -60,7 +57,7 @@ impl ExtraFieldsDidCommV2Builder {
     pub fn build(self) -> ExtraFieldsDidCommV2 {
         ExtraFieldsDidCommV2 {
             routing_keys: self.routing_keys,
-            accept: self.accept.into_iter().collect(),
+            accept: self.accept,
         }
     }
 }

--- a/did_doc_sov/src/extra_fields/didcommv2.rs
+++ b/did_doc_sov/src/extra_fields/didcommv2.rs
@@ -5,8 +5,9 @@ use super::{AcceptType, KeyKind};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtraFieldsDidCommV2 {
-    accept: Vec<AcceptType>,
     routing_keys: Vec<KeyKind>,
+    #[serde(default)]
+    accept: Vec<AcceptType>,
 }
 
 impl ExtraFieldsDidCommV2 {
@@ -23,9 +24,18 @@ impl ExtraFieldsDidCommV2 {
     }
 }
 
-#[derive(Default)]
 pub struct ExtraFieldsDidCommV2Builder {
     routing_keys: Vec<KeyKind>,
+    accept: Vec<AcceptType>,
+}
+
+impl Default for ExtraFieldsDidCommV2Builder {
+    fn default() -> Self {
+        Self {
+            routing_keys: Vec::new(),
+            accept: vec![AcceptType::DIDCommV2],
+        }
+    }
 }
 
 impl ExtraFieldsDidCommV2Builder {
@@ -34,10 +44,23 @@ impl ExtraFieldsDidCommV2Builder {
         self
     }
 
+    pub fn set_accept<I>(mut self, accept: I) -> Self
+    where
+        I: IntoIterator<Item = AcceptType>,
+    {
+        self.accept = accept.into_iter().collect();
+        self
+    }
+
+    pub fn add_accept(mut self, accept: AcceptType) -> Self {
+        self.accept.push(accept);
+        self
+    }
+
     pub fn build(self) -> ExtraFieldsDidCommV2 {
         ExtraFieldsDidCommV2 {
-            accept: vec![AcceptType::DIDCommV2],
             routing_keys: self.routing_keys,
+            accept: self.accept.into_iter().collect(),
         }
     }
 }

--- a/did_doc_sov/src/extra_fields/mod.rs
+++ b/did_doc_sov/src/extra_fields/mod.rs
@@ -9,11 +9,21 @@ pub mod aip1;
 pub mod didcommv1;
 pub mod didcommv2;
 
-#[derive(Serialize, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum AcceptType {
     DIDCommV1,
     DIDCommV2,
     Other(String),
+}
+
+impl From<&str> for AcceptType {
+    fn from(s: &str) -> Self {
+        match s {
+            "didcomm/aip2;env=rfc19" => AcceptType::DIDCommV1,
+            "didcomm/v2" => AcceptType::DIDCommV2,
+            _ => AcceptType::Other(s.to_string()),
+        }
+    }
 }
 
 impl Display for AcceptType {
@@ -36,6 +46,19 @@ impl<'de> Deserialize<'de> for AcceptType {
             "didcomm/aip2;env=rfc19" => Ok(AcceptType::DIDCommV1),
             "didcomm/v2" => Ok(AcceptType::DIDCommV2),
             _ => Ok(AcceptType::Other(s)),
+        }
+    }
+}
+
+impl Serialize for AcceptType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            AcceptType::DIDCommV1 => serializer.serialize_str("didcomm/aip2;env=rfc19"),
+            AcceptType::DIDCommV2 => serializer.serialize_str("didcomm/v2"),
+            AcceptType::Other(other) => serializer.serialize_str(other),
         }
     }
 }

--- a/did_parser/src/did.rs
+++ b/did_parser/src/did.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::DidUrl;
 use crate::{error::ParseError, utils::parse::parse_did_method_id, DidRange};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -13,6 +14,7 @@ pub struct Did {
     id: DidRange,
 }
 
+// TODO: Add a builder / constructor so that we don't have to create strings and parse them?
 impl Did {
     pub fn parse(did: String) -> Result<Self, ParseError> {
         let (_, method, id) = parse_did_method_id(&did)?;
@@ -89,5 +91,11 @@ impl<'de> Deserialize<'de> for Did {
     {
         let did = String::deserialize(deserializer)?;
         Self::parse(did).map_err(serde::de::Error::custom)
+    }
+}
+
+impl From<Did> for DidUrl {
+    fn from(did: Did) -> Self {
+        Self::from_did_parts(did.did().to_string(), 0..did.did.len(), did.method, did.id)
     }
 }

--- a/did_parser/src/did_url.rs
+++ b/did_parser/src/did_url.rs
@@ -146,6 +146,48 @@ impl DidUrl {
             })
             .collect()
     }
+
+    // TODO: Ideally we would have a builder instead of purpose-specific constructors
+    pub fn from_fragment(fragment: String) -> Result<Self, ParseError> {
+        // TODO: Better validation
+        if fragment.contains("#") {
+            return Err(ParseError::InvalidInput(
+                "Fragment cannot contain '#' character",
+            ));
+        }
+        if fragment.is_empty() {
+            return Err(ParseError::InvalidInput("Empty fragment"));
+        }
+        let len = fragment.len();
+        Ok(Self {
+            did_url: format!("#{}", fragment),
+            did: None,
+            method: None,
+            id: None,
+            path: None,
+            fragment: Some(1..len + 1),
+            queries: HashMap::new(),
+            params: HashMap::new(),
+        })
+    }
+
+    pub(crate) fn from_did_parts(
+        did_url: String,
+        did: DidRange,
+        method: DidRange,
+        id: DidRange,
+    ) -> Self {
+        Self {
+            did_url,
+            did: Some(did),
+            method: Some(method),
+            id: Some(id),
+            path: None,
+            fragment: None,
+            queries: HashMap::new(),
+            params: HashMap::new(),
+        }
+    }
 }
 
 impl TryFrom<String> for DidUrl {

--- a/did_peer/Cargo.toml
+++ b/did_peer/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "did_peer"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+did_parser = { path = "../did_parser" }
+did_doc = { path = "../did_doc" }
+did_doc_sov = { path = "../did_doc_sov" }
+did_resolver = { path = "../did_resolver" }
+thiserror = "1.0.40"
+regex = "1.8.4"
+serde = { version = "1.0.164", features = ["derive"] }
+serde_json = "1.0.96"
+async-trait = "0.1.68"
+base64 = "0.21.2"
+bs58 = "0.5.0"
+multibase = "0.9.1"
+unsigned-varint = "0.7.1"
+once_cell = "1.18.0"
+
+[dev-dependencies]
+tokio = { version = "1.27.0", default-features = false, features = ["macros", "rt"] }

--- a/did_peer/src/error.rs
+++ b/did_peer/src/error.rs
@@ -1,0 +1,69 @@
+use std::convert::Infallible;
+
+use did_doc::schema::verification_method::VerificationMethodType;
+use thiserror::Error;
+
+use crate::peer_did::Numalgo;
+
+#[derive(Debug, Error)]
+pub enum DidPeerError {
+    #[error("DID parser error: {0}")]
+    DidParserError(#[from] did_parser::ParseError),
+    #[error("DID validation error: {0}")]
+    DidValidationError(String),
+    #[error("DID document builder error: {0}")]
+    DidDocumentBuilderError(#[from] did_doc::error::DidDocumentBuilderError),
+    #[error("Invalid key reference: {0}")]
+    InvalidKeyReference(String),
+    #[error("Invalid service type")]
+    InvalidServiceType,
+    #[error("Sovrin DID document builder error: {0}")]
+    DidDocumentSovBuilderError(#[from] did_doc_sov::error::DidDocumentSovError),
+    #[error("Unsupported numalgo: {0}")]
+    UnsupportedNumalgo(Numalgo),
+    #[error("Invalid numalgo character: {0}")]
+    InvalidNumalgoCharacter(char),
+    #[error("Unsupported purpose character: {0}")]
+    UnsupportedPurpose(char),
+    #[error("Unsupported multicodec descriptor: {0}")]
+    UnsupportedMulticodecDescriptor(u64),
+    #[error("Unsupported verification method type: {0}")]
+    UnsupportedVerificationMethodType(VerificationMethodType),
+    #[error("Base 64 decoding error")]
+    Base64DecodingError(#[from] base64::DecodeError),
+    #[error("Multibase decoding error")]
+    MultibaseDecodingError(#[from] multibase::Error),
+    #[error("Varint decoding error")]
+    VarintDecodingError(#[from] VarintDecodingError),
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("Regex error: {0}")]
+    RegexError(#[from] regex::Error),
+}
+
+impl From<Infallible> for DidPeerError {
+    fn from(_: Infallible) -> Self {
+        panic!("Attempted to convert an Infallible error")
+    }
+}
+
+#[derive(Debug, Error)]
+pub struct VarintDecodingError(unsigned_varint::decode::Error);
+
+impl std::fmt::Display for VarintDecodingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Varint decoding error: {}", self.0)
+    }
+}
+
+impl From<unsigned_varint::decode::Error> for VarintDecodingError {
+    fn from(error: unsigned_varint::decode::Error) -> Self {
+        Self(error)
+    }
+}
+
+impl From<unsigned_varint::decode::Error> for DidPeerError {
+    fn from(error: unsigned_varint::decode::Error) -> Self {
+        Self::VarintDecodingError(error.into())
+    }
+}

--- a/did_peer/src/key/key.rs
+++ b/did_peer/src/key/key.rs
@@ -37,6 +37,10 @@ impl Key {
         multibase::encode(multibase::Base::Base58Btc, &self.multicodec_prefixed_key())
     }
 
+    pub fn prefixless_fingerprint(&self) -> String {
+        self.fingerprint().trim_start_matches('z').to_string()
+    }
+
     pub fn base58(&self) -> String {
         bs58::encode(&self.key).into_string()
     }

--- a/did_peer/src/key/key.rs
+++ b/did_peer/src/key/key.rs
@@ -1,0 +1,244 @@
+use crate::error::DidPeerError;
+
+use super::SupportedKeyType;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Key {
+    key_type: SupportedKeyType,
+    key: Vec<u8>,
+}
+
+impl Key {
+    pub fn new(key: Vec<u8>, key_type: SupportedKeyType) -> Result<Self, DidPeerError> {
+        // If the key is a multibase key coming from a verification method, for some reason it is also
+        // multicodec encoded, so we need to strip that. But should it be?
+        let key = Self::strip_multicodec_prefix_if_present(key, &key_type);
+        Ok(Self { key_type, key })
+    }
+
+    pub fn key_type(&self) -> &SupportedKeyType {
+        &self.key_type
+    }
+
+    pub fn key(&self) -> &[u8] {
+        self.key.as_ref()
+    }
+
+    pub fn prefixed_key(&self) -> Vec<u8> {
+        let code = self.key_type().into();
+        let mut buffer = [0u8; 10];
+        let bytes = unsigned_varint::encode::u64(code, &mut buffer);
+        let mut prefixed_key = bytes.to_vec();
+        prefixed_key.extend_from_slice(&self.key);
+        prefixed_key
+    }
+
+    pub fn fingerprint(&self) -> String {
+        multibase::encode(multibase::Base::Base58Btc, &self.prefixed_key())
+    }
+
+    pub fn prefixless_fingerprint(&self) -> String {
+        self.fingerprint().trim_start_matches('z').to_string()
+    }
+
+    pub fn base58(&self) -> String {
+        bs58::encode(&self.key).into_string()
+    }
+
+    pub fn multibase(&self) -> String {
+        multibase::encode(multibase::Base::Base58Btc, &self.key)
+    }
+
+    pub fn from_fingerprint(fingerprint: &str) -> Result<Self, DidPeerError> {
+        let (_base, decoded_bytes) = multibase::decode(fingerprint)?;
+        let (code, remaining_bytes) = unsigned_varint::decode::u64(&decoded_bytes)?;
+        Ok(Self {
+            key_type: code.try_into()?,
+            key: remaining_bytes.to_vec(),
+        })
+    }
+
+    fn strip_multicodec_prefix_if_present(key: Vec<u8>, key_type: &SupportedKeyType) -> Vec<u8> {
+        if let Ok((value, remaining)) = unsigned_varint::decode::u64(&key) {
+            if value == Into::<u64>::into(key_type) {
+                remaining.to_vec()
+            } else {
+                key
+            }
+        } else {
+            key
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_key_test(key_bytes: Vec<u8>, key_type: SupportedKeyType) {
+        let key = Key::new(key_bytes.clone(), key_type.clone());
+        assert!(key.is_ok());
+        let key = key.unwrap();
+        assert_eq!(key.key_type(), &key_type);
+        assert_eq!(key.key(), key_bytes.as_slice());
+    }
+
+    fn prefixed_key_test(
+        key_bytes: Vec<u8>,
+        key_type: SupportedKeyType,
+        expected_prefixed_key: String,
+        encode_fn: fn(Vec<u8>) -> String,
+    ) {
+        let key = Key::new(key_bytes, key_type).unwrap();
+        let prefixed_key = key.prefixed_key();
+        assert_eq!(expected_prefixed_key, encode_fn(prefixed_key),);
+    }
+
+    fn fingerprint_test(key_bytes: Vec<u8>, key_type: SupportedKeyType, expected_fingerprint: &str) {
+        let key = Key::new(key_bytes, key_type).unwrap();
+        let fingerprint = key.fingerprint();
+        assert_eq!(fingerprint, expected_fingerprint);
+    }
+
+    fn base58_test(key_bytes: Vec<u8>, key_type: SupportedKeyType, expected_base58: &str) {
+        let key = Key::new(key_bytes, key_type).unwrap();
+        let base58 = key.base58();
+        assert_eq!(base58, expected_base58);
+    }
+
+    fn from_fingerprint_test(key_bytes: Vec<u8>, key_type: SupportedKeyType, fingerprint: &str) {
+        let key = Key::new(key_bytes, key_type).unwrap();
+        let key_from_fingerprint = Key::from_fingerprint(fingerprint);
+        assert!(key_from_fingerprint.is_ok());
+        let key_from_fingerprint = key_from_fingerprint.unwrap();
+        assert_eq!(key.key_type(), key_from_fingerprint.key_type());
+        assert_eq!(key.key(), key_from_fingerprint.key());
+        assert_eq!(key.prefixed_key(), key_from_fingerprint.prefixed_key());
+        assert_eq!(key.fingerprint(), fingerprint);
+        assert_eq!(key_from_fingerprint.fingerprint(), fingerprint);
+    }
+
+    fn strip_multicodec_prefix_if_present_test(key_bytes: Vec<u8>, key_type: &SupportedKeyType) {
+        let key_type_u64: u64 = key_type.into();
+
+        let mut buffer = [0u8; 10];
+        let key_type_bytes = unsigned_varint::encode::u64(key_type_u64, &mut buffer);
+        let mut prefixed_key = key_type_bytes.to_vec();
+        prefixed_key.extend_from_slice(&key_bytes);
+
+        let (_, remaining_bytes) = unsigned_varint::decode::u64(&prefixed_key).unwrap();
+        let manually_stripped_key = remaining_bytes.to_vec();
+
+        let function_stripped_key = Key::strip_multicodec_prefix_if_present(prefixed_key, &key_type);
+        assert_eq!(function_stripped_key, manually_stripped_key);
+
+        let no_prefix_stripped_key = Key::strip_multicodec_prefix_if_present(key_bytes.clone(), &key_type);
+        assert_eq!(no_prefix_stripped_key, key_bytes);
+    }
+
+    #[test]
+    fn from_fingerprint_error_test() {
+        let key = Key::from_fingerprint("this is not a valid fingerprint");
+        assert!(key.is_err());
+    }
+
+    mod ed25519 {
+        use super::*;
+
+        const TEST_KEY_BASE58: &str = "8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K";
+        const TEST_FINGERPRINT: &str = "z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th";
+
+        fn key_bytes() -> Vec<u8> {
+            bs58::decode(TEST_KEY_BASE58).into_vec().unwrap()
+        }
+
+        fn encode_multibase(key_bytes: Vec<u8>) -> String {
+            multibase::encode(multibase::Base::Base58Btc, &key_bytes)
+        }
+
+        #[test]
+        fn new_key_test() {
+            super::new_key_test(key_bytes(), SupportedKeyType::Ed25519);
+        }
+
+        #[test]
+        fn prefixed_key_test() {
+            super::prefixed_key_test(
+                key_bytes(),
+                SupportedKeyType::Ed25519,
+                TEST_FINGERPRINT.to_string(),
+                encode_multibase,
+            );
+        }
+
+        #[test]
+        fn fingerprint_test() {
+            super::fingerprint_test(key_bytes(), SupportedKeyType::Ed25519, TEST_FINGERPRINT);
+        }
+
+        #[test]
+        fn base58_test() {
+            super::base58_test(key_bytes(), SupportedKeyType::Ed25519, TEST_KEY_BASE58);
+        }
+
+        #[test]
+        fn from_fingerprint_test() {
+            super::from_fingerprint_test(key_bytes(), SupportedKeyType::Ed25519, TEST_FINGERPRINT);
+        }
+
+        #[test]
+        fn strip_multicodec_prefix_if_present_test() {
+            super::strip_multicodec_prefix_if_present_test(key_bytes(), &SupportedKeyType::Ed25519);
+        }
+    }
+
+    mod x25519 {
+        use super::*;
+
+        const TEST_KEY_BASE58: &str = "6fUMuABnqSDsaGKojbUF3P7ZkEL3wi2njsDdUWZGNgCU";
+        const TEST_FINGERPRINT: &str = "z6LShLeXRTzevtwcfehaGEzCMyL3bNsAeKCwcqwJxyCo63yE";
+
+        fn key_bytes() -> Vec<u8> {
+            bs58::decode(TEST_KEY_BASE58).into_vec().unwrap()
+        }
+
+        fn encode_multibase(key_bytes: Vec<u8>) -> String {
+            multibase::encode(multibase::Base::Base58Btc, &key_bytes)
+        }
+
+        #[test]
+        fn new_key_test() {
+            super::new_key_test(key_bytes(), SupportedKeyType::X25519);
+        }
+
+        #[test]
+        fn prefixed_key_test() {
+            super::prefixed_key_test(
+                key_bytes(),
+                SupportedKeyType::X25519,
+                TEST_FINGERPRINT.to_string(),
+                encode_multibase,
+            );
+        }
+
+        #[test]
+        fn fingerprint_test() {
+            super::fingerprint_test(key_bytes(), SupportedKeyType::X25519, TEST_FINGERPRINT);
+        }
+
+        #[test]
+        fn base58_test() {
+            super::base58_test(key_bytes(), SupportedKeyType::X25519, TEST_KEY_BASE58);
+        }
+
+        #[test]
+        fn from_fingerprint_test() {
+            super::from_fingerprint_test(key_bytes(), SupportedKeyType::X25519, TEST_FINGERPRINT);
+        }
+
+        #[test]
+        fn strip_multicodec_prefix_if_present_test() {
+            super::strip_multicodec_prefix_if_present_test(key_bytes(), &SupportedKeyType::X25519);
+        }
+    }
+}

--- a/did_peer/src/key/key_type.rs
+++ b/did_peer/src/key/key_type.rs
@@ -1,7 +1,7 @@
 use crate::error::DidPeerError;
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum SupportedKeyType {
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum KeyType {
     Ed25519,
     Bls12381g1g2,
     Bls12381g1,
@@ -12,34 +12,46 @@ pub enum SupportedKeyType {
     P521,
 }
 
-impl From<&SupportedKeyType> for u64 {
-    fn from(key_type: &SupportedKeyType) -> Self {
+impl KeyType {
+    const C_BLS12381G1: u64 = 234;
+    const C_BLS12381G2: u64 = 235;
+    const C_X25519: u64 = 236;
+    const C_ED25519: u64 = 237;
+    const C_BLS12381G1G2: u64 = 238;
+    const C_P256: u64 = 4608;
+    const C_P384: u64 = 4609;
+    const C_P521: u64 = 4610;
+}
+
+// https://github.com/multiformats/multicodec/blob/master/table.csv
+impl From<&KeyType> for u64 {
+    fn from(key_type: &KeyType) -> Self {
         match key_type {
-            SupportedKeyType::Ed25519 => 237,
-            SupportedKeyType::Bls12381g1 => 234,
-            SupportedKeyType::Bls12381g2 => 235,
-            SupportedKeyType::X25519 => 236,
-            SupportedKeyType::P256 => 4608,
-            SupportedKeyType::P384 => 4609,
-            SupportedKeyType::P521 => 4610,
-            SupportedKeyType::Bls12381g1g2 => 238,
+            KeyType::Bls12381g1 => KeyType::C_BLS12381G1,
+            KeyType::Bls12381g2 => KeyType::C_BLS12381G2,
+            KeyType::X25519 => KeyType::C_X25519,
+            KeyType::Ed25519 => KeyType::C_ED25519,
+            KeyType::Bls12381g1g2 => KeyType::C_BLS12381G1G2,
+            KeyType::P256 => KeyType::C_P256,
+            KeyType::P384 => KeyType::C_P384,
+            KeyType::P521 => KeyType::C_P521,
         }
     }
 }
 
-impl TryFrom<u64> for SupportedKeyType {
+impl TryFrom<u64> for KeyType {
     type Error = DidPeerError;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
-            234 => Ok(SupportedKeyType::Bls12381g1),
-            235 => Ok(SupportedKeyType::Bls12381g2),
-            236 => Ok(SupportedKeyType::X25519),
-            237 => Ok(SupportedKeyType::Ed25519),
-            238 => Ok(SupportedKeyType::Bls12381g1g2),
-            4608 => Ok(SupportedKeyType::P256),
-            4609 => Ok(SupportedKeyType::P384),
-            4610 => Ok(SupportedKeyType::P521),
+            KeyType::C_BLS12381G1 => Ok(KeyType::Bls12381g1),
+            KeyType::C_BLS12381G2 => Ok(KeyType::Bls12381g2),
+            KeyType::C_X25519 => Ok(KeyType::X25519),
+            KeyType::C_ED25519 => Ok(KeyType::Ed25519),
+            KeyType::C_BLS12381G1G2 => Ok(KeyType::Bls12381g1g2),
+            KeyType::C_P256 => Ok(KeyType::P256),
+            KeyType::C_P384 => Ok(KeyType::P384),
+            KeyType::C_P521 => Ok(KeyType::P521),
             p @ _ => Err(DidPeerError::UnsupportedMulticodecDescriptor(p)),
         }
     }

--- a/did_peer/src/key/key_type.rs
+++ b/did_peer/src/key/key_type.rs
@@ -1,0 +1,46 @@
+use crate::error::DidPeerError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SupportedKeyType {
+    Ed25519,
+    Bls12381g1g2,
+    Bls12381g1,
+    Bls12381g2,
+    X25519,
+    P256,
+    P384,
+    P521,
+}
+
+impl From<&SupportedKeyType> for u64 {
+    fn from(key_type: &SupportedKeyType) -> Self {
+        match key_type {
+            SupportedKeyType::Ed25519 => 237,
+            SupportedKeyType::Bls12381g1 => 234,
+            SupportedKeyType::Bls12381g2 => 235,
+            SupportedKeyType::X25519 => 236,
+            SupportedKeyType::P256 => 4608,
+            SupportedKeyType::P384 => 4609,
+            SupportedKeyType::P521 => 4610,
+            SupportedKeyType::Bls12381g1g2 => 238,
+        }
+    }
+}
+
+impl TryFrom<u64> for SupportedKeyType {
+    type Error = DidPeerError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            234 => Ok(SupportedKeyType::Bls12381g1),
+            235 => Ok(SupportedKeyType::Bls12381g2),
+            236 => Ok(SupportedKeyType::X25519),
+            237 => Ok(SupportedKeyType::Ed25519),
+            238 => Ok(SupportedKeyType::Bls12381g1g2),
+            4608 => Ok(SupportedKeyType::P256),
+            4609 => Ok(SupportedKeyType::P384),
+            4610 => Ok(SupportedKeyType::P521),
+            p @ _ => Err(DidPeerError::UnsupportedMulticodecDescriptor(p)),
+        }
+    }
+}

--- a/did_peer/src/key/mod.rs
+++ b/did_peer/src/key/mod.rs
@@ -7,5 +7,5 @@ mod key_type;
 mod verification_method;
 
 pub use key::Key;
-pub use key_type::SupportedKeyType;
+pub use key_type::KeyType;
 pub use verification_method::{get_key_by_verification_method, get_verification_methods_by_key};

--- a/did_peer/src/key/mod.rs
+++ b/did_peer/src/key/mod.rs
@@ -1,0 +1,11 @@
+// TODO: Where else should we move this file?
+// depends on: multibase, bs58, unsigned_varint
+// two of which are also deps of did_doc, but did_doc does not use this abstraction
+
+mod key;
+mod key_type;
+mod verification_method;
+
+pub use key::Key;
+pub use key_type::SupportedKeyType;
+pub use verification_method::{get_key_by_verification_method, get_verification_methods_by_key};

--- a/did_peer/src/key/verification_method.rs
+++ b/did_peer/src/key/verification_method.rs
@@ -1,0 +1,228 @@
+use did_doc::schema::verification_method::{
+    IncompleteVerificationMethodBuilder, VerificationMethod, VerificationMethodType,
+};
+use did_parser::{Did, DidUrl};
+
+use crate::{error::DidPeerError, peer_did_resolver::options::PublicKeyEncoding};
+
+use super::{Key, SupportedKeyType};
+
+pub fn get_verification_methods_by_key(
+    key: &Key,
+    did: &Did,
+    public_key_encoding: &PublicKeyEncoding,
+) -> Result<Vec<VerificationMethod>, DidPeerError> {
+    let id = DidUrl::from_fragment(key.prefixless_fingerprint().chars().take(8).collect::<String>())?;
+    let vm_type = match key.key_type() {
+        SupportedKeyType::Ed25519 => VerificationMethodType::Ed25519VerificationKey2020,
+        SupportedKeyType::Bls12381g1 => VerificationMethodType::Bls12381G1Key2020,
+        SupportedKeyType::Bls12381g2 => VerificationMethodType::Bls12381G2Key2020,
+        SupportedKeyType::X25519 => VerificationMethodType::X25519KeyAgreementKey2020,
+        SupportedKeyType::P256 => VerificationMethodType::JsonWebKey2020,
+        SupportedKeyType::P384 => VerificationMethodType::JsonWebKey2020,
+        SupportedKeyType::P521 => VerificationMethodType::JsonWebKey2020,
+        SupportedKeyType::Bls12381g1g2 => {
+            let g1_key = Key::new(key.key()[..48].to_vec(), SupportedKeyType::Bls12381g1)?;
+            let g2_key = Key::new(key.key()[48..].to_vec(), SupportedKeyType::Bls12381g2)?;
+            return Ok(build_verification_methods_from_bls_multikey(
+                g1_key,
+                g2_key,
+                id,
+                did.to_owned(),
+                public_key_encoding,
+            ));
+        }
+    };
+    Ok(build_verification_methods_from_type_and_key(
+        vm_type,
+        key,
+        id,
+        did.to_owned(),
+        public_key_encoding,
+    ))
+}
+
+pub fn get_key_by_verification_method(vm: &VerificationMethod) -> Result<Key, DidPeerError> {
+    let key_type = match vm.verification_method_type() {
+        VerificationMethodType::Ed25519VerificationKey2018 | VerificationMethodType::Ed25519VerificationKey2020 => {
+            SupportedKeyType::Ed25519
+        }
+        VerificationMethodType::Bls12381G1Key2020 => SupportedKeyType::Bls12381g1,
+        VerificationMethodType::Bls12381G2Key2020 => SupportedKeyType::Bls12381g2,
+        VerificationMethodType::X25519KeyAgreementKey2019 | VerificationMethodType::X25519KeyAgreementKey2020 => {
+            SupportedKeyType::X25519
+        }
+        t @ _ => return Err(DidPeerError::UnsupportedVerificationMethodType(t.to_owned())),
+    };
+    Key::new(vm.public_key().key_decoded()?, key_type)
+}
+
+fn build_verification_methods_from_type_and_key(
+    vm_type: VerificationMethodType,
+    key: &Key,
+    id: DidUrl,
+    did: Did,
+    public_key_encoding: &PublicKeyEncoding,
+) -> Vec<VerificationMethod> {
+    vec![VerificationMethod::builder(id, did, vm_type)]
+        .iter()
+        .map(|builder| add_public_key_to_builder(builder.to_owned(), key, public_key_encoding))
+        .collect::<Vec<VerificationMethod>>()
+}
+
+fn build_verification_methods_from_bls_multikey(
+    g1_key: Key,
+    g2_key: Key,
+    id: DidUrl,
+    did: Did,
+    public_key_encoding: &PublicKeyEncoding,
+) -> Vec<VerificationMethod> {
+    vec![
+        VerificationMethod::builder(id.to_owned(), did.to_owned(), VerificationMethodType::Bls12381G1Key2020),
+        VerificationMethod::builder(id, did, VerificationMethodType::Bls12381G2Key2020),
+    ]
+    .iter()
+    .enumerate()
+    .map(|(index, builder)| {
+        let key = match index {
+            0 => &g1_key,
+            1 => &g2_key,
+            _ => unreachable!(),
+        };
+        add_public_key_to_builder(builder.to_owned(), key, public_key_encoding)
+    })
+    .collect::<Vec<VerificationMethod>>()
+}
+
+fn add_public_key_to_builder(
+    builder: IncompleteVerificationMethodBuilder,
+    key: &Key,
+    public_key_encoding: &PublicKeyEncoding,
+) -> VerificationMethod {
+    match public_key_encoding {
+        PublicKeyEncoding::Base58 => builder.add_public_key_base58(key.base58()).build(),
+        PublicKeyEncoding::Multibase => builder.add_public_key_multibase(key.fingerprint()).build(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn did() -> Did {
+        "did:peer:2\
+        .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+        .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+        .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
+            .parse()
+            .unwrap()
+    }
+
+    fn key_0() -> Key {
+        Key::from_fingerprint("z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc").unwrap()
+    }
+
+    fn key_1() -> Key {
+        Key::from_fingerprint("z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V").unwrap()
+    }
+
+    fn key_2() -> Key {
+        Key::from_fingerprint("z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg").unwrap()
+    }
+
+    fn verification_method_0() -> VerificationMethod {
+        VerificationMethod::builder(did().into(), did(), VerificationMethodType::X25519KeyAgreementKey2020)
+            .add_public_key_multibase(key_0().fingerprint())
+            .build()
+    }
+
+    fn verification_method_1() -> VerificationMethod {
+        VerificationMethod::builder(did().into(), did(), VerificationMethodType::Ed25519VerificationKey2020)
+            .add_public_key_multibase(key_1().fingerprint())
+            .build()
+    }
+
+    fn verification_method_2() -> VerificationMethod {
+        VerificationMethod::builder(did().into(), did(), VerificationMethodType::Ed25519VerificationKey2020)
+            .add_public_key_multibase(key_2().fingerprint())
+            .build()
+    }
+
+    mod get_verification_methods_by_key {
+        use super::*;
+
+        // Multibase encoded keys are multicodec-prefixed by their encoding type ...
+        fn test_get_verification_methods_by_key_multibase(key: &Key) {
+            let vms = get_verification_methods_by_key(key, &did(), &PublicKeyEncoding::Multibase).unwrap();
+            assert_eq!(vms.len(), 1);
+            assert_eq!(vms[0].public_key().key_decoded().unwrap(), key.prefixed_key());
+            assert_ne!(vms[0].public_key().key_decoded().unwrap(), key.key());
+        }
+
+        // ... and base58 encoded keys are not
+        fn test_get_verification_methods_by_key_base58(key: &Key) {
+            let vms = get_verification_methods_by_key(key, &did(), &PublicKeyEncoding::Base58).unwrap();
+            assert_eq!(vms.len(), 1);
+            assert_ne!(vms[0].public_key().key_decoded().unwrap(), key.prefixed_key());
+            assert_eq!(vms[0].public_key().key_decoded().unwrap(), key.key());
+        }
+
+        #[test]
+        fn test_get_verification_methods_by_key_multibase_0() {
+            test_get_verification_methods_by_key_multibase(&key_0());
+        }
+
+        #[test]
+        fn test_get_verification_methods_by_key_multibase_1() {
+            test_get_verification_methods_by_key_multibase(&key_1());
+        }
+
+        #[test]
+        fn test_get_verification_methods_by_key_multibase_2() {
+            test_get_verification_methods_by_key_multibase(&key_2());
+        }
+
+        #[test]
+        fn test_get_verification_methods_by_key_base58_0() {
+            test_get_verification_methods_by_key_base58(&key_0());
+        }
+
+        #[test]
+        fn test_get_verification_methods_by_key_base58_1() {
+            test_get_verification_methods_by_key_base58(&key_1());
+        }
+
+        #[test]
+        fn test_get_verification_methods_by_key_base58_2() {
+            test_get_verification_methods_by_key_base58(&key_2());
+        }
+    }
+
+    mod get_key_by_verification_method {
+        use super::*;
+
+        #[test]
+        fn test_get_key_by_verification_method_0() {
+            assert_eq!(
+                get_key_by_verification_method(&verification_method_0()).unwrap(),
+                key_0()
+            );
+        }
+
+        #[test]
+        fn test_get_key_by_verification_method_1() {
+            assert_eq!(
+                get_key_by_verification_method(&verification_method_1()).unwrap(),
+                key_1()
+            );
+        }
+
+        #[test]
+        fn test_get_key_by_verification_method_2() {
+            assert_eq!(
+                get_key_by_verification_method(&verification_method_2()).unwrap(),
+                key_2()
+            );
+        }
+    }
+}

--- a/did_peer/src/lib.rs
+++ b/did_peer/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod error;
+pub mod key;
+mod numalgos;
+pub mod peer_did;
+pub mod peer_did_resolver;

--- a/did_peer/src/numalgos/mod.rs
+++ b/did_peer/src/numalgos/mod.rs
@@ -1,0 +1,1 @@
+pub mod numalgo2;

--- a/did_peer/src/numalgos/numalgo2/generate/helpers.rs
+++ b/did_peer/src/numalgos/numalgo2/generate/helpers.rs
@@ -1,0 +1,256 @@
+use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
+use did_doc::schema::{did_doc::DidDocument, verification_method::VerificationMethodKind};
+use did_doc_sov::extra_fields::ExtraFieldsSov;
+
+use crate::{
+    error::DidPeerError,
+    key::get_key_by_verification_method,
+    numalgos::numalgo2::{purpose::ElementPurpose, service_abbreviated::ServiceAbbreviated},
+};
+
+pub fn append_encoded_key_segments(
+    mut did: String,
+    did_document: &DidDocument<ExtraFieldsSov>,
+) -> Result<String, DidPeerError> {
+    for am in did_document.assertion_method() {
+        did = append_encoded_key_segment(did, &did_document, am, ElementPurpose::Assertion)?;
+    }
+
+    for ka in did_document.key_agreement() {
+        did = append_encoded_key_segment(did, &did_document, ka, ElementPurpose::Encryption)?;
+    }
+
+    for vm in did_document.verification_method() {
+        did = append_encoded_key_segment(
+            did,
+            &did_document,
+            &VerificationMethodKind::Resolved(vm.to_owned()),
+            ElementPurpose::Verification,
+        )?;
+    }
+
+    for a in did_document.authentication() {
+        did = append_encoded_key_segment(did, &did_document, a, ElementPurpose::Verification)?;
+    }
+
+    for ci in did_document.capability_invocation() {
+        did = append_encoded_key_segment(did, &did_document, ci, ElementPurpose::CapabilityInvocation)?;
+    }
+
+    for cd in did_document.capability_delegation() {
+        did = append_encoded_key_segment(did, &did_document, cd, ElementPurpose::CapabilityDelegation)?;
+    }
+
+    Ok(did)
+}
+
+pub fn append_encoded_service_segment(
+    mut did: String,
+    did_document: &DidDocument<ExtraFieldsSov>,
+) -> Result<String, DidPeerError> {
+    let services_abbreviated = did_document
+        .service()
+        .iter()
+        .map(|s| s.try_into())
+        .collect::<Result<Vec<ServiceAbbreviated>, _>>()?;
+
+    let service_encoded = if services_abbreviated.len() == 1 {
+        // SAFETY: We just checked that the length is 1
+        let service_abbreviated = services_abbreviated.first().unwrap();
+        Some(STANDARD_NO_PAD.encode(serde_json::to_vec(&service_abbreviated)?))
+    } else if services_abbreviated.len() > 1 {
+        Some(STANDARD_NO_PAD.encode(serde_json::to_vec(&services_abbreviated)?))
+    } else {
+        None
+    };
+
+    if let Some(service_encoded) = service_encoded {
+        let encoded = format!(".{}{}", ElementPurpose::Service, service_encoded);
+        did.push_str(&encoded);
+    }
+
+    Ok(did)
+}
+
+fn append_encoded_key_segment(
+    mut did: String,
+    did_document: &DidDocument<ExtraFieldsSov>,
+    vm: &VerificationMethodKind,
+    purpose: ElementPurpose,
+) -> Result<String, DidPeerError> {
+    let vm = match vm {
+        VerificationMethodKind::Resolved(vm) => vm,
+        VerificationMethodKind::Resolvable(did_url) => did_document
+            .dereference_key(did_url)
+            .ok_or(DidPeerError::InvalidKeyReference(did_url.to_string()))?,
+    };
+
+    let key = get_key_by_verification_method(vm)?;
+    let encoded = format!(".{}{}", purpose, key.fingerprint());
+    did.push_str(&encoded);
+
+    Ok(did)
+}
+
+#[cfg(test)]
+mod tests {
+    use did_doc::schema::{
+        service::Service,
+        verification_method::{VerificationMethod, VerificationMethodType},
+    };
+    use did_doc_sov::extra_fields::{didcommv2::ExtraFieldsDidCommV2, KeyKind};
+    use did_parser::DidUrl;
+
+    use super::*;
+
+    fn create_verification_method(
+        did_full: String,
+        key: String,
+        verification_type: VerificationMethodType,
+    ) -> VerificationMethod {
+        VerificationMethod::builder(did_full.parse().unwrap(), did_full.parse().unwrap(), verification_type)
+            .add_public_key_multibase(key)
+            .build()
+    }
+
+    fn create_did_document_with_service(
+        did_full: String,
+        service: Service<ExtraFieldsSov>,
+    ) -> DidDocument<ExtraFieldsSov> {
+        DidDocument::<ExtraFieldsSov>::builder(did_full.parse().unwrap())
+            .add_service(service)
+            .build()
+    }
+
+    #[test]
+    fn test_append_encoded_key_segments() {
+        let did = "did:peer:2";
+        let key_0 = "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc";
+        let key_1 = "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V";
+        let did_full = format!("{}.E{}.V{}", did, key_0, key_1);
+
+        let vm_0 = create_verification_method(
+            did_full.to_string(),
+            key_0.to_string(),
+            VerificationMethodType::X25519KeyAgreementKey2020,
+        );
+        let vm_1 = create_verification_method(
+            did_full.to_string(),
+            key_1.to_string(),
+            VerificationMethodType::Ed25519VerificationKey2020,
+        );
+
+        let did_document = DidDocument::<ExtraFieldsSov>::builder(did_full.parse().unwrap())
+            .add_key_agreement(vm_0)
+            .add_verification_method(vm_1)
+            .build();
+
+        let did = append_encoded_key_segments(did.to_string(), &did_document).unwrap();
+        assert_eq!(did, did_full);
+    }
+
+    #[test]
+    fn test_append_encoded_service_segment() {
+        let did = "did:peer:2";
+        let service = "eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0";
+        let did_full = format!("{}.S{}", did, service);
+
+        let extra = ExtraFieldsSov::DIDCommV2(
+            ExtraFieldsDidCommV2::builder()
+                .set_routing_keys(vec![KeyKind::Reference(
+                    "did:example:somemediator#somekey".parse().unwrap(),
+                )])
+                .add_accept("didcomm/aip2;env=rfc587".into())
+                .build(),
+        );
+        let service = Service::<ExtraFieldsSov>::builder(
+            did_full.parse().unwrap(),
+            "https://example.com/endpoint".parse().unwrap(),
+            extra,
+        )
+        .add_service_type("DIDCommMessaging".to_string())
+        .unwrap()
+        .build();
+
+        let did_document = create_did_document_with_service(did_full.to_string(), service);
+
+        let did = append_encoded_service_segment(did.to_string(), &did_document).unwrap();
+        assert_eq!(did, did_full);
+    }
+
+    #[test]
+    fn test_append_encoded_segments_error() {
+        let did = "did:peer:2";
+        let key = "invalid_key";
+        let did_full = format!("{}.E{}", did, key);
+
+        let vm = create_verification_method(
+            did_full.to_string(),
+            key.to_string(),
+            VerificationMethodType::X25519KeyAgreementKey2020,
+        );
+
+        let did_document = DidDocument::<ExtraFieldsSov>::builder(did_full.parse().unwrap())
+            .add_key_agreement(vm)
+            .build();
+
+        let result = append_encoded_key_segments(did.to_string(), &did_document);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_append_encoded_key_segments_multiple_keys() {
+        let did = "did:peer:2";
+        let key_0 = "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc";
+        let key_1 = "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V";
+        let key_2 = "z6Mkumaf3DZPAw8CN8r7vqA4UbW5b6hFfpq6nM4xud1MBZ9n";
+        let did_full = format!("{}.A{}.E{}.V{}", did, key_0, key_1, key_2);
+
+        let vm_0 = create_verification_method(
+            did_full.to_string(),
+            key_0.to_string(),
+            VerificationMethodType::X25519KeyAgreementKey2020,
+        );
+        let vm_1 = create_verification_method(
+            did_full.to_string(),
+            key_1.to_string(),
+            VerificationMethodType::Ed25519VerificationKey2020,
+        );
+        let vm_2 = create_verification_method(
+            did_full.to_string(),
+            key_2.to_string(),
+            VerificationMethodType::Ed25519VerificationKey2020,
+        );
+
+        let did_document = DidDocument::<ExtraFieldsSov>::builder(did_full.parse().unwrap())
+            .add_assertion_method(vm_0)
+            .add_key_agreement(vm_1)
+            .add_verification_method(vm_2)
+            .build();
+
+        let did = append_encoded_key_segments(did.to_string(), &did_document).unwrap();
+        assert_eq!(did, did_full);
+    }
+
+    #[test]
+    fn test_append_encoded_key_segments_resolvable_key() {
+        let did = "did:peer:2";
+        let key = "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc";
+        let did_full = format!("{}.E{}.V{}", did, key, key);
+        let reference = "ref-1";
+
+        let vm = create_verification_method(
+            format!("{did_full}#{reference}"),
+            key.to_string(),
+            VerificationMethodType::X25519KeyAgreementKey2020,
+        );
+
+        let did_document = DidDocument::<ExtraFieldsSov>::builder(did_full.parse().unwrap())
+            .add_verification_method(vm)
+            .add_key_agreement_reference(DidUrl::from_fragment(reference.to_string()).unwrap())
+            .build();
+
+        let did = append_encoded_key_segments(did.to_string(), &did_document).unwrap();
+        assert_eq!(did, did_full);
+    }
+}

--- a/did_peer/src/numalgos/numalgo2/generate/mod.rs
+++ b/did_peer/src/numalgos/numalgo2/generate/mod.rs
@@ -1,0 +1,17 @@
+mod helpers;
+
+use did_doc::schema::did_doc::DidDocument;
+use did_doc_sov::extra_fields::ExtraFieldsSov;
+
+use crate::{error::DidPeerError, peer_did::PeerDid};
+
+use self::helpers::{append_encoded_key_segments, append_encoded_service_segment};
+
+pub fn generate_numalgo2(did_document: DidDocument<ExtraFieldsSov>) -> Result<PeerDid, DidPeerError> {
+    let mut did = String::from("did:peer:2");
+
+    did = append_encoded_key_segments(did, &did_document)?;
+    did = append_encoded_service_segment(did, &did_document)?;
+
+    PeerDid::parse(did)
+}

--- a/did_peer/src/numalgos/numalgo2/mod.rs
+++ b/did_peer/src/numalgos/numalgo2/mod.rs
@@ -1,0 +1,7 @@
+mod generate;
+mod purpose;
+mod resolve;
+mod service_abbreviated;
+
+pub use generate::generate_numalgo2;
+pub use resolve::resolve_numalgo2;

--- a/did_peer/src/numalgos/numalgo2/purpose.rs
+++ b/did_peer/src/numalgos/numalgo2/purpose.rs
@@ -1,0 +1,49 @@
+use std::fmt::Display;
+
+use crate::error::DidPeerError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElementPurpose {
+    Assertion,
+    Encryption,
+    Verification,
+    CapabilityInvocation,
+    CapabilityDelegation,
+    Service,
+}
+
+impl Display for ElementPurpose {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let c: char = (*self).into();
+        write!(f, "{}", c)
+    }
+}
+
+impl TryFrom<char> for ElementPurpose {
+    type Error = DidPeerError;
+
+    fn try_from(c: char) -> Result<Self, Self::Error> {
+        match c {
+            'A' => Ok(ElementPurpose::Assertion),
+            'E' => Ok(ElementPurpose::Encryption),
+            'V' => Ok(ElementPurpose::Verification),
+            'I' => Ok(ElementPurpose::CapabilityInvocation),
+            'D' => Ok(ElementPurpose::CapabilityDelegation),
+            'S' => Ok(ElementPurpose::Service),
+            c @ _ => Err(DidPeerError::UnsupportedPurpose(c)),
+        }
+    }
+}
+
+impl From<ElementPurpose> for char {
+    fn from(purpose: ElementPurpose) -> Self {
+        match purpose {
+            ElementPurpose::Assertion => 'A',
+            ElementPurpose::Encryption => 'E',
+            ElementPurpose::Verification => 'V',
+            ElementPurpose::CapabilityInvocation => 'I',
+            ElementPurpose::CapabilityDelegation => 'D',
+            ElementPurpose::Service => 'S',
+        }
+    }
+}

--- a/did_peer/src/numalgos/numalgo2/resolve/helpers.rs
+++ b/did_peer/src/numalgos/numalgo2/resolve/helpers.rs
@@ -1,0 +1,413 @@
+use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
+use did_doc::schema::{did_doc::DidDocumentBuilder, service::Service, types::uri::Uri, utils::OneOrList};
+use did_doc_sov::extra_fields::{aip1::ExtraFieldsAIP1, didcommv2::ExtraFieldsDidCommV2, ExtraFieldsSov};
+use did_parser::Did;
+
+use crate::{
+    error::DidPeerError,
+    key::{get_verification_methods_by_key, Key},
+    numalgos::numalgo2::{purpose::ElementPurpose, service_abbreviated::ServiceAbbreviated},
+    peer_did_resolver::options::PublicKeyEncoding,
+};
+
+pub fn process_elements(
+    mut did_doc_builder: DidDocumentBuilder<ExtraFieldsSov>,
+    did: &Did,
+    public_key_encoding: &PublicKeyEncoding,
+) -> Result<DidDocumentBuilder<ExtraFieldsSov>, DidPeerError> {
+    let numalgoless_id = did.id().chars().skip(1).collect::<String>();
+    let mut service_index: usize = 0;
+
+    // Skipping one here because the first element is empty string
+    for element in numalgoless_id.split('.').skip(1) {
+        did_doc_builder = process_element(element, did_doc_builder, &mut service_index, did, public_key_encoding)?;
+    }
+
+    Ok(did_doc_builder)
+}
+
+fn process_element(
+    element: &str,
+    mut did_doc_builder: DidDocumentBuilder<ExtraFieldsSov>,
+    service_index: &mut usize,
+    did: &Did,
+    public_key_encoding: &PublicKeyEncoding,
+) -> Result<DidDocumentBuilder<ExtraFieldsSov>, DidPeerError> {
+    let purpose: ElementPurpose = element
+        .chars()
+        .nth(0)
+        .ok_or(DidPeerError::DidValidationError(format!(
+            "No purpose code following element separator in '{}'",
+            element
+        )))?
+        .try_into()?;
+    let purposeless_element = element.chars().skip(1).collect::<String>();
+
+    if purpose == ElementPurpose::Service {
+        did_doc_builder = process_service_element(&purposeless_element, did_doc_builder, service_index)?;
+    } else {
+        did_doc_builder =
+            process_key_element(&purposeless_element, did_doc_builder, did, public_key_encoding, purpose)?;
+    }
+
+    Ok(did_doc_builder)
+}
+
+fn process_service_element(
+    element: &str,
+    mut did_doc_builder: DidDocumentBuilder<ExtraFieldsSov>,
+    service_index: &mut usize,
+) -> Result<DidDocumentBuilder<ExtraFieldsSov>, DidPeerError> {
+    let decoded = STANDARD_NO_PAD.decode(element)?;
+    let service: OneOrList<ServiceAbbreviated> = serde_json::from_slice(&decoded)?;
+
+    match service {
+        OneOrList::One(service) => {
+            did_doc_builder = did_doc_builder.add_service(deabbreviate_service(service, *service_index)?);
+            *service_index += 1;
+        }
+        OneOrList::List(services) => {
+            for service in services.into_iter() {
+                did_doc_builder = did_doc_builder.add_service(deabbreviate_service(service, *service_index)?);
+                *service_index += 1;
+            }
+        }
+    }
+
+    Ok(did_doc_builder)
+}
+
+fn process_key_element(
+    element: &str,
+    mut did_doc_builder: DidDocumentBuilder<ExtraFieldsSov>,
+    did: &Did,
+    public_key_encoding: &PublicKeyEncoding,
+    purpose: ElementPurpose,
+) -> Result<DidDocumentBuilder<ExtraFieldsSov>, DidPeerError> {
+    let key = Key::from_fingerprint(&element)?;
+    let vms = get_verification_methods_by_key(&key, did, public_key_encoding)?;
+
+    for vm in vms.into_iter() {
+        match purpose {
+            ElementPurpose::Assertion => {
+                did_doc_builder = did_doc_builder.add_assertion_method(vm);
+            }
+            ElementPurpose::Encryption => {
+                did_doc_builder = did_doc_builder.add_key_agreement(vm);
+            }
+            ElementPurpose::Verification => {
+                did_doc_builder = did_doc_builder.add_verification_method(vm);
+            }
+            ElementPurpose::CapabilityInvocation => did_doc_builder = did_doc_builder.add_capability_invocation(vm),
+            ElementPurpose::CapabilityDelegation => did_doc_builder = did_doc_builder.add_capability_delegation(vm),
+            _ => return Err(DidPeerError::UnsupportedPurpose(purpose.into())),
+        }
+    }
+
+    Ok(did_doc_builder)
+}
+
+fn deabbreviate_service(service: ServiceAbbreviated, index: usize) -> Result<Service<ExtraFieldsSov>, DidPeerError> {
+    let service_type = match service.service_type() {
+        "dm" => "DIDCommMessaging".to_string(),
+        t @ _ => t.to_string(),
+    };
+
+    let id = format!("#{}-{}", service_type.to_lowercase(), index).parse()?;
+
+    if service.routing_keys().is_empty() {
+        build_service_aip1(service, id, service_type)
+    } else {
+        build_service_didcommv2(service, id, service_type)
+    }
+}
+
+fn build_service_aip1(
+    service: ServiceAbbreviated,
+    id: Uri,
+    service_type: String,
+) -> Result<Service<ExtraFieldsSov>, DidPeerError> {
+    Ok(Service::<ExtraFieldsSov>::builder(
+        id,
+        service.service_endpoint().parse()?,
+        ExtraFieldsSov::AIP1(ExtraFieldsAIP1::default()),
+    )
+    .add_service_type(service_type.to_string())?
+    .build())
+}
+
+fn build_service_didcommv2(
+    service: ServiceAbbreviated,
+    id: Uri,
+    service_type: String,
+) -> Result<Service<ExtraFieldsSov>, DidPeerError> {
+    let extra_builder = ExtraFieldsDidCommV2::builder()
+        .set_routing_keys(service.routing_keys().to_owned())
+        .set_accept(service.accept().to_owned());
+    let extra = ExtraFieldsSov::DIDCommV2(extra_builder.build());
+    Ok(
+        Service::<ExtraFieldsSov>::builder(id, service.service_endpoint().parse()?, extra)
+            .add_service_type(service_type.to_string())?
+            .build(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use did_doc::schema::utils::OneOrList;
+    use did_doc_sov::extra_fields::{AcceptType, ExtraFieldsSov, KeyKind};
+
+    #[test]
+    fn test_process_elements_empty_did() {
+        let did: Did = "did:peer:2".parse().unwrap();
+
+        let built_ddo = process_elements(
+            DidDocumentBuilder::<ExtraFieldsSov>::new(did.clone()),
+            &did,
+            &PublicKeyEncoding::Base58,
+        )
+        .unwrap()
+        .build();
+        assert_eq!(built_ddo.id().to_string(), did.to_string());
+    }
+
+    #[test]
+    fn test_process_elements_with_multiple_elements() {
+        let did: Did = "did:peer:2\
+                        .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+                        .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9"
+            .parse()
+            .unwrap();
+
+        let processed_did_doc_builder = process_elements(
+            DidDocumentBuilder::<ExtraFieldsSov>::new(did.clone()),
+            &did,
+            &PublicKeyEncoding::Multibase,
+        )
+        .unwrap();
+        let built_ddo = processed_did_doc_builder.build();
+
+        assert_eq!(built_ddo.id().to_string(), did.to_string());
+        assert_eq!(built_ddo.verification_method().len(), 1);
+        assert_eq!(built_ddo.service().len(), 1);
+    }
+
+    #[test]
+    fn test_process_elements_error_on_invalid_element() {
+        let did: Did = "did:peer:2\
+                        .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+                        .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9\
+                        .Xinvalid"
+            .parse()
+            .unwrap();
+
+        match process_elements(
+            DidDocumentBuilder::<ExtraFieldsSov>::new(did.clone()),
+            &did,
+            &PublicKeyEncoding::Multibase,
+        ) {
+            Ok(_) => panic!("Expected Err, got Ok"),
+            Err(e) => {
+                println!("{:?}", e);
+                assert!(matches!(e, DidPeerError::UnsupportedPurpose('X')));
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_service_element_one_service() {
+        let purposeless_service_element = "eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9";
+        let did: Did = format!("did:peer:2.S{}", purposeless_service_element).parse().unwrap();
+        let mut index = 0;
+        let ddo_builder = DidDocumentBuilder::<ExtraFieldsSov>::new(did.clone());
+        let built_ddo = process_service_element(purposeless_service_element, ddo_builder, &mut index)
+            .unwrap()
+            .build();
+        assert_eq!(built_ddo.service().len(), 1);
+        let service = built_ddo.service().first().unwrap();
+        assert_eq!(service.id().to_string(), "#didcommmessaging-0".to_string());
+        assert_eq!(service.service_type().to_string(), "DIDCommMessaging".to_string());
+        assert_eq!(
+            service.service_endpoint().to_string(),
+            "https://example.com/endpoint".to_string()
+        );
+    }
+
+    #[test]
+    fn test_process_service_element_multiple_services() {
+        let purposeless_service_element = "W3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0";
+        let did: Did = format!("did:peer:2.S{}", purposeless_service_element).parse().unwrap();
+        let mut index = 0;
+        let ddo_builder = DidDocumentBuilder::<ExtraFieldsSov>::new(did.clone());
+        let built_ddo = process_service_element(purposeless_service_element, ddo_builder, &mut index)
+            .unwrap()
+            .build();
+
+        assert_eq!(built_ddo.service().len(), 2);
+
+        let first_service = built_ddo.service().first().unwrap();
+        assert_eq!(first_service.id().to_string(), "#didcommmessaging-0".to_string());
+        assert_eq!(first_service.service_type().to_string(), "DIDCommMessaging".to_string());
+        assert_eq!(
+            first_service.extra().first_routing_key().unwrap().to_string(),
+            "did:example:somemediator#somekey".to_string()
+        );
+        assert_eq!(
+            first_service.service_endpoint().to_string(),
+            "https://example.com/endpoint".to_string()
+        );
+
+        let second_service = built_ddo.service().get(1).unwrap();
+        assert_eq!(second_service.id().to_string(), "#example-1".to_string());
+        assert_eq!(second_service.service_type().to_string(), "example".to_string());
+        assert_eq!(
+            second_service.service_endpoint().to_string(),
+            "https://example.com/endpoint2".to_string()
+        );
+        assert_eq!(
+            second_service.extra().accept().unwrap(),
+            vec![
+                AcceptType::DIDCommV2,
+                AcceptType::Other("didcomm/aip2;env=rfc587".to_string())
+            ]
+        );
+        assert_eq!(
+            second_service.extra().first_routing_key().unwrap().to_string(),
+            "did:example:somemediator#somekey2".to_string()
+        );
+    }
+
+    #[test]
+    fn test_process_key_element() {
+        let purposeless_key_element = "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V";
+        let did: Did = format!("did:peer:2.V{}", purposeless_key_element).parse().unwrap();
+
+        let ddo_builder = DidDocumentBuilder::<ExtraFieldsSov>::new(did.clone());
+        let public_key_encoding = PublicKeyEncoding::Multibase;
+        let built_ddo = process_key_element(
+            purposeless_key_element,
+            ddo_builder,
+            &did,
+            &public_key_encoding,
+            ElementPurpose::Verification,
+        )
+        .unwrap()
+        .build();
+
+        assert_eq!(built_ddo.verification_method().len(), 1);
+        let vm = built_ddo.verification_method().first().unwrap();
+        assert_eq!(vm.id().to_string(), "#6MkqRYqQ");
+        assert_eq!(vm.controller().to_string(), did.to_string());
+    }
+
+    #[test]
+    fn test_process_key_element_negative() {
+        let did: Did = "did:peer:2".parse().unwrap();
+        assert!(process_key_element(
+            "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            DidDocumentBuilder::<ExtraFieldsSov>::new(did.clone()),
+            &did,
+            &PublicKeyEncoding::Multibase,
+            ElementPurpose::Service
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_deabbreviate_service_aip1() {
+        let service_abbreviated = ServiceAbbreviated::from_parts("dm", "https://example.com/endpoint", &[], &[]);
+        let index = 0;
+
+        let service = deabbreviate_service(service_abbreviated, index).unwrap();
+
+        assert_eq!(
+            service.service_type().clone(),
+            OneOrList::One("DIDCommMessaging".to_string())
+        );
+        assert_eq!(service.id().to_string(), "#didcommmessaging-0");
+
+        assert!(matches!(service.extra(), ExtraFieldsSov::AIP1(_)));
+    }
+
+    #[test]
+    fn test_deabbreviate_service_didcommv2() {
+        let routing_keys = vec![KeyKind::Value("key1".to_string())];
+        let service_abbreviated =
+            ServiceAbbreviated::from_parts("dm", "https://example.com/endpoint", &routing_keys, &[]);
+        let index = 0;
+
+        let service = deabbreviate_service(service_abbreviated, index).unwrap();
+
+        assert_eq!(
+            service.service_type().clone(),
+            OneOrList::One("DIDCommMessaging".to_string())
+        );
+        assert_eq!(service.id().to_string(), "#didcommmessaging-0");
+
+        match service.extra() {
+            ExtraFieldsSov::DIDCommV2(extra) => {
+                assert_eq!(extra.routing_keys(), &routing_keys);
+            }
+            _ => panic!("Expected ExtraFieldsSov::DIDCommV2"),
+        }
+    }
+
+    #[test]
+    fn test_build_service_aip1() {
+        let routing_keys = vec![KeyKind::Value("key1".to_string())];
+        let service_abbreviated = ServiceAbbreviated::from_parts(
+            "dm",
+            "https://example.com/endpoint",
+            routing_keys.as_ref(),
+            vec![].as_ref(),
+        );
+
+        let id = Uri::new("did:peer:2").unwrap();
+        let service_type = "DIDCommMessaging".to_string();
+
+        let service = build_service_aip1(service_abbreviated, id, service_type).unwrap();
+
+        assert_eq!(service.id().to_string(), "did:peer:2");
+        assert_eq!(
+            service.service_type().clone(),
+            OneOrList::One("DIDCommMessaging".to_string())
+        );
+
+        match service.extra() {
+            ExtraFieldsSov::AIP1(_) => { /* This is expected */ }
+            _ => panic!("Expected ExtraFieldsSov::AIP1"),
+        }
+    }
+
+    #[test]
+    fn test_build_service_didcommv2() {
+        let routing_keys = vec![KeyKind::Value("key1".to_string())];
+        let accept = vec![AcceptType::DIDCommV2];
+        let service_abbreviated = ServiceAbbreviated::from_parts(
+            "dm",
+            "https://example.com/endpoint",
+            routing_keys.as_ref(),
+            accept.as_ref(),
+        );
+
+        let id = Uri::new("did:peer:2").unwrap();
+        let service_type = "DIDCommMessaging".to_string();
+
+        let service = build_service_didcommv2(service_abbreviated, id, service_type).unwrap();
+
+        assert_eq!(service.id().to_string(), "did:peer:2");
+        assert_eq!(
+            service.service_type().clone(),
+            OneOrList::One("DIDCommMessaging".to_string())
+        );
+
+        match service.extra() {
+            ExtraFieldsSov::DIDCommV2(extra) => {
+                assert_eq!(extra.routing_keys(), &routing_keys);
+                assert_eq!(extra.accept(), &accept);
+            }
+            _ => panic!("Expected ExtraFieldsSov::DIDCommV2"),
+        }
+    }
+}

--- a/did_peer/src/numalgos/numalgo2/resolve/helpers.rs
+++ b/did_peer/src/numalgos/numalgo2/resolve/helpers.rs
@@ -15,11 +15,10 @@ pub fn process_elements(
     did: &Did,
     public_key_encoding: &PublicKeyEncoding,
 ) -> Result<DidDocumentBuilder<ExtraFieldsSov>, DidPeerError> {
-    let numalgoless_id = did.id().chars().skip(1).collect::<String>();
     let mut service_index: usize = 0;
 
     // Skipping one here because the first element is empty string
-    for element in numalgoless_id.split('.').skip(1) {
+    for element in did.id()[1..].split('.').skip(1) {
         did_doc_builder = process_element(element, did_doc_builder, &mut service_index, did, public_key_encoding)?;
     }
 
@@ -41,7 +40,7 @@ fn process_element(
             element
         )))?
         .try_into()?;
-    let purposeless_element = element.chars().skip(1).collect::<String>();
+    let purposeless_element = &element[1..];
 
     if purpose == ElementPurpose::Service {
         did_doc_builder = process_service_element(&purposeless_element, did_doc_builder, service_index)?;

--- a/did_peer/src/numalgos/numalgo2/resolve/mod.rs
+++ b/did_peer/src/numalgos/numalgo2/resolve/mod.rs
@@ -1,0 +1,20 @@
+mod helpers;
+
+use did_doc::schema::did_doc::{DidDocument, DidDocumentBuilder};
+use did_doc_sov::extra_fields::ExtraFieldsSov;
+use did_parser::Did;
+
+use crate::{error::DidPeerError, peer_did_resolver::options::PublicKeyEncoding};
+
+use self::helpers::process_elements;
+
+pub fn resolve_numalgo2(
+    did: &Did,
+    public_key_encoding: &PublicKeyEncoding,
+) -> Result<DidDocument<ExtraFieldsSov>, DidPeerError> {
+    let mut did_doc_builder: DidDocumentBuilder<ExtraFieldsSov> = DidDocument::builder(did.to_owned());
+
+    did_doc_builder = process_elements(did_doc_builder, did, public_key_encoding)?;
+
+    Ok(did_doc_builder.build())
+}

--- a/did_peer/src/numalgos/numalgo2/service_abbreviated.rs
+++ b/did_peer/src/numalgos/numalgo2/service_abbreviated.rs
@@ -1,0 +1,90 @@
+use did_doc::schema::{service::Service, types::url::Url, utils::OneOrList};
+use did_doc_sov::extra_fields::{AcceptType, ExtraFieldsSov, KeyKind};
+use serde::{Deserialize, Serialize};
+
+use crate::error::DidPeerError;
+
+#[derive(Serialize, Deserialize)]
+pub struct ServiceAbbreviated {
+    #[serde(rename = "t")]
+    _type: String,
+    #[serde(rename = "s")]
+    service_endpoint: Url,
+    #[serde(rename = "r")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    routing_keys: Vec<KeyKind>,
+    #[serde(rename = "a")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    accept: Vec<AcceptType>,
+}
+
+impl ServiceAbbreviated {
+    pub fn service_type(&self) -> &str {
+        self._type.as_ref()
+    }
+
+    pub fn service_endpoint(&self) -> &str {
+        self.service_endpoint.as_ref()
+    }
+
+    pub fn routing_keys(&self) -> &[KeyKind] {
+        self.routing_keys.as_ref()
+    }
+
+    pub fn accept(&self) -> &[AcceptType] {
+        self.accept.as_ref()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_parts(
+        service_type: &str,
+        service_endpoint: &str,
+        routing_keys: &[KeyKind],
+        accept: &[AcceptType],
+    ) -> Self {
+        Self {
+            _type: service_type.to_string(),
+            service_endpoint: service_endpoint.parse().unwrap(),
+            routing_keys: routing_keys.to_vec(),
+            accept: accept.to_vec(),
+        }
+    }
+}
+
+impl TryFrom<&Service<ExtraFieldsSov>> for ServiceAbbreviated {
+    type Error = DidPeerError;
+
+    fn try_from(value: &Service<ExtraFieldsSov>) -> Result<Self, Self::Error> {
+        let service_endpoint = value.service_endpoint().clone();
+        let (routing_keys, accept) = match value.extra() {
+            ExtraFieldsSov::DIDCommV2(extra) => (extra.routing_keys().to_vec(), extra.accept().to_vec()),
+            ExtraFieldsSov::DIDCommV1(extra) => (extra.routing_keys().to_vec(), extra.accept().to_vec()),
+            _ => (vec![], vec![]),
+        };
+        let service_type = match value.service_type() {
+            OneOrList::One(service_type) => service_type,
+            OneOrList::List(service_types) => {
+                if let Some(first_service) = service_types.first() {
+                    first_service
+                } else {
+                    return Err(DidPeerError::InvalidServiceType);
+                }
+            }
+        };
+
+        let service_type_abbr = if service_type.to_lowercase() == "didcommmessaging" {
+            "dm"
+        } else {
+            service_type
+        };
+
+        Ok(Self {
+            _type: service_type_abbr.to_string(),
+            service_endpoint,
+            routing_keys,
+            accept,
+        })
+    }
+}

--- a/did_peer/src/peer_did/mod.rs
+++ b/did_peer/src/peer_did/mod.rs
@@ -1,5 +1,6 @@
 mod numalgo;
 mod peer_did;
+mod regex;
 mod transform;
 
 pub use numalgo::Numalgo;

--- a/did_peer/src/peer_did/mod.rs
+++ b/did_peer/src/peer_did/mod.rs
@@ -1,0 +1,6 @@
+mod numalgo;
+mod peer_did;
+mod transform;
+
+pub use numalgo::Numalgo;
+pub use peer_did::PeerDid;

--- a/did_peer/src/peer_did/numalgo.rs
+++ b/did_peer/src/peer_did/numalgo.rs
@@ -1,0 +1,36 @@
+use std::fmt::Display;
+
+use crate::error::DidPeerError;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Numalgo {
+    InceptionKeyWithoutDoc,
+    GenesisDoc,
+    MultipleInceptionKeys,
+    DidShortening,
+}
+
+impl Display for Numalgo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Numalgo::InceptionKeyWithoutDoc => write!(f, "0"),
+            Numalgo::GenesisDoc => write!(f, "1"),
+            Numalgo::MultipleInceptionKeys => write!(f, "2"),
+            Numalgo::DidShortening => write!(f, "3"),
+        }
+    }
+}
+
+impl TryFrom<char> for Numalgo {
+    type Error = DidPeerError;
+
+    fn try_from(value: char) -> Result<Self, Self::Error> {
+        match value {
+            '0' => Ok(Numalgo::InceptionKeyWithoutDoc),
+            '1' => Ok(Numalgo::GenesisDoc),
+            '2' => Ok(Numalgo::MultipleInceptionKeys),
+            '3' => Ok(Numalgo::DidShortening),
+            c @ _ => Err(DidPeerError::InvalidNumalgoCharacter(c)),
+        }
+    }
+}

--- a/did_peer/src/peer_did/numalgo.rs
+++ b/did_peer/src/peer_did/numalgo.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::error::DidPeerError;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Numalgo {
     InceptionKeyWithoutDoc,
     GenesisDoc,

--- a/did_peer/src/peer_did/peer_did.rs
+++ b/did_peer/src/peer_did/peer_did.rs
@@ -4,16 +4,9 @@ use crate::{error::DidPeerError, numalgos::numalgo2::generate_numalgo2};
 use did_doc::schema::did_doc::DidDocument;
 use did_doc_sov::extra_fields::ExtraFieldsSov;
 use did_parser::Did;
-use once_cell::sync::Lazy;
-use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::{numalgo::Numalgo, transform::Transform};
-
-// TODO: This regex does not cover peer:did:3
-static PEER_DID_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^did:peer:(([01](z)([1-9a-km-zA-HJ-NP-Z]{5,200}))|(2((.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{5,200}))+(.(S)[0-9a-zA-Z=]*)?)))$").unwrap()
-});
+use super::{numalgo::Numalgo, regex::PEER_DID_REGEX, transform::Transform};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PeerDid {

--- a/did_peer/src/peer_did/peer_did.rs
+++ b/did_peer/src/peer_did/peer_did.rs
@@ -1,0 +1,154 @@
+use std::fmt::Display;
+
+use crate::{error::DidPeerError, numalgos::numalgo2::generate_numalgo2};
+use did_doc::schema::did_doc::DidDocument;
+use did_doc_sov::extra_fields::ExtraFieldsSov;
+use did_parser::Did;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::{numalgo::Numalgo, transform::Transform};
+
+// TODO: This regex does not cover peer:did:3
+static PEER_DID_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^did:peer:(([01](z)([1-9a-km-zA-HJ-NP-Z]{5,200}))|(2((.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{5,200}))+(.(S)[0-9a-zA-Z=]*)?)))$").unwrap()
+});
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PeerDid {
+    did: Did,
+    numalgo: Numalgo,
+    transform: Option<Transform>,
+}
+
+impl PeerDid {
+    pub fn parse<T>(did: T) -> Result<Self, DidPeerError>
+    where
+        Did: TryFrom<T>,
+        <Did as TryFrom<T>>::Error: Into<DidPeerError>,
+    {
+        let did: Did = did.try_into().map_err(Into::into)?;
+        let numalgo = Self::parse_numalgo(&did)?;
+        let transform = match numalgo {
+            Numalgo::InceptionKeyWithoutDoc | Numalgo::GenesisDoc => Some(Self::parse_transform(&did)?),
+            _ => None,
+        };
+        Self::validate(&did)?;
+        Ok(Self {
+            did,
+            numalgo,
+            transform,
+        })
+    }
+    pub fn did(&self) -> &Did {
+        &self.did
+    }
+
+    pub fn numalgo(&self) -> &Numalgo {
+        &self.numalgo
+    }
+
+    pub fn transform(&self) -> Option<&Transform> {
+        self.transform.as_ref()
+    }
+
+    pub fn generate_numalgo2(did_document: DidDocument<ExtraFieldsSov>) -> Result<PeerDid, DidPeerError> {
+        generate_numalgo2(did_document)
+    }
+
+    fn validate(did: &Did) -> Result<(), DidPeerError> {
+        if !PEER_DID_REGEX.is_match(did.did()) {
+            Err(DidPeerError::DidValidationError(format!("Invalid did: {}", did.did())))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn parse_numalgo(did: &Did) -> Result<Numalgo, DidPeerError> {
+        did.id()
+            .chars()
+            .nth(0)
+            .ok_or_else(|| DidPeerError::DidValidationError(format!("Invalid did: {}", did.did())))?
+            .try_into()
+    }
+
+    fn parse_transform(did: &Did) -> Result<Transform, DidPeerError> {
+        did.id()
+            .chars()
+            .nth(1)
+            .ok_or_else(|| DidPeerError::DidValidationError(format!("Invalid did: {}", did.did())))?
+            .try_into()
+    }
+}
+
+impl Serialize for PeerDid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.did.did())
+    }
+}
+
+impl<'de> Deserialize<'de> for PeerDid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let did = String::deserialize(deserializer)?;
+        Self::parse(did).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Display for PeerDid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.did)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod parse {
+        use super::*;
+
+        macro_rules! generate_parse_test {
+            ($test_name:ident, $input:expr, $error_pattern:pat) => {
+                #[test]
+                fn $test_name() {
+                    let result = PeerDid::parse($input.to_string());
+                    assert!(matches!(result, Err($error_pattern)));
+                }
+            };
+        }
+
+        generate_parse_test!(
+            test_peer_did_parse_unsupported_transform_code,
+            "did:peer:2\
+            .Ea6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+            .Va6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+            .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0",
+            DidPeerError::DidValidationError(_)
+        );
+
+        generate_parse_test!(
+            test_peer_did_parse_malformed_base58_encoding_signing,
+            "did:peer:2\
+            .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+            .Vz6MkqRYqQiSgvZQdnBytw86Qbs0ZWUkGv22od935YF4s8M7V\
+            .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0",
+            DidPeerError::DidValidationError(_)
+        );
+
+        generate_parse_test!(
+            test_peer_did_parse_malformed_base58_encoding_encryption,
+            "did:peer:2\
+            .Ez6LSbysY2xFMRpG0hb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+            .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+            .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0=",
+            DidPeerError::DidParserError(_)
+        );
+    }
+}

--- a/did_peer/src/peer_did/regex.rs
+++ b/did_peer/src/peer_did/regex.rs
@@ -1,0 +1,13 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static GROUP_NUMALGO_0_AND_1: &str = r"([01](z)([1-9a-km-zA-HJ-NP-Z]{5,200}))";
+static GROUP_NUMALGO_2: &str = r"(2((.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{5,200}))+(.(S)[0-9a-zA-Z=]*)?))";
+static GROUP_NUMALGO_3: &str = r"(3\.[0-9a-fA-F]{64})";
+
+pub static PEER_DID_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(&format!(
+        r"^did:peer:({GROUP_NUMALGO_0_AND_1}|{GROUP_NUMALGO_2}|{GROUP_NUMALGO_3})$"
+    ))
+    .unwrap()
+});

--- a/did_peer/src/peer_did/transform.rs
+++ b/did_peer/src/peer_did/transform.rs
@@ -1,0 +1,20 @@
+use crate::error::DidPeerError;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Transform {
+    BASE58BTC,
+}
+
+impl TryFrom<char> for Transform {
+    type Error = DidPeerError;
+
+    fn try_from(value: char) -> Result<Self, Self::Error> {
+        match value {
+            'z' => Ok(Transform::BASE58BTC),
+            c @ _ => Err(DidPeerError::DidValidationError(format!(
+                "Unsupported transform character: {}",
+                c
+            ))),
+        }
+    }
+}

--- a/did_peer/src/peer_did_resolver/mod.rs
+++ b/did_peer/src/peer_did_resolver/mod.rs
@@ -1,0 +1,2 @@
+pub mod options;
+pub mod resolver;

--- a/did_peer/src/peer_did_resolver/options.rs
+++ b/did_peer/src/peer_did_resolver/options.rs
@@ -1,0 +1,31 @@
+pub enum PublicKeyEncoding {
+    Multibase,
+    Base58,
+}
+
+pub struct ExtraFieldsOptions {
+    public_key_encoding: PublicKeyEncoding,
+}
+
+impl Default for ExtraFieldsOptions {
+    fn default() -> Self {
+        Self {
+            public_key_encoding: PublicKeyEncoding::Base58,
+        }
+    }
+}
+
+impl ExtraFieldsOptions {
+    pub fn new() -> Self {
+        Self { ..Default::default() }
+    }
+
+    pub fn set_public_key_encoding(mut self, public_key_encoding: PublicKeyEncoding) -> Self {
+        self.public_key_encoding = public_key_encoding;
+        self
+    }
+
+    pub fn public_key_encoding(&self) -> &PublicKeyEncoding {
+        &self.public_key_encoding
+    }
+}

--- a/did_peer/src/peer_did_resolver/resolver.rs
+++ b/did_peer/src/peer_did_resolver/resolver.rs
@@ -1,0 +1,51 @@
+use async_trait::async_trait;
+use did_doc_sov::extra_fields::ExtraFieldsSov;
+use did_parser::Did;
+use did_resolver::{
+    error::GenericError,
+    traits::resolvable::{
+        resolution_metadata::DidResolutionMetadata, resolution_options::DidResolutionOptions,
+        resolution_output::DidResolutionOutput, DidResolvable,
+    },
+};
+
+use crate::{
+    error::DidPeerError,
+    numalgos::numalgo2::resolve_numalgo2,
+    peer_did::{Numalgo, PeerDid},
+};
+
+use super::options::ExtraFieldsOptions;
+
+pub struct PeerDidResolver;
+
+impl PeerDidResolver {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl DidResolvable for PeerDidResolver {
+    type ExtraFieldsService = ExtraFieldsSov;
+    type ExtraFieldsOptions = ExtraFieldsOptions;
+
+    async fn resolve(
+        &self,
+        did: &Did,
+        options: &DidResolutionOptions<Self::ExtraFieldsOptions>,
+    ) -> Result<DidResolutionOutput<Self::ExtraFieldsService>, GenericError> {
+        let peer_did = PeerDid::parse(did.to_owned())?;
+        match peer_did.numalgo() {
+            Numalgo::MultipleInceptionKeys => {
+                let did_doc = resolve_numalgo2(&peer_did.did(), options.extra().public_key_encoding())?;
+                let resolution_metadata = DidResolutionMetadata::builder()
+                    .content_type("application/did+json".to_string())
+                    .build();
+                let builder = DidResolutionOutput::builder(did_doc).did_resolution_metadata(resolution_metadata);
+                Ok(builder.build())
+            }
+            n @ _ => Err(Box::new(DidPeerError::UnsupportedNumalgo(n.clone()))),
+        }
+    }
+}

--- a/did_peer/tests/fixtures/basic.rs
+++ b/did_peer/tests/fixtures/basic.rs
@@ -1,0 +1,47 @@
+pub static PEER_DID_NUMALGO_2_BASIC: &str = "did:peer:2\
+.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0";
+
+pub static DID_DOC_BASIC: &str = r##"
+    {
+        "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
+        "verificationMethod": [
+            {
+                "id": "#6MkqRYqQ",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
+                "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+            },
+            {
+                "id": "#6MkgoLTn",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
+                "publicKeyBase58": "3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
+            }
+        ],
+        "authentication": [],
+        "assertionMethod": [],
+        "keyAgreement": [
+            {
+                "id": "#6LSbysY2",
+                "type": "X25519KeyAgreementKey2020",
+                "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
+                "publicKeyBase58": "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
+            }
+
+        ],
+        "capabilityInvocation": [],
+        "capabilityDelegation": [],
+        "service": [
+            {
+                "id": "#didcommmessaging-0",
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": "https://example.com/endpoint",
+                "routingKeys": ["did:example:somemediator#somekey"],
+                "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+            }
+        ]
+    }
+"##;

--- a/did_peer/tests/fixtures/mod.rs
+++ b/did_peer/tests/fixtures/mod.rs
@@ -1,0 +1,4 @@
+pub mod basic;
+pub mod multiple_services;
+pub mod no_routing_keys;
+pub mod no_services;

--- a/did_peer/tests/fixtures/multiple_services.rs
+++ b/did_peer/tests/fixtures/multiple_services.rs
@@ -1,0 +1,45 @@
+pub static PEER_DID_NUMALGO_2_MULTIPLE_SERVICES: &str = "did:peer:2\
+.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud\
+.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0";
+
+pub static DID_DOC_MULTIPLE_SERVICES: &str = r##"
+    {
+        "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
+        "verificationMethod": [
+            {
+                "id": "#6MkqRYqQ",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
+                "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            }
+        ],
+        "authentication": [],
+        "assertionMethod": [],
+        "keyAgreement": [
+            {
+                "id": "#6LSpSrLx",
+                "type": "X25519KeyAgreementKey2020",
+                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
+                "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
+            }
+        ],
+        "capabilityInvocation": [],
+        "capabilityDelegation": [],
+        "service": [
+            {
+                "id": "#didcommmessaging-0",
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": "https://example.com/endpoint",
+                "routingKeys": ["did:example:somemediator#somekey"]
+            },
+            {
+                "id": "#example-1",
+                "type": "example",
+                "serviceEndpoint": "https://example.com/endpoint2",
+                "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
+                "routingKeys": ["did:example:somemediator#somekey2"]
+            }
+        ]
+    }
+"##;

--- a/did_peer/tests/fixtures/no_routing_keys.rs
+++ b/did_peer/tests/fixtures/no_routing_keys.rs
@@ -1,0 +1,44 @@
+pub static PEER_DID_NUMALGO_2_NO_ROUTING_KEYS: &str = "did:peer:2\
+.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9";
+
+pub static DID_DOC_NO_ROUTING_KEYS: &str = r##"
+    {
+        "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
+        "verificationMethod": [
+            {
+                "id": "#6MkqRYqQ",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
+                "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            },
+            {
+                "id": "#6MkgoLTn",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
+                "publicKeyMultibase": "z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
+            }
+        ],
+        "authentication": [],
+        "assertionMethod": [],
+        "keyAgreement": [
+            {
+                "id": "#6LSbysY2",
+                "type": "X25519KeyAgreementKey2020",
+                "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
+                "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+            }
+        ],
+        "capabilityInvocation": [],
+        "capabilityDelegation": [],
+        "service": [
+            {
+                "id": "#didcommmessaging-0",
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": "https://example.com/endpoint"
+            }
+        ]
+    }
+"##;

--- a/did_peer/tests/fixtures/no_services.rs
+++ b/did_peer/tests/fixtures/no_services.rs
@@ -1,0 +1,29 @@
+pub static PEER_DID_NUMALGO_2_NO_SERVICES: &str = "did:peer:2\
+.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud\
+.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V";
+
+pub static DID_DOC_NO_SERVICES: &str = r##"
+    {
+        "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+        "verificationMethod": [
+            {
+                "id": "#6MkqRYqQ",
+                "type": "Ed25519VerificationKey2020",
+                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+            }
+        ],
+        "authentication": [],
+        "assertionMethod": [],
+        "keyAgreement": [
+            {
+                "id": "#6LSpSrLx",
+                "type": "X25519KeyAgreementKey2020",
+                "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
+            }
+        ],
+        "capabilityInvocation": [],
+        "capabilityDelegation": []
+    }
+"##;

--- a/did_peer/tests/generate.rs
+++ b/did_peer/tests/generate.rs
@@ -1,0 +1,45 @@
+mod fixtures;
+
+use did_doc::schema::did_doc::DidDocument;
+use did_doc_sov::extra_fields::ExtraFieldsSov;
+use did_peer::peer_did::PeerDid;
+
+use crate::fixtures::{
+    basic::{DID_DOC_BASIC, PEER_DID_NUMALGO_2_BASIC},
+    multiple_services::{DID_DOC_MULTIPLE_SERVICES, PEER_DID_NUMALGO_2_MULTIPLE_SERVICES},
+    no_routing_keys::{DID_DOC_NO_ROUTING_KEYS, PEER_DID_NUMALGO_2_NO_ROUTING_KEYS},
+    no_services::{DID_DOC_NO_SERVICES, PEER_DID_NUMALGO_2_NO_SERVICES},
+};
+
+macro_rules! generate_test {
+    ($test_name:ident, $did_doc:expr, $peer_did:expr) => {
+        #[test]
+        fn $test_name() {
+            let did_document = serde_json::from_str::<DidDocument<ExtraFieldsSov>>($did_doc).unwrap();
+            assert_eq!(
+                PeerDid::parse($peer_did.to_string()).unwrap(),
+                PeerDid::generate_numalgo2(did_document).unwrap()
+            );
+        }
+    };
+}
+
+generate_test!(test_generate_numalgo2_basic, DID_DOC_BASIC, PEER_DID_NUMALGO_2_BASIC);
+
+generate_test!(
+    test_generate_numalgo2_multiple_services,
+    DID_DOC_MULTIPLE_SERVICES,
+    PEER_DID_NUMALGO_2_MULTIPLE_SERVICES
+);
+
+generate_test!(
+    test_generate_numalgo2_no_services,
+    DID_DOC_NO_SERVICES,
+    PEER_DID_NUMALGO_2_NO_SERVICES
+);
+
+generate_test!(
+    test_generate_numalgo2_no_routing_keys,
+    DID_DOC_NO_ROUTING_KEYS,
+    PEER_DID_NUMALGO_2_NO_ROUTING_KEYS
+);

--- a/did_peer/tests/resolve_negative.rs
+++ b/did_peer/tests/resolve_negative.rs
@@ -1,89 +1,123 @@
 mod fixtures;
 
-use did_peer::peer_did_resolver::{
-    options::{ExtraFieldsOptions, PublicKeyEncoding},
-    resolver::PeerDidResolver,
+use did_peer::{
+    error::DidPeerError,
+    peer_did_resolver::{
+        options::{ExtraFieldsOptions, PublicKeyEncoding},
+        resolver::PeerDidResolver,
+    },
 };
 use did_resolver::traits::resolvable::{resolution_options::DidResolutionOptions, DidResolvable};
 use tokio::test;
 
-macro_rules! resolve_negative_test {
-    ($test_name:ident, $peer_did:expr) => {
-        #[test]
-        async fn $test_name() {
-            let resolver = PeerDidResolver::new();
-            let options = DidResolutionOptions::new()
-                .set_extra(ExtraFieldsOptions::new().set_public_key_encoding(PublicKeyEncoding::Multibase));
-            let ddo_result = resolver.resolve(&$peer_did.parse().unwrap(), &options).await;
-            assert!(ddo_result.is_err());
-        }
-    };
+async fn resolve_error(peer_did: &str) -> DidPeerError {
+    let resolver = PeerDidResolver::new();
+    let options =
+        DidResolutionOptions::new(ExtraFieldsOptions::new().set_public_key_encoding(PublicKeyEncoding::Multibase));
+    *resolver
+        .resolve(&peer_did.parse().unwrap(), &options)
+        .await
+        .unwrap_err()
+        .downcast::<DidPeerError>()
+        .unwrap()
 }
 
-resolve_negative_test!(
-    test_resolve_numalgo_2_invalid_0,
-    "did:peer:2\
-    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
-    .Vz6666YqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
-    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
-);
+#[test]
+async fn test_resolve_numalgo_2_invalid_0() {
+    let peer_did = "did:peer:2\
+        .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+        .Vz6666YqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+        .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0";
+    assert!(matches!(
+        resolve_error(peer_did).await,
+        DidPeerError::UnsupportedMulticodecDescriptor(3)
+    ));
+}
 
-resolve_negative_test!(
-    test_resolve_numalgo_2_invalid_1,
-    "did:peer:2\
-    .Ez7777sY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
-    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
-    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
-);
+#[test]
+async fn test_resolve_numalgo_2_invalid_1() {
+    let peer_did = "did:peer:2\
+        .Ez7777sY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+        .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+        .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0";
+    assert!(matches!(
+        resolve_error(peer_did).await,
+        DidPeerError::UnsupportedMulticodecDescriptor(4)
+    ));
+}
 
-resolve_negative_test!(
-    test_resolve_numalgo_2_invalid_2,
-    "did:peer:2\
-    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
-    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
-    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
-    .Sasdf123"
-);
+#[test]
+async fn test_resolve_numalgo_2_invalid_2() {
+    let peer_did = "did:peer:2\
+        .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+        .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+        .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+        .Sasdf123";
+    assert!(matches!(
+        resolve_error(peer_did).await,
+        DidPeerError::Base64DecodingError(_)
+    ));
+}
 
-resolve_negative_test!(
-    test_resolve_numalgo_2_invalid_3,
-    "did:peer:2\
-    .Cz6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
-    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
-    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
-);
+#[test]
+async fn test_resolve_numalgo_2_invalid_3() {
+    let peer_did = "did:peer:2\
+        .Cz6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+        .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+        .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0";
+    assert!(matches!(
+        resolve_error(peer_did).await,
+        DidPeerError::DidValidationError(_)
+    ));
+}
 
-resolve_negative_test!(
-    test_resolve_numalgo_2_invalid_4,
-    "did:peer:2\
-    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
-    .Vz6MkqRYqQiS\
-    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
-);
+#[test]
+async fn test_resolve_numalgo_2_invalid_4() {
+    let peer_did = "did:peer:2\
+        .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+        .Vz6MkqRYqQiS\
+        .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0";
+    assert!(matches!(
+        resolve_error(peer_did).await,
+        DidPeerError::UnsupportedMulticodecDescriptor(12557)
+    ));
+}
 
-resolve_negative_test!(
-    test_resolve_numalgo_2_invalid_5,
-    "did:peer:2\
-    .Ez6LSbysY2\
-    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
-    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
-    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
-);
+#[test]
+async fn test_resolve_numalgo_2_invalid_5() {
+    let peer_did = "did:peer:2\
+        .Ez6LSbysY2\
+        .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+        .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+        .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0";
+    assert!(matches!(
+        resolve_error(peer_did).await,
+        DidPeerError::UnsupportedMulticodecDescriptor(10)
+    ));
+}
 
-resolve_negative_test!(
-    test_resolve_numalgo_2_invalid_6,
-    "did:peer:2\
-    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
-    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7Vcccccccccc\
-    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
-    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
-);
+#[test]
+async fn test_resolve_numalgo_2_invalid_6() {
+    let peer_did = "did:peer:2\
+        .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+        .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7Vcccccccccc\
+        .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+        .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0";
+    assert!(matches!(
+        resolve_error(peer_did).await,
+        DidPeerError::UnsupportedMulticodecDescriptor(5)
+    ));
+}
 
-resolve_negative_test!(
-    test_resolve_numalgo_2_invalid_7,
-    "did:peer:2\
-    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCcccccccc\
-    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
-    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
-    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
-);
+#[test]
+async fn test_resolve_numalgo_2_invalid_7() {
+    let peer_did = "did:peer:2\
+        .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCcccccccc\
+        .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+        .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+        .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0";
+    assert!(matches!(
+        resolve_error(peer_did).await,
+        DidPeerError::UnsupportedMulticodecDescriptor(1)
+    ));
+}

--- a/did_peer/tests/resolve_negative.rs
+++ b/did_peer/tests/resolve_negative.rs
@@ -1,0 +1,89 @@
+mod fixtures;
+
+use did_peer::peer_did_resolver::{
+    options::{ExtraFieldsOptions, PublicKeyEncoding},
+    resolver::PeerDidResolver,
+};
+use did_resolver::traits::resolvable::{resolution_options::DidResolutionOptions, DidResolvable};
+use tokio::test;
+
+macro_rules! resolve_negative_test {
+    ($test_name:ident, $peer_did:expr) => {
+        #[test]
+        async fn $test_name() {
+            let resolver = PeerDidResolver::new();
+            let options = DidResolutionOptions::new()
+                .set_extra(ExtraFieldsOptions::new().set_public_key_encoding(PublicKeyEncoding::Multibase));
+            let ddo_result = resolver.resolve(&$peer_did.parse().unwrap(), &options).await;
+            assert!(ddo_result.is_err());
+        }
+    };
+}
+
+resolve_negative_test!(
+    test_resolve_numalgo_2_invalid_0,
+    "did:peer:2\
+    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+    .Vz6666YqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
+);
+
+resolve_negative_test!(
+    test_resolve_numalgo_2_invalid_1,
+    "did:peer:2\
+    .Ez7777sY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
+);
+
+resolve_negative_test!(
+    test_resolve_numalgo_2_invalid_2,
+    "did:peer:2\
+    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+    .Sasdf123"
+);
+
+resolve_negative_test!(
+    test_resolve_numalgo_2_invalid_3,
+    "did:peer:2\
+    .Cz6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
+);
+
+resolve_negative_test!(
+    test_resolve_numalgo_2_invalid_4,
+    "did:peer:2\
+    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+    .Vz6MkqRYqQiS\
+    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
+);
+
+resolve_negative_test!(
+    test_resolve_numalgo_2_invalid_5,
+    "did:peer:2\
+    .Ez6LSbysY2\
+    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
+);
+
+resolve_negative_test!(
+    test_resolve_numalgo_2_invalid_6,
+    "did:peer:2\
+    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\
+    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7Vcccccccccc\
+    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
+);
+
+resolve_negative_test!(
+    test_resolve_numalgo_2_invalid_7,
+    "did:peer:2\
+    .Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCcccccccc\
+    .Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V\
+    .Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg\
+    .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0"
+);

--- a/did_peer/tests/resolve_positive.rs
+++ b/did_peer/tests/resolve_positive.rs
@@ -21,8 +21,7 @@ macro_rules! resolve_positive_test {
         #[test]
         async fn $test_name() {
             let resolver = PeerDidResolver::new();
-            let options =
-                DidResolutionOptions::new().set_extra(ExtraFieldsOptions::new().set_public_key_encoding($encoding));
+            let options = DidResolutionOptions::new(ExtraFieldsOptions::new().set_public_key_encoding($encoding));
             let did_document_expected = serde_json::from_str::<DidDocument<ExtraFieldsSov>>($did_doc).unwrap();
             let ddo = resolver
                 .resolve(&$peer_did.parse().unwrap(), &options)

--- a/did_peer/tests/resolve_positive.rs
+++ b/did_peer/tests/resolve_positive.rs
@@ -1,0 +1,63 @@
+mod fixtures;
+
+use did_doc::schema::did_doc::DidDocument;
+use did_doc_sov::extra_fields::ExtraFieldsSov;
+use did_peer::peer_did_resolver::{
+    options::{ExtraFieldsOptions, PublicKeyEncoding},
+    resolver::PeerDidResolver,
+};
+use did_resolver::traits::resolvable::{resolution_options::DidResolutionOptions, DidResolvable};
+use tokio::test;
+
+use crate::fixtures::{
+    basic::{DID_DOC_BASIC, PEER_DID_NUMALGO_2_BASIC},
+    multiple_services::{DID_DOC_MULTIPLE_SERVICES, PEER_DID_NUMALGO_2_MULTIPLE_SERVICES},
+    no_routing_keys::{DID_DOC_NO_ROUTING_KEYS, PEER_DID_NUMALGO_2_NO_ROUTING_KEYS},
+    no_services::{DID_DOC_NO_SERVICES, PEER_DID_NUMALGO_2_NO_SERVICES},
+};
+
+macro_rules! resolve_positive_test {
+    ($test_name:ident, $did_doc:expr, $peer_did:expr, $encoding:expr) => {
+        #[test]
+        async fn $test_name() {
+            let resolver = PeerDidResolver::new();
+            let options =
+                DidResolutionOptions::new().set_extra(ExtraFieldsOptions::new().set_public_key_encoding($encoding));
+            let did_document_expected = serde_json::from_str::<DidDocument<ExtraFieldsSov>>($did_doc).unwrap();
+            let ddo = resolver
+                .resolve(&$peer_did.parse().unwrap(), &options)
+                .await
+                .unwrap();
+            let did_document_actual = ddo.did_document().clone();
+            assert_eq!(did_document_actual, did_document_expected);
+        }
+    };
+}
+
+resolve_positive_test!(
+    test_resolve_numalgo2_basic,
+    DID_DOC_BASIC,
+    PEER_DID_NUMALGO_2_BASIC,
+    PublicKeyEncoding::Base58
+);
+
+resolve_positive_test!(
+    test_resolve_numalgo2_multiple_services,
+    DID_DOC_MULTIPLE_SERVICES,
+    PEER_DID_NUMALGO_2_MULTIPLE_SERVICES,
+    PublicKeyEncoding::Multibase
+);
+
+resolve_positive_test!(
+    test_resolve_numalgo2_no_routing_keys,
+    DID_DOC_NO_ROUTING_KEYS,
+    PEER_DID_NUMALGO_2_NO_ROUTING_KEYS,
+    PublicKeyEncoding::Multibase
+);
+
+resolve_positive_test!(
+    test_resolve_numalgo2_no_services,
+    DID_DOC_NO_SERVICES,
+    PEER_DID_NUMALGO_2_NO_SERVICES,
+    PublicKeyEncoding::Multibase
+);

--- a/did_resolver/src/traits/resolvable/mod.rs
+++ b/did_resolver/src/traits/resolvable/mod.rs
@@ -11,11 +11,12 @@ use self::{resolution_options::DidResolutionOptions, resolution_output::DidResol
 
 #[async_trait]
 pub trait DidResolvable {
-    type ExtraFields: Default;
+    type ExtraFieldsService: Default;
+    type ExtraFieldsOptions: Default;
 
     async fn resolve(
         &self,
         did: &Did,
-        options: &DidResolutionOptions,
-    ) -> Result<DidResolutionOutput<Self::ExtraFields>, GenericError>;
+        options: &DidResolutionOptions<Self::ExtraFieldsOptions>,
+    ) -> Result<DidResolutionOutput<Self::ExtraFieldsService>, GenericError>;
 }

--- a/did_resolver/src/traits/resolvable/mod.rs
+++ b/did_resolver/src/traits/resolvable/mod.rs
@@ -12,7 +12,7 @@ use self::{resolution_options::DidResolutionOptions, resolution_output::DidResol
 #[async_trait]
 pub trait DidResolvable {
     type ExtraFieldsService: Default;
-    type ExtraFieldsOptions: Default;
+    type ExtraFieldsOptions;
 
     async fn resolve(
         &self,

--- a/did_resolver/src/traits/resolvable/resolution_options.rs
+++ b/did_resolver/src/traits/resolvable/resolution_options.rs
@@ -1,26 +1,21 @@
 use crate::shared_types::media_type::MediaType;
 
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct DidResolutionOptions<E: Default> {
+pub struct DidResolutionOptions<E> {
     accept: Option<MediaType>,
     extra: E,
 }
 
-impl<E: Default> DidResolutionOptions<E> {
-    pub fn new() -> Self {
+impl<E> DidResolutionOptions<E> {
+    pub fn new(extra: E) -> Self {
         Self {
             accept: None,
-            extra: E::default(),
+            extra,
         }
     }
 
     pub fn set_accept(mut self, accept: MediaType) -> Self {
         self.accept = Some(accept);
-        self
-    }
-
-    pub fn set_extra(mut self, extra: E) -> Self {
-        self.extra = extra;
         self
     }
 

--- a/did_resolver/src/traits/resolvable/resolution_options.rs
+++ b/did_resolver/src/traits/resolvable/resolution_options.rs
@@ -1,13 +1,17 @@
 use crate::shared_types::media_type::MediaType;
 
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct DidResolutionOptions {
+pub struct DidResolutionOptions<E: Default> {
     accept: Option<MediaType>,
+    extra: E,
 }
 
-impl DidResolutionOptions {
+impl<E: Default> DidResolutionOptions<E> {
     pub fn new() -> Self {
-        Self { accept: None }
+        Self {
+            accept: None,
+            extra: E::default(),
+        }
     }
 
     pub fn set_accept(mut self, accept: MediaType) -> Self {
@@ -15,7 +19,16 @@ impl DidResolutionOptions {
         self
     }
 
+    pub fn set_extra(mut self, extra: E) -> Self {
+        self.extra = extra;
+        self
+    }
+
     pub fn accept(&self) -> Option<&MediaType> {
         self.accept.as_ref()
+    }
+
+    pub fn extra(&self) -> &E {
+        &self.extra
     }
 }

--- a/did_resolver_registry/src/lib.rs
+++ b/did_resolver_registry/src/lib.rs
@@ -13,7 +13,8 @@ use did_resolver::{
 use error::DidResolverRegistryError;
 
 pub struct ResolverRegistry {
-    resolvers: HashMap<String, Box<dyn DidResolvable<ExtraFields = ()>>>, // TODO: Use e.g. hashmap
+    resolvers:
+        HashMap<String, Box<dyn DidResolvable<ExtraFieldsService = (), ExtraFieldsOptions = ()>>>, // TODO: Use e.g. hashmap
 }
 
 impl ResolverRegistry {
@@ -26,7 +27,7 @@ impl ResolverRegistry {
     pub fn register_resolver(
         &mut self,
         method: String,
-        resolver: Box<dyn DidResolvable<ExtraFields = ()>>,
+        resolver: Box<dyn DidResolvable<ExtraFieldsService = (), ExtraFieldsOptions = ()>>,
     ) {
         self.resolvers.insert(method, resolver);
     }
@@ -38,7 +39,7 @@ impl ResolverRegistry {
     pub async fn resolve(
         &self,
         did: &Did,
-        options: &DidResolutionOptions,
+        options: &DidResolutionOptions<()>,
     ) -> Result<DidResolutionOutput<()>, GenericError> {
         let method = did.method();
         match self.resolvers.get(method) {
@@ -61,12 +62,13 @@ mod tests {
     #[async_trait]
     #[automock]
     impl DidResolvable for DummyDidResolver {
-        type ExtraFields = ();
+        type ExtraFieldsService = ();
+        type ExtraFieldsOptions = ();
 
         async fn resolve(
             &self,
             did: &Did,
-            _options: &DidResolutionOptions,
+            _options: &DidResolutionOptions<()>,
         ) -> Result<DidResolutionOutput<()>, GenericError> {
             Ok(DidResolutionOutput::builder(
                 DidDocumentBuilder::new(Did::parse(did.did().to_string()).unwrap()).build(),

--- a/did_resolver_sov/src/resolution/resolver.rs
+++ b/did_resolver_sov/src/resolution/resolver.rs
@@ -32,13 +32,14 @@ impl DidSovResolver {
 
 #[async_trait]
 impl DidResolvable for DidSovResolver {
-    type ExtraFields = ExtraFieldsSov;
+    type ExtraFieldsService = ExtraFieldsSov;
+    type ExtraFieldsOptions = ();
 
     async fn resolve(
         &self,
         parsed_did: &Did,
-        options: &DidResolutionOptions,
-    ) -> Result<DidResolutionOutput<Self::ExtraFields>, GenericError> {
+        options: &DidResolutionOptions<()>,
+    ) -> Result<DidResolutionOutput<Self::ExtraFieldsService>, GenericError> {
         if let Some(accept) = options.accept() {
             if accept != &MediaType::DidJson {
                 return Err(Box::new(DidSovError::RepresentationNotSupported(

--- a/did_resolver_web/src/resolution/resolver.rs
+++ b/did_resolver_web/src/resolution/resolver.rs
@@ -65,12 +65,13 @@ impl<C> DidResolvable for DidWebResolver<C>
 where
     C: Connect + Send + Sync + Clone + 'static,
 {
-    type ExtraFields = ();
+    type ExtraFieldsService = ();
+    type ExtraFieldsOptions = ();
 
     async fn resolve(
         &self,
         did: &Did,
-        options: &DidResolutionOptions,
+        options: &DidResolutionOptions<Self::ExtraFieldsOptions>,
     ) -> Result<DidResolutionOutput<()>, GenericError> {
         if did.method() != "web" {
             return Err(Box::new(DidWebError::MethodNotSupported(did.method().to_string())));


### PR DESCRIPTION
Implementation of did:peer method 2:

* construction of did:peer:2 peer DID based on a DID document
* construction of DID document based on did:peer:2 peer DID.

The main non-functional requirement is maximal interoperability with the already existing implementations in other Aries frameworks.