### PR TITLE
Enable compiling the workspace with --tests --all-features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,6 +192,7 @@ jobs:
         run: |
           cd aries_vcx
           cargo check
+          cargo check --tests --all-features
           cargo check --no-default-features
           cargo check --features vdrtools --no-default-features
           cargo check --features modular_libs --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,6 +2478,7 @@ dependencies = [
 name = "indy-wallet"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "async-trait",
  "bs58 0.4.0",
  "byteorder",

--- a/libvcx/src/lib.rs
+++ b/libvcx/src/lib.rs
@@ -10,7 +10,6 @@
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 #![deny(clippy::unwrap_used)]
-#![cfg_attr(feature = "fatal_warnings", deny(warnings))]
 #![crate_name = "vcx"]
 //this is needed for some large json macro invocations
 #![recursion_limit = "128"]

--- a/libvcx_core/src/api_vcx/api_handle/issuer_credential.rs
+++ b/libvcx_core/src/api_vcx/api_handle/issuer_credential.rs
@@ -363,32 +363,6 @@ pub mod tests {
 
     #[tokio::test]
     #[cfg(feature = "general_test")]
-    async fn test_retry_build_credential_offer() {
-        let _setup = SetupMocks::init();
-
-        let _connection_handle = build_test_connection_inviter_requested().await;
-
-        let credential_handle = _issuer_credential_create();
-        assert_eq!(get_state(credential_handle).unwrap(), u32::from(IssuerState::Initial));
-
-        StatusCodeMock::set_next_result(error::TIMEOUT_LIBINDY_ERROR);
-
-        let (_, cred_def_handle) = create_and_publish_nonrevocable_creddef().await;
-        let _err = build_credential_offer_msg_v2(credential_handle, cred_def_handle, 1234, _cred_json(), None)
-            .await
-            .unwrap_err();
-        assert_eq!(get_state(credential_handle).unwrap(), u32::from(IssuerState::Initial));
-
-        // Can retry after initial failure
-        let (_, cred_def_handle) = create_and_publish_nonrevocable_creddef().await;
-        let _err = build_credential_offer_msg_v2(credential_handle, cred_def_handle, 1234, _cred_json(), None)
-            .await
-            .unwrap();
-        assert_eq!(get_state(credential_handle).unwrap(), u32::from(IssuerState::OfferSet));
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "general_test")]
     async fn test_from_string_succeeds() {
         let _setup = SetupMocks::init();
 

--- a/libvcx_core/src/api_vcx/api_handle/schema.rs
+++ b/libvcx_core/src/api_vcx/api_handle/schema.rs
@@ -183,7 +183,7 @@ pub mod tests {
 
     #[cfg(feature = "pool_tests")]
     use crate::api_vcx::api_handle::schema;
-    #[cfg(feature = "pool_tests")]
+    #[cfg(any(feature = "pool_tests", feature = "general_test"))]
     use crate::api_vcx::api_handle::schema::test_utils::{check_schema, create_schema_real, prepare_schema_data};
     #[cfg(feature = "pool_tests")]
     use crate::api_vcx::utils::devsetup::SetupGlobalsWalletPoolAgency;

--- a/libvcx_core/src/lib.rs
+++ b/libvcx_core/src/lib.rs
@@ -10,7 +10,6 @@
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 #![deny(clippy::unwrap_used)]
-#![cfg_attr(feature = "fatal_warnings", deny(warnings))]
 // todo: is this recursion_limit still needed and justified?
 //this is needed for some large json macro invocations
 #![recursion_limit = "128"]

--- a/libvdrtools/indy-wallet/Cargo.toml
+++ b/libvdrtools/indy-wallet/Cargo.toml
@@ -27,3 +27,6 @@ serde_derive = "1.0.99"
 sqlx = { version = "0.5.8", git = "https://github.com/jovfer/sqlx", branch = "feature/json_no_preserve_order_v5", features = [ "sqlite", "mysql", "json_no_preserve_order", "runtime-tokio-rustls" ] }
 zeroize = "~1.3.0"
 lru = "0.7.6"
+
+[dev-dependencies]
+async-std = "1.12.0"

--- a/libvdrtools/src/lib.rs
+++ b/libvdrtools/src/lib.rs
@@ -3,7 +3,6 @@
 #[macro_use]
 extern crate log;
 
-#[macro_use]
 extern crate num_derive;
 
 extern crate num_traits;

--- a/libvdrtools/src/utils/mod.rs
+++ b/libvdrtools/src/utils/mod.rs
@@ -23,15 +23,3 @@ pub use indy_utils::wql;
 pub mod qualifier;
 
 pub mod extensions;
-
-macro_rules! map (
-    { $($key:expr => $value:expr),+ } => {
-        {
-            let mut m = ::std::collections::HashMap::new();
-            $(
-                m.insert($key, $value);
-            )+
-            m
-        }
-     };
-);


### PR DESCRIPTION
A hotfix to enable compiling the workspace with `--tests --all-features`.

It is [recommended](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification) that

> [...] features should be additive. That is, enabling a feature should not disable functionality, and it should usually be safe to enable any combination of features. [...]

meaning the code should compile with all features enabled as well.

(Selfish reason is that I am using these cargo options in the rust-analyzer settings globally to enable code completion and error / warnings hints in any Rust project in all code, including code compiled conditionally using features and all tests. If the workspace stops compiling before it reaches the code I am working on, I get no error hints.)