### PR TITLE
CI: Skip test-android job

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -1,7 +1,7 @@
 name: 'build-image'
 description: |
-  Tries to load <docker-img> from github cache. 
-  On cache miss, load up layers of last build of this image within the same branch. If no such image is found, try 
+  Tries to load <docker-img> from github cache.
+  On cache miss, load up layers of last build of this image within the same branch. If no such image is found, try
     to load last build of this image from master branch.
   Then image is built ( and reusing the pre-loaded layers from last branch/master build ).
   Finally, image is pushed to docker registry.
@@ -51,7 +51,7 @@ runs:
         set -x
         GITHUB_REPOSITORY_LOWERCASE=`echo $GITHUB_REPOSITORY | awk '{print tolower($0)}'`
         REMOTE_DOCKER_REPOSITORY="${URL_DOCKER_REGISTRY}/${GITHUB_REPOSITORY_LOWERCASE}/${{ inputs.docker-repo-local-name }}"
-        
+
         LAST_BRANCH_BUILD="$REMOTE_DOCKER_REPOSITORY:${{ inputs.branch-name }}"
         if ! docker pull "$LAST_BRANCH_BUILD"; then
           LAST_MASTER_BUILD="$REMOTE_DOCKER_REPOSITORY:${{ inputs.branch-main }}"
@@ -72,6 +72,7 @@ runs:
         else
           docker build -t "${{ inputs.docker-img }}" --build-arg ${{ inputs.build-arg }} -f ${{ inputs.dockerfile-path }} .
         fi;
+        docker image ls -a
         docker save "${{ inputs.docker-img }}" > "${{ steps.setup.outputs.cache-file-path }}"
     - name: "Publish branch image"
       if: steps.loadcachedimg.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -611,30 +611,30 @@ jobs:
       - name: "Run integration tests"
         run: (cd agents/node/vcxagent-core && AGENCY_URL=http://localhost:8080 npm run test:integration)
 
-  test-android-build:
-    runs-on: ubuntu-20.04
-    needs: [ workflow-setup, build-docker-android ]
-    if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' && needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
-    env:
-      DOCKER_IMG_CACHED_ANDROID: ${{needs.workflow-setup.outputs.DOCKER_IMG_CACHED_ANDROID}}
-    steps:
-      - name: "Git checkout"
-        uses: actions/checkout@v3
-      - name: "Docker Login"
-        uses: azure/docker-login@v1
-        with:
-          login-server: ${{ env.URL_DOCKER_REGISTRY }}
-          username: $GITHUB_ACTOR
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Load android image"
-        uses: ./.github/actions/load-image
-        with:
-          docker-img: ${{ env.DOCKER_IMG_CACHED_ANDROID }}
-      - name: "Run android tests"
-        run: |
-          rm -rf /tmp/imgcache
-          docker run --rm -i  $DOCKER_IMG_CACHED_ANDROID \
-                              sh -c '(cd $HOME/aries-vcx && ./wrappers/java/ci/android.test.sh armv7)'
+#  test-android-build:
+#    runs-on: ubuntu-20.04
+#    needs: [ workflow-setup, build-docker-android ]
+#    if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' && needs.workflow-setup.outputs.SKIP_ANDROID != 'true' }}
+#    env:
+#      DOCKER_IMG_CACHED_ANDROID: ${{needs.workflow-setup.outputs.DOCKER_IMG_CACHED_ANDROID}}
+#    steps:
+#      - name: "Git checkout"
+#        uses: actions/checkout@v3
+#      - name: "Docker Login"
+#        uses: azure/docker-login@v1
+#        with:
+#          login-server: ${{ env.URL_DOCKER_REGISTRY }}
+#          username: $GITHUB_ACTOR
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#      - name: "Load android image"
+#        uses: ./.github/actions/load-image
+#        with:
+#          docker-img: ${{ env.DOCKER_IMG_CACHED_ANDROID }}
+#      - name: "Run android tests"
+#        run: |
+#          rm -rf /tmp/imgcache
+#          docker run --rm -i  $DOCKER_IMG_CACHED_ANDROID \
+#                              sh -c '(cd $HOME/aries-vcx && ./wrappers/java/ci/android.test.sh armv7)'
 
   build-and-publish-ios-wrapper:
     needs: workflow-setup
@@ -939,7 +939,7 @@ jobs:
       - test-integration-libvcx
       - test-integration-aries-vcx
       - test-integration-aries-vcx-mysql
-      - test-android-build
+#      - test-android-build
       - test-node-wrapper
       - test-integration-node-wrapper
     if: ${{ needs.workflow-setup.outputs.RELEASE == 'true' || needs.workflow-setup.outputs.PRERELEASE == 'true' }}

--- a/wrappers/java/android/build.gradle
+++ b/wrappers/java/android/build.gradle
@@ -29,10 +29,6 @@ repositories {
     maven {
         url "https://jitpack.io"
     }
-    maven {
-        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "./node_modules/react-native/android"
-    }
 }
 
 allprojects {
@@ -180,7 +176,6 @@ dependencies {
     testImplementation group: 'org.json', name: 'json', version:'20160810'
     testImplementation 'net.java.dev.jna:jna:4.5.0'
     testImplementation 'org.awaitility:awaitility-scala:3.1.2'
-    androidTestImplementation('com.facebook.react:react-native:0.59.9') { force = true }
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support:support-annotations:26.1.0'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'

--- a/wrappers/java/ci/android.build.sh
+++ b/wrappers/java/ci/android.build.sh
@@ -42,10 +42,6 @@ prepare_artifacts(){
 
 build_android_wrapper(){
     pushd ${JAVA_WRAPPER_DIR}
-        pushd android
-            npm install
-        popd
-
         ./gradlew --no-daemon clean build --project-dir=android
     popd
 }

--- a/wrappers/java/ci/android.dockerfile
+++ b/wrappers/java/ci/android.dockerfile
@@ -33,11 +33,6 @@ RUN usermod -aG sudo indy
 
 WORKDIR /home/indy
 
-# Install node
-ARG NODE_VER=12.x
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VER} | bash -
-RUN apt-get install -y nodejs
-
 USER indy
 
 # Install Rust toolchain

--- a/wrappers/java/ci/android.prepare.sh
+++ b/wrappers/java/ci/android.prepare.sh
@@ -7,6 +7,5 @@ source ${SCRIPT_DIR}/setup.android.env.sh
 
 download_sdk
 download_and_setup_toolchain
-download_emulator
 
 prepare_dependencies "arm"

--- a/wrappers/java/ci/setup.android.env.sh
+++ b/wrappers/java/ci/setup.android.env.sh
@@ -52,16 +52,19 @@ create_avd(){
     if [ ! -d "${ANDROID_SDK}/emulator/" ] ; then
         echo "y" |
               sdkmanager --no_https \
+                "emulator" \
                 "platform-tools" \
                 "platforms;android-24" \
                 "system-images;android-24;default;${ABI}" > sdkmanager.install.emulator.and.tools.out 2>&1
 
         # TODO sdkmanager upgrades by default. Hack to downgrade Android Emulator so as to work in headless mode (node display).
         # Remove as soon as headless mode is fixed.
+        # todo: Why do we download emulator manually if we've just installed it above with sdkmanager?
         download_emulator
         mv /home/indy/emu.zip emu.zip
+        mv emulator emulator_backup
         unzip emu.zip
-        rm emu.zip
+        rm "emu.zip"
     else
         echo "Skipping sdkmanager activity"
     fi
@@ -74,12 +77,7 @@ create_avd(){
             --package "system-images;android-24;default;${ABI}" \
             -f \
             -c 3000M
-
-    echo "foobar123"
-    ls ${ANDROID_HOME}/tools/emulator
-    echo "xyz123"
-    which emulator
-    ANDROID_SDK_ROOT=${ANDROID_SDK} ANDROID_HOME=${ANDROID_SDK} emulator -avd ${ABSOLUTE_ARCH} -netdelay none -partition-size 3000 -netspeed full -no-audio -no-window -no-snapshot -no-accel &
+    ANDROID_SDK_ROOT=${ANDROID_SDK} ANDROID_HOME=${ANDROID_SDK} ${ANDROID_HOME}/tools/emulator -avd ${ABSOLUTE_ARCH} -netdelay none -partition-size 3000 -netspeed full -no-audio -no-window -no-snapshot -no-accel &
 }
 
 kill_avd(){

--- a/wrappers/java/ci/setup.android.env.sh
+++ b/wrappers/java/ci/setup.android.env.sh
@@ -38,6 +38,11 @@ accept_licenses(){
     yes | sdkmanager --licenses
 }
 
+
+download_emulator() {
+    curl -o /home/indy/emu.zip https://dl.google.com/android/repository/emulator-linux-5889189.zip
+}
+
 # TODO: Recreating avd for more than a single arch doesn't work
 create_avd(){
     echo "${GREEN}Creating Android SDK${RESET}"
@@ -47,17 +52,16 @@ create_avd(){
     if [ ! -d "${ANDROID_SDK}/emulator/" ] ; then
         echo "y" |
               sdkmanager --no_https \
-                "emulator" \
                 "platform-tools" \
                 "platforms;android-24" \
                 "system-images;android-24;default;${ABI}" > sdkmanager.install.emulator.and.tools.out 2>&1
 
         # TODO sdkmanager upgrades by default. Hack to downgrade Android Emulator so as to work in headless mode (node display).
         # Remove as soon as headless mode is fixed.
+        download_emulator
         mv /home/indy/emu.zip emu.zip
-        mv emulator emulator_backup
         unzip emu.zip
-        rm "emu.zip"
+        rm emu.zip
     else
         echo "Skipping sdkmanager activity"
     fi
@@ -70,7 +74,12 @@ create_avd(){
             --package "system-images;android-24;default;${ABI}" \
             -f \
             -c 3000M
-    ANDROID_SDK_ROOT=${ANDROID_SDK} ANDROID_HOME=${ANDROID_SDK} ${ANDROID_HOME}/tools/emulator -avd ${ABSOLUTE_ARCH} -netdelay none -partition-size 3000 -netspeed full -no-audio -no-window -no-snapshot -no-accel &
+
+    echo "foobar123"
+    ls ${ANDROID_HOME}/tools/emulator
+    echo "xyz123"
+    which emulator
+    ANDROID_SDK_ROOT=${ANDROID_SDK} ANDROID_HOME=${ANDROID_SDK} emulator -avd ${ABSOLUTE_ARCH} -netdelay none -partition-size 3000 -netspeed full -no-audio -no-window -no-snapshot -no-accel &
 }
 
 kill_avd(){
@@ -120,10 +129,6 @@ cat << EOF > ${HOME}/.cargo/config
 ar = "$(realpath ${AR})"
 linker = "$(realpath ${CC})"
 EOF
-}
-
-download_emulator() {
-    curl -o /home/indy/emu.zip https://dl.google.com/android/repository/emulator-linux-5889189.zip
 }
 
 download_and_unzip_if_missed() {


### PR DESCRIPTION
- Android builds recently started failing due to lack of disk space on github runners
- This pr fixes the andorid-build job itself, but the problem re-occurs in android test jobs
   - do not install `npm`
   - moves downloading emulator to scripts to latter phase, just before testing. This significantly decreases size of the job
   - remove seemingly unnecessary nodejs/react-native related items from java wrapper directory
- Fixing the disk space issue would require bigger revision of the entire approach to find places where we can be more efficient. Having other higher priority in backlog, and libvcx being deprecated, this skips the android test job in CI instead of fixing the issue. 