### PR TITLE
libvcx implementation profiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -557,7 +557,7 @@ jobs:
           RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs -- --include-ignored;
           RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs_revocations -- --include-ignored;
 
-  test-integration-libvcx:
+  test-integration-libvcx-vdrtools:
     needs: workflow-setup
     if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
     runs-on: ubuntu-20.04
@@ -568,8 +568,23 @@ jobs:
         uses: ./.github/actions/setup-testing-rust
       - name: "Run libvcx integration tests"
         run: |
-          RUST_TEST_THREADS=1 cargo test --manifest-path="libvcx/Cargo.toml" -- --include-ignored;
-          RUST_TEST_THREADS=1 cargo test --manifest-path="libvcx_core/Cargo.toml" -- --include-ignored;
+          RUST_TEST_THREADS=1 cargo test --features ledger_vdrtools,anoncreds_vdrtools --manifest-path="libvcx/Cargo.toml" -- --include-ignored;
+          RUST_TEST_THREADS=1 cargo test --features ledger_vdrtools,anoncreds_vdrtools --manifest-path="libvcx_core/Cargo.toml" -- --include-ignored;
+
+  test-integration-libvcx-modular:
+    needs: workflow-setup
+    if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Git checkout"
+        uses: actions/checkout@v3
+      - name: "Setup rust testing environment"
+        uses: ./.github/actions/setup-testing-rust
+      - name: "Run libvcx integration tests"
+        run: |
+          RUST_TEST_THREADS=1 cargo test --features ledger_indyvdr,anoncreds_credx --manifest-path="libvcx/Cargo.toml" -- --include-ignored;
+          RUST_TEST_THREADS=1 cargo test --features ledger_indyvdr,anoncreds_credx --manifest-path="libvcx_core/Cargo.toml" -- --include-ignored;
+
 
   test-integration-resolver:
     needs: workflow-setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -850,7 +850,7 @@ jobs:
               set -e
               sudo apt-get update -y
               sudo apt-get install -y libssl-dev libzmq3-dev
-              npm run build:napi -- --target x86_64-unknown-linux-gnu
+              npm run build:napi
               strip *.node
           - host: ubuntu-20.04
             target: x86_64-unknown-linux-musl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -557,10 +557,13 @@ jobs:
           RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs -- --include-ignored;
           RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs_revocations -- --include-ignored;
 
-  test-integration-libvcx-vdrtools:
+  test-integration-libvcx:
     needs: workflow-setup
     if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        features: ["ledger_vdrtools,anoncreds_vdrtools", "ledger_indyvdr,anoncreds_credx"]
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -568,23 +571,8 @@ jobs:
         uses: ./.github/actions/setup-testing-rust
       - name: "Run libvcx integration tests"
         run: |
-          RUST_TEST_THREADS=1 cargo test --features ledger_vdrtools,anoncreds_vdrtools --manifest-path="libvcx/Cargo.toml" -- --include-ignored;
-          RUST_TEST_THREADS=1 cargo test --features ledger_vdrtools,anoncreds_vdrtools --manifest-path="libvcx_core/Cargo.toml" -- --include-ignored;
-
-  test-integration-libvcx-modular:
-    needs: workflow-setup
-    if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Git checkout"
-        uses: actions/checkout@v3
-      - name: "Setup rust testing environment"
-        uses: ./.github/actions/setup-testing-rust
-      - name: "Run libvcx integration tests"
-        run: |
-          RUST_TEST_THREADS=1 cargo test --features ledger_indyvdr,anoncreds_credx --manifest-path="libvcx/Cargo.toml" -- --include-ignored;
-          RUST_TEST_THREADS=1 cargo test --features ledger_indyvdr,anoncreds_credx --manifest-path="libvcx_core/Cargo.toml" -- --include-ignored;
-
+          RUST_TEST_THREADS=1 cargo test --features ${{ matrix.features }} --manifest-path="libvcx/Cargo.toml" -- --include-ignored;
+          RUST_TEST_THREADS=1 cargo test --features ${{ matrix.features }} --manifest-path="libvcx_core/Cargo.toml" -- --include-ignored;
 
   test-integration-resolver:
     needs: workflow-setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -563,16 +563,41 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        features: ["ledger_vdrtools,anoncreds_vdrtools", "ledger_indyvdr,anoncreds_credx"]
+        features: [
+          "ledger_vdrtools,anoncreds_vdrtools",
+          "ledger_vdrtools,anoncreds_credx",
+          "ledger_indyvdr,anoncreds_vdrtools",
+          "ledger_indyvdr,anoncreds_credx"
+        ]
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
-      - name: "Run libvcx integration tests"
+      - name: "Run libvcx_core integration tests"
         run: |
-          RUST_TEST_THREADS=1 cargo test --features ${{ matrix.features }} --manifest-path="libvcx/Cargo.toml" -- --include-ignored;
           RUST_TEST_THREADS=1 cargo test --features ${{ matrix.features }} --manifest-path="libvcx_core/Cargo.toml" -- --include-ignored;
+
+  test-integration-libvcx-c:
+    needs: workflow-setup
+    if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        features: [
+          "ledger_vdrtools,anoncreds_vdrtools",
+          "ledger_vdrtools,anoncreds_credx",
+          "ledger_indyvdr,anoncreds_vdrtools",
+          "ledger_indyvdr,anoncreds_credx"
+        ]
+    steps:
+      - name: "Git checkout"
+        uses: actions/checkout@v3
+      - name: "Setup rust testing environment"
+        uses: ./.github/actions/setup-testing-rust
+      - name: "Run libvcx unit tests"
+        run: |
+          RUST_TEST_THREADS=1 cargo test --features ${{ matrix.features }} --manifest-path="libvcx/Cargo.toml";
 
   test-integration-resolver:
     needs: workflow-setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -373,68 +373,6 @@ jobs:
 
 #  ##########################################################################################
 #  ###############################    CODECOV    ###########################################
-#
-  code-coverage-aries-vcx-unit-tests:
-    needs: workflow-setup
-    if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Git checkout"
-        uses: actions/checkout@v3
-      - name: "Setup rust codecov environment"
-        uses: ./.github/actions/setup-codecov-rust
-        with:
-          skip-docker-setup: true
-      - name: "Run aries-vcx unit tests"
-        run: |
-          RUSTFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests' \
-          RUSTDOCFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests' \
-          RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --package aries-vcx;
-
-          mkdir -p /tmp/artifacts/coverage
-          grcov ./target/debug/ -s . -t lcov --llvm --branch --ignore-not-existing -o /tmp/artifacts/coverage/coverage.lcov
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v2
-        with:
-          directory: /tmp/artifacts/coverage
-          flags: unittests-aries-vcx
-          name: codecov-unit-aries-vcx
-          fail_ci_if_error: true
-          path_to_write_report: /tmp/artifacts/coverage/codecov_report.gz
-      - uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-report-unit-aries-vcx
-          path: /tmp/artifacts/coverage
-
-  code-coverage-aries-vcx-integration-tests:
-    needs: workflow-setup
-    if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Git checkout"
-        uses: actions/checkout@v3
-      - name: "Setup rust codecov environment"
-        uses: ./.github/actions/setup-codecov-rust
-      - name: "Run workspace tests: vdrtools profile"
-        run: |
-          RUSTFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests' \
-          RUSTDOCFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests' \
-          RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --package aries-vcx -- --ignored;
-
-          mkdir -p /tmp/artifacts/coverage
-          grcov ./target/debug/ -s . -t lcov --llvm --branch --ignore-not-existing -o /tmp/artifacts/coverage/coverage.lcov
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v2
-        with:
-          directory: /tmp/artifacts/coverage
-          flags: unittests-aries-vcx
-          name: codecov-unit-aries-vcx
-          fail_ci_if_error: true
-          path_to_write_report: /tmp/artifacts/coverage/codecov_report.gz
-      - uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-report-unit-aries-vcx
-          path: /tmp/artifacts/coverage
 
   code-coverage-aries-vcx-integration-modular-libs:
     needs: workflow-setup
@@ -472,6 +410,12 @@ jobs:
   test-unit-workspace:
     needs: workflow-setup
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        features: [
+          "anoncreds_vdrtools",
+          "anoncreds_credx",
+        ]
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
@@ -480,18 +424,24 @@ jobs:
         with:
           skip-docker-setup: true
       - name: "Run workspace unit tests"
-        run: RUST_TEST_THREADS=1 cargo test --workspace --lib --exclude aries-vcx-agent --exclude libvdrtools --exclude wallet_migrator
+        run: RUST_TEST_THREADS=1 cargo test --workspace --lib --exclude aries-vcx-agent --exclude libvdrtools --exclude wallet_migrator --features ${{ matrix.features }}
 
   test-integration-aries-vcx:
     needs: workflow-setup
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        features: [
+          "vdrtools",
+          "modular_libs"
+        ]
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v3
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
       - name: "Run aries-vcx integration tests"
-        run: RUST_LOG=trace RUST_TEST_THREADS=1 cargo test --manifest-path="aries_vcx/Cargo.toml" -- --ignored;
+        run: RUST_LOG=trace RUST_TEST_THREADS=1 cargo test --manifest-path="aries_vcx/Cargo.toml" --features ${{ matrix.features }} -- --ignored;
 
   test-integration-aries-vcx-mysql:
     needs: workflow-setup

--- a/aries_vcx/src/common/primitives/revocation_registry.rs
+++ b/aries_vcx/src/common/primitives/revocation_registry.rs
@@ -50,7 +50,12 @@ impl RevocationRegistry {
             &format!("tag{}", tag),
         )
         .await
-        .map_err(|err| err.map(AriesVcxErrorKind::CreateRevRegDef, "Cannot create Revocation Registry"))?;
+        .map_err(|err| {
+            AriesVcxError::from_msg(
+                AriesVcxErrorKind::SerializationError,
+                format!("Failed to locally create a new Revocation Registry: {:?}", err),
+            )
+        })?;
         Ok(RevocationRegistry {
             cred_def_id: cred_def_id.to_string(),
             issuer_did: issuer_did.to_string(),

--- a/aries_vcx/src/core/profile/modular_libs_profile.rs
+++ b/aries_vcx/src/core/profile/modular_libs_profile.rs
@@ -36,49 +36,49 @@ pub struct ModularLibsProfile {
     taa_configurator: Arc<dyn TaaConfigurator>,
 }
 
+pub fn indyvdr_build_ledger_read(
+    request_submitter: Arc<IndyVdrSubmitter>,
+) -> VcxResult<IndyVdrLedgerRead<IndyVdrSubmitter, InMemoryResponseCacher>> {
+    let response_parser = Arc::new(ResponseParser::new());
+    let cacher_config = InMemoryResponseCacherConfig::builder()
+        .ttl(Duration::from_secs(60))
+        .capacity(1000)?
+        .build();
+    let response_cacher = Arc::new(InMemoryResponseCacher::new(cacher_config));
+
+    let config_read = IndyVdrLedgerReadConfig {
+        request_submitter: request_submitter.clone(),
+        response_parser,
+        response_cacher,
+        protocol_version: ProtocolVersion::node_1_4(),
+    };
+    Ok(IndyVdrLedgerRead::new(config_read))
+}
+
+pub fn indyvdr_build_ledger_write(
+    wallet: Arc<dyn BaseWallet>,
+    request_submitter: Arc<IndyVdrSubmitter>,
+    taa_options: Option<TxnAuthrAgrmtOptions>,
+) -> IndyVdrLedgerWrite<IndyVdrSubmitter, BaseWalletRequestSigner> {
+    let request_signer = Arc::new(BaseWalletRequestSigner::new(wallet.clone()));
+    let config_write = IndyVdrLedgerWriteConfig {
+        request_signer,
+        request_submitter,
+        taa_options,
+        protocol_version: ProtocolVersion::node_1_4(),
+    };
+    IndyVdrLedgerWrite::new(config_write)
+}
+
 impl ModularLibsProfile {
-    fn init_ledger_read(
-        request_submitter: Arc<IndyVdrSubmitter>,
-    ) -> VcxResult<IndyVdrLedgerRead<IndyVdrSubmitter, InMemoryResponseCacher>> {
-        let response_parser = Arc::new(ResponseParser::new());
-        let cacher_config = InMemoryResponseCacherConfig::builder()
-            .ttl(Duration::from_secs(60))
-            .capacity(1000)?
-            .build();
-        let response_cacher = Arc::new(InMemoryResponseCacher::new(cacher_config));
-
-        let config_read = IndyVdrLedgerReadConfig {
-            request_submitter,
-            response_parser,
-            response_cacher,
-            protocol_version: ProtocolVersion::node_1_4(),
-        };
-        Ok(IndyVdrLedgerRead::new(config_read))
-    }
-
-    fn init_ledger_write(
-        wallet: Arc<dyn BaseWallet>,
-        request_submitter: Arc<IndyVdrSubmitter>,
-        taa_options: Option<TxnAuthrAgrmtOptions>,
-    ) -> IndyVdrLedgerWrite<IndyVdrSubmitter, BaseWalletRequestSigner> {
-        let request_signer = Arc::new(BaseWalletRequestSigner::new(wallet.clone()));
-        let config_write = IndyVdrLedgerWriteConfig {
-            request_signer,
-            request_submitter,
-            taa_options,
-            protocol_version: ProtocolVersion::node_1_4(),
-        };
-        IndyVdrLedgerWrite::new(config_write)
-    }
-
     pub fn init(wallet: Arc<dyn BaseWallet>, ledger_pool_config: LedgerPoolConfig) -> VcxResult<Self> {
         let anoncreds = Arc::new(IndyCredxAnonCreds::new(Arc::clone(&wallet)));
 
         let ledger_pool = Arc::new(IndyVdrLedgerPool::new(ledger_pool_config)?);
         let request_submitter = Arc::new(IndyVdrSubmitter::new(ledger_pool));
 
-        let ledger_read = Self::init_ledger_read(request_submitter.clone())?;
-        let ledger_write = Self::init_ledger_write(wallet.clone(), request_submitter, None);
+        let ledger_read = indyvdr_build_ledger_read(request_submitter.clone())?;
+        let ledger_write = indyvdr_build_ledger_write(wallet.clone(), request_submitter, None);
 
         let ledger_read = Arc::new(ledger_read);
         let ledger_write = Arc::new(ledger_write);

--- a/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
@@ -4,6 +4,7 @@ use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use async_trait::async_trait;
 
 use crate::utils::{self};
+#[cfg(feature = "vdrtools")]
 use aries_vcx_core::WalletHandle;
 use std::collections::HashMap;
 
@@ -15,6 +16,7 @@ pub struct MockWallet;
 #[allow(unused)]
 #[async_trait]
 impl BaseWallet for MockWallet {
+    #[cfg(feature = "vdrtools")]
     fn get_wallet_handle(&self) -> WalletHandle {
         WalletHandle(1)
     }

--- a/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
+++ b/aries_vcx/src/utils/mockdata/profile/mock_wallet.rs
@@ -4,6 +4,7 @@ use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use async_trait::async_trait;
 
 use crate::utils::{self};
+use aries_vcx_core::WalletHandle;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -14,8 +15,8 @@ pub struct MockWallet;
 #[allow(unused)]
 #[async_trait]
 impl BaseWallet for MockWallet {
-    fn get_wallet_handle(&self) -> i32 {
-        1
+    fn get_wallet_handle(&self) -> WalletHandle {
+        WalletHandle(1)
     }
 
     async fn create_and_store_my_did(

--- a/aries_vcx_core/src/errors/mapping_indyvdr.rs
+++ b/aries_vcx_core/src/errors/mapping_indyvdr.rs
@@ -7,6 +7,7 @@ impl From<VdrError> for AriesVcxCoreError {
         match err.kind() {
             VdrErrorKind::Config => AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::InvalidConfiguration, err),
             VdrErrorKind::Connection => AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::PoolLedgerConnect, err),
+            // todo: we are losing information about the err
             VdrErrorKind::FileSystem(_) => AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::IOError, err),
             VdrErrorKind::Input => AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::InvalidInput, err),
             VdrErrorKind::Resource => AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::UnknownError, err),
@@ -14,8 +15,9 @@ impl From<VdrError> for AriesVcxCoreError {
             VdrErrorKind::Unexpected => AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::UnknownError, err),
             VdrErrorKind::Incompatible => AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::UnknownError, err),
             VdrErrorKind::PoolNoConsensus => AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::UnknownError, err),
+            // todo: we are losing information about the err
             VdrErrorKind::PoolRequestFailed(_) => {
-                AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::PoolLedgerConnect, err)
+                AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::InvalidLedgerResponse, err)
             }
             VdrErrorKind::PoolTimeout => AriesVcxCoreError::from_msg(AriesVcxCoreErrorKind::UnknownError, err),
         }

--- a/aries_vcx_core/src/ledger/indy_vdr_ledger.rs
+++ b/aries_vcx_core/src/ledger/indy_vdr_ledger.rs
@@ -401,10 +401,7 @@ where
             if let AriesVcxCoreErrorKind::InvalidLedgerResponse = err.kind() {
                 return Err(AriesVcxCoreError::from_msg(
                     AriesVcxCoreErrorKind::DuplicationSchema,
-                    format!(
-                        "Schema probably already exists, ledger request failed: {:?}",
-                        err.clone()
-                    ),
+                    format!("Schema probably already exists, ledger request failed: {:?}", &err),
                 ));
             }
         }

--- a/aries_vcx_core/src/wallet/agency_client_wallet.rs
+++ b/aries_vcx_core/src/wallet/agency_client_wallet.rs
@@ -7,6 +7,7 @@ use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResu
 use agency_client::errors::error::{AgencyClientError, AgencyClientErrorKind, AgencyClientResult};
 use agency_client::wallet::base_agency_client_wallet::BaseAgencyClientWallet;
 use async_trait::async_trait;
+use vdrtools::WalletHandle;
 
 #[derive(Debug)]
 pub(crate) struct AgencyClientWallet {
@@ -106,7 +107,7 @@ impl BaseWallet for AgencyClientWallet {
         Ok(self.inner.unpack_message(msg).await?)
     }
 
-    fn get_wallet_handle(&self) -> i32 {
+    fn get_wallet_handle(&self) -> WalletHandle {
         unimplemented!("AgencyClientWallet::get_wallet_handle - this was not expected to be called")
     }
 }

--- a/aries_vcx_core/src/wallet/agency_client_wallet.rs
+++ b/aries_vcx_core/src/wallet/agency_client_wallet.rs
@@ -7,6 +7,7 @@ use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResu
 use agency_client::errors::error::{AgencyClientError, AgencyClientErrorKind, AgencyClientResult};
 use agency_client::wallet::base_agency_client_wallet::BaseAgencyClientWallet;
 use async_trait::async_trait;
+#[cfg(feature = "vdrtools")]
 use vdrtools::WalletHandle;
 
 #[derive(Debug)]
@@ -107,6 +108,7 @@ impl BaseWallet for AgencyClientWallet {
         Ok(self.inner.unpack_message(msg).await?)
     }
 
+    #[cfg(feature = "vdrtools")]
     fn get_wallet_handle(&self) -> WalletHandle {
         unimplemented!("AgencyClientWallet::get_wallet_handle - this was not expected to be called")
     }

--- a/aries_vcx_core/src/wallet/base_wallet.rs
+++ b/aries_vcx_core/src/wallet/base_wallet.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use crate::errors::error::VcxCoreResult;
 use crate::utils::async_fn_iterator::AsyncFnIterator;
 
+use crate::WalletHandle;
 use std::collections::HashMap;
 
 /// Trait defining standard 'wallet' related functionality. The APIs, including
@@ -11,7 +12,7 @@ use std::collections::HashMap;
 #[async_trait]
 pub trait BaseWallet: std::fmt::Debug + Send + Sync {
     // todo: workaround, this needs to be removed, vdrtools wallet specific concept
-    fn get_wallet_handle(&self) -> i32;
+    fn get_wallet_handle(&self) -> WalletHandle;
 
     // ----- DIDs
     async fn create_and_store_my_did(

--- a/aries_vcx_core/src/wallet/base_wallet.rs
+++ b/aries_vcx_core/src/wallet/base_wallet.rs
@@ -3,15 +3,16 @@ use async_trait::async_trait;
 use crate::errors::error::VcxCoreResult;
 use crate::utils::async_fn_iterator::AsyncFnIterator;
 
-use crate::WalletHandle;
 use std::collections::HashMap;
+#[cfg(feature = "vdrtools")]
+use vdrtools::WalletHandle;
 
 /// Trait defining standard 'wallet' related functionality. The APIs, including
 /// input and output types are loosely based off the indy Wallet API:
 /// see: <https://github.com/hyperledger/indy-sdk/blob/main/libindy/src/api/wallet.rs>
 #[async_trait]
 pub trait BaseWallet: std::fmt::Debug + Send + Sync {
-    // todo: workaround, this needs to be removed, vdrtools wallet specific concept
+    #[cfg(feature = "vdrtools")]
     fn get_wallet_handle(&self) -> WalletHandle;
 
     // ----- DIDs

--- a/aries_vcx_core/src/wallet/indy_wallet.rs
+++ b/aries_vcx_core/src/wallet/indy_wallet.rs
@@ -133,8 +133,8 @@ impl BaseWallet for IndySdkWallet {
         indy::signing::unpack_message(self.wallet_handle, msg).await
     }
 
-    fn get_wallet_handle(&self) -> i32 {
-        self.wallet_handle.0
+    fn get_wallet_handle(&self) -> WalletHandle {
+        self.wallet_handle
     }
 }
 

--- a/libvcx/Cargo.toml
+++ b/libvcx/Cargo.toml
@@ -14,8 +14,6 @@ doctest = false
 [features]
 fatal_warnings = []
 
-default = [ "ledger_vdrtools", "anoncreds_vdrtools" ]
-
 ledger_indyvdr = ["libvcx_core/ledger_indyvdr"]
 ledger_vdrtools = ["libvcx_core/ledger_vdrtools"]
 

--- a/libvcx/Cargo.toml
+++ b/libvcx/Cargo.toml
@@ -14,6 +14,14 @@ doctest = false
 [features]
 fatal_warnings = []
 
+default = [ "ledger_vdrtools", "anoncreds_vdrtools" ]
+
+ledger_indyvdr = ["libvcx_core/ledger_indyvdr"]
+ledger_vdrtools = ["libvcx_core/ledger_vdrtools"]
+
+anoncreds_credx = ["libvcx_core/anoncreds_credx"]
+anoncreds_vdrtools = ["libvcx_core/anoncreds_vdrtools"]
+
 [dependencies]
 num-traits = "0.2.0"
 once_cell = { version = "1.15" }

--- a/libvcx/src/api_c/vcx.rs
+++ b/libvcx/src/api_c/vcx.rs
@@ -607,7 +607,6 @@ mod tests {
     use aries_vcx::utils::mockdata::mockdata_credex::ARIES_CREDENTIAL_OFFER;
     use aries_vcx::utils::mockdata::mockdata_proof::ARIES_PROOF_REQUEST_PRESENTATION;
     use libvcx_core;
-    use libvcx_core::api_vcx::api_global::pool::reset_global_ledger_components;
     use libvcx_core::api_vcx::api_global::settings;
     use libvcx_core::api_vcx::api_global::wallet::close_main_wallet;
     #[cfg(test)]

--- a/libvcx_core/Cargo.toml
+++ b/libvcx_core/Cargo.toml
@@ -6,7 +6,14 @@ license.workspace = true
 edition.workspace = true
 
 [features]
+default = [ "ledger_vdrtools", "anoncreds_vdrtools" ]
 fatal_warnings = []
+
+ledger_indyvdr = ["aries-vcx/modular_libs"]
+ledger_vdrtools = ["aries-vcx/vdrtools"]
+
+anoncreds_credx = ["aries-vcx/modular_libs"]
+anoncreds_vdrtools = ["aries-vcx/vdrtools"]
 
 [dependencies]
 num-traits = "0.2.0"

--- a/libvcx_core/Cargo.toml
+++ b/libvcx_core/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 edition.workspace = true
 
 [features]
-default = [ "ledger_vdrtools", "anoncreds_vdrtools" ]
 fatal_warnings = []
 
 ledger_indyvdr = ["aries-vcx/modular_libs"]

--- a/libvcx_core/src/api_vcx/api_global/pool.rs
+++ b/libvcx_core/src/api_vcx/api_global/pool.rs
@@ -236,7 +236,7 @@ pub mod tests {
         #[cfg(feature = "ledger_vdrtools")]
         assert_eq!(
             open_main_pool(&pool_config).await.unwrap_err().kind(),
-            LibvcxErrorKind::InvalidGenesisTxnPath
+            LibvcxErrorKind::PoolLedgerConnect
         );
         // todo: indy-vdr panics if the file is invalid, see: indy-vdr-0.3.4/src/pool/runner.rs:44:22
         // #[cfg(feature = "ledger_indyvdr")]

--- a/libvcx_core/src/api_vcx/api_global/pool.rs
+++ b/libvcx_core/src/api_vcx/api_global/pool.rs
@@ -23,7 +23,6 @@ use aries_vcx::core::profile::profile::Profile;
 use aries_vcx::errors::error::{AriesVcxError, VcxResult};
 use std::sync::Arc;
 use std::sync::RwLock;
-use aries_vcx::aries_vcx_core::errors::error::AriesVcxCoreError;
 
 lazy_static! {
     static ref POOL_HANDLE: RwLock<Option<i32>> = RwLock::new(None);

--- a/libvcx_core/src/api_vcx/api_global/pool.rs
+++ b/libvcx_core/src/api_vcx/api_global/pool.rs
@@ -10,6 +10,7 @@ use aries_vcx::global::settings::{indy_mocks_enabled, DEFAULT_POOL_NAME};
 use crate::api_vcx::api_global::profile::get_main_wallet;
 use crate::api_vcx::api_global::wallet::get_main_wallet_handle;
 use crate::errors::error::{LibvcxError, LibvcxErrorKind, LibvcxResult};
+use aries_vcx::aries_vcx_core::errors::error::AriesVcxCoreError;
 use aries_vcx::aries_vcx_core::ledger::indy_ledger::{IndySdkLedgerRead, IndySdkLedgerWrite};
 #[cfg(feature = "ledger_indyvdr")]
 use aries_vcx::aries_vcx_core::ledger::request_submitter::vdr_ledger::{
@@ -19,7 +20,7 @@ use aries_vcx::aries_vcx_core::wallet::base_wallet::BaseWallet;
 #[cfg(feature = "ledger_indyvdr")]
 use aries_vcx::core::profile::modular_libs_profile::{indyvdr_build_ledger_read, indyvdr_build_ledger_write};
 use aries_vcx::core::profile::profile::Profile;
-use aries_vcx::errors::error::VcxResult;
+use aries_vcx::errors::error::{AriesVcxError, VcxResult};
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -110,6 +111,10 @@ async fn build_components_ledger(
         let indy_read: Arc<dyn IndyLedgerRead> = ledger_read.clone();
         let indy_write: Arc<dyn IndyLedgerWrite> = ledger_write.clone();
         return Ok((anoncreds_read, anoncreds_write, indy_read, indy_write));
+    }
+    #[cfg(not(any(feature = "ledger_indyvdr", feature = "ledger_vdrtools")))]
+    {
+        panic!("No ledger implementation has been selected by feature flag upon build");
     }
 }
 

--- a/libvcx_core/src/api_vcx/api_global/pool.rs
+++ b/libvcx_core/src/api_vcx/api_global/pool.rs
@@ -23,6 +23,7 @@ use aries_vcx::core::profile::profile::Profile;
 use aries_vcx::errors::error::{AriesVcxError, VcxResult};
 use std::sync::Arc;
 use std::sync::RwLock;
+use aries_vcx::aries_vcx_core::errors::error::AriesVcxCoreError;
 
 lazy_static! {
     static ref POOL_HANDLE: RwLock<Option<i32>> = RwLock::new(None);

--- a/libvcx_core/src/api_vcx/api_global/pool.rs
+++ b/libvcx_core/src/api_vcx/api_global/pool.rs
@@ -7,10 +7,19 @@ use aries_vcx::aries_vcx_core::ledger::base_ledger::{
 use aries_vcx::aries_vcx_core::{PoolHandle, INVALID_POOL_HANDLE};
 use aries_vcx::global::settings::{indy_mocks_enabled, DEFAULT_POOL_NAME};
 
+use crate::api_vcx::api_global::profile::get_main_wallet;
 use crate::api_vcx::api_global::wallet::get_main_wallet_handle;
 use crate::errors::error::{LibvcxError, LibvcxErrorKind, LibvcxResult};
 use aries_vcx::aries_vcx_core::ledger::indy_ledger::{IndySdkLedgerRead, IndySdkLedgerWrite};
+#[cfg(feature = "ledger_indyvdr")]
+use aries_vcx::aries_vcx_core::ledger::request_submitter::vdr_ledger::{
+    IndyVdrLedgerPool, IndyVdrSubmitter, LedgerPoolConfig,
+};
+use aries_vcx::aries_vcx_core::wallet::base_wallet::BaseWallet;
+#[cfg(feature = "ledger_indyvdr")]
+use aries_vcx::core::profile::modular_libs_profile::{indyvdr_build_ledger_read, indyvdr_build_ledger_write};
 use aries_vcx::core::profile::profile::Profile;
+use aries_vcx::errors::error::VcxResult;
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -18,12 +27,16 @@ lazy_static! {
     static ref POOL_HANDLE: RwLock<Option<i32>> = RwLock::new(None);
 }
 
+#[cfg(feature = "ledger_vdrtools")]
 pub fn set_vdrtools_global_pool_handle(handle: Option<i32>) {
+    trace!("set_vdrtools_global_pool_handle >>> handle: {handle:?}");
     let mut h = POOL_HANDLE.write().expect("Unable to access POOL_HANDLE");
     *h = handle;
 }
 
+#[cfg(feature = "ledger_vdrtools")]
 pub fn get_vdrtools_global_pool_handle() -> LibvcxResult<i32> {
+    trace!("get_vdrtools_global_pool_handle >>>");
     if indy_mocks_enabled() {
         return Ok(INVALID_POOL_HANDLE);
     }
@@ -40,10 +53,10 @@ pub fn get_vdrtools_global_pool_handle() -> LibvcxResult<i32> {
 }
 
 lazy_static! {
-    pub static ref ledger_anoncreds_read: RwLock<Option<Arc<dyn AnoncredsLedgerRead>>> = RwLock::new(None);
-    pub static ref ledger_anoncreds_write: RwLock<Option<Arc<dyn AnoncredsLedgerWrite>>> = RwLock::new(None);
-    pub static ref ledger_indy_read: RwLock<Option<Arc<dyn IndyLedgerRead>>> = RwLock::new(None);
-    pub static ref ledger_indy_write: RwLock<Option<Arc<dyn IndyLedgerWrite>>> = RwLock::new(None);
+    pub static ref global_ledger_anoncreds_read: RwLock<Option<Arc<dyn AnoncredsLedgerRead>>> = RwLock::new(None);
+    pub static ref global_ledger_anoncreds_write: RwLock<Option<Arc<dyn AnoncredsLedgerWrite>>> = RwLock::new(None);
+    pub static ref global_ledger_indy_read: RwLock<Option<Arc<dyn IndyLedgerRead>>> = RwLock::new(None);
+    pub static ref global_ledger_indy_write: RwLock<Option<Arc<dyn IndyLedgerWrite>>> = RwLock::new(None);
 }
 
 pub fn is_main_pool_open() -> bool {
@@ -52,38 +65,81 @@ pub fn is_main_pool_open() -> bool {
     // global_profile.inject_anoncreds_ledger_read()
 }
 
-pub fn reset_global_ledger_components() -> LibvcxResult<()> {
-    setup_ledger_components(None)?;
+async fn build_components_ledger(
+    base_wallet: Arc<dyn BaseWallet>,
+    pool_name: String,
+    config: &PoolConfig,
+) -> VcxResult<(
+    Arc<dyn AnoncredsLedgerRead>,
+    Arc<dyn AnoncredsLedgerWrite>,
+    Arc<dyn IndyLedgerRead>,
+    Arc<dyn IndyLedgerWrite>,
+)> {
+    #[cfg(feature = "ledger_indyvdr")]
+    {
+        let ledger_pool_config = LedgerPoolConfig {
+            genesis_file_path: config.genesis_path.clone(),
+        };
+        let ledger_pool = Arc::new(IndyVdrLedgerPool::new(ledger_pool_config)?);
+        let request_submitter = Arc::new(IndyVdrSubmitter::new(ledger_pool));
+
+        let ledger_read = Arc::new(indyvdr_build_ledger_read(request_submitter.clone())?);
+        let ledger_write = Arc::new(indyvdr_build_ledger_write(base_wallet, request_submitter, None));
+        let anoncreds_read: Arc<dyn AnoncredsLedgerRead> = ledger_read.clone();
+        let anoncreds_write: Arc<dyn AnoncredsLedgerWrite> = ledger_write.clone();
+        let indy_read: Arc<dyn IndyLedgerRead> = ledger_read.clone();
+        let indy_write: Arc<dyn IndyLedgerWrite> = ledger_write.clone();
+        return Ok((anoncreds_read, anoncreds_write, indy_read, indy_write));
+    }
+    #[cfg(feature = "ledger_vdrtools")]
+    {
+        create_pool_ledger_config(&pool_name, &config.genesis_path)
+            .map_err(|err| err.extend("Can not create Pool Ledger Config"))?;
+
+        let pool_handle = indy_open_pool(&pool_name, config.pool_config.clone())
+            .await
+            .map_err(|err| err.extend("Can not open Pool Ledger"))?;
+
+        set_vdrtools_global_pool_handle(Some(pool_handle));
+
+        let wallet_handle = base_wallet.get_wallet_handle();
+        let ledger_read = Arc::new(IndySdkLedgerRead::new(wallet_handle, pool_handle));
+        let ledger_write = Arc::new(IndySdkLedgerWrite::new(wallet_handle, pool_handle));
+        let anoncreds_read: Arc<dyn AnoncredsLedgerRead> = ledger_read.clone();
+        let anoncreds_write: Arc<dyn AnoncredsLedgerWrite> = ledger_write.clone();
+        let indy_read: Arc<dyn IndyLedgerRead> = ledger_read.clone();
+        let indy_write: Arc<dyn IndyLedgerWrite> = ledger_write.clone();
+        return Ok((anoncreds_read, anoncreds_write, indy_read, indy_write));
+    }
+}
+
+pub fn reset_ledger_components() -> LibvcxResult<()> {
+    #[cfg(feature = "ledger_vdrtools")]
     set_vdrtools_global_pool_handle(None);
+
+    let mut anoncreds_read = global_ledger_anoncreds_read.write()?;
+    *anoncreds_read = None;
+    let mut anoncreds_write = global_ledger_anoncreds_write.write()?;
+    *anoncreds_write = None;
+    let mut indy_read = global_ledger_indy_read.write()?;
+    *indy_read = None;
+    let mut indy_write = global_ledger_indy_write.write()?;
+    *indy_write = None;
     Ok(())
 }
 
-pub fn setup_ledger_components(handle: Option<PoolHandle>) -> LibvcxResult<()> {
-    match handle {
-        None => {
-            let mut anoncreds_read = ledger_anoncreds_read.write()?;
-            *anoncreds_read = None;
-            let mut anoncreds_write = ledger_anoncreds_write.write()?;
-            *anoncreds_write = None;
-            let mut indy_read = ledger_indy_read.write()?;
-            *indy_read = None;
-            let mut indy_write = ledger_indy_write.write()?;
-            *indy_write = None;
-        }
-        Some(pool_handle) => {
-            let wallet_handle = get_main_wallet_handle()?;
-            let ledger_read = Arc::new(IndySdkLedgerRead::new(wallet_handle, pool_handle));
-            let ledger_write = Arc::new(IndySdkLedgerWrite::new(wallet_handle, pool_handle));
-            let mut anoncreds_read = ledger_anoncreds_read.write()?;
-            *anoncreds_read = Some(ledger_read.clone() as Arc<dyn AnoncredsLedgerRead>);
-            let mut anoncreds_write = ledger_anoncreds_write.write()?;
-            *anoncreds_write = Some(ledger_write.clone() as Arc<dyn AnoncredsLedgerWrite>);
-            let mut indy_read = ledger_indy_read.write()?;
-            *indy_read = Some(ledger_read.clone() as Arc<dyn IndyLedgerRead>);
-            let mut indy_write = ledger_indy_write.write()?;
-            *indy_write = Some(ledger_write.clone() as Arc<dyn IndyLedgerWrite>);
-        }
-    }
+pub async fn setup_ledger_components(pool_name: String, config: &PoolConfig) -> LibvcxResult<()> {
+    let base_wallet = get_main_wallet()?;
+    let (anoncreds_read, anoncreds_write, indy_read, indy_write) =
+        build_components_ledger(base_wallet, pool_name, config).await?;
+    let mut anoncreds_read_guard = global_ledger_anoncreds_read.write()?;
+    *anoncreds_read_guard = Some(anoncreds_read.clone() as Arc<dyn AnoncredsLedgerRead>);
+    let mut anoncreds_write_guard = global_ledger_anoncreds_write.write()?;
+    *anoncreds_write_guard = Some(anoncreds_write.clone() as Arc<dyn AnoncredsLedgerWrite>);
+    let mut indy_read_guard = global_ledger_indy_read.write()?;
+    *indy_read_guard = Some(indy_read.clone() as Arc<dyn IndyLedgerRead>);
+    let mut indy_write_guard = global_ledger_indy_write.write()?;
+    *indy_write_guard = Some(indy_write.clone() as Arc<dyn IndyLedgerWrite>);
     Ok(())
 }
 
@@ -104,17 +160,7 @@ pub async fn open_main_pool(config: &PoolConfig) -> LibvcxResult<()> {
         config.pool_config
     );
 
-    create_pool_ledger_config(&pool_name, &config.genesis_path)
-        .map_err(|err| err.extend("Can not create Pool Ledger Config"))?;
-
-    debug!("open_pool >> Pool Config Created Successfully");
-
-    let pool_handle = indy_open_pool(&pool_name, config.pool_config.clone())
-        .await
-        .map_err(|err| err.extend("Can not open Pool Ledger"))?;
-
-    set_vdrtools_global_pool_handle(Some(pool_handle));
-    setup_ledger_components(Some(pool_handle))?;
+    setup_ledger_components(pool_name, config).await?;
 
     info!("open_pool >> Pool Opened Successfully");
 
@@ -123,17 +169,19 @@ pub async fn open_main_pool(config: &PoolConfig) -> LibvcxResult<()> {
 
 pub async fn close_main_pool() -> LibvcxResult<()> {
     info!("close_main_pool >> Closing main pool");
+
+    #[cfg(feature = "ledger_vdrtools")]
     indy_close_pool(get_vdrtools_global_pool_handle()?).await?;
-    // todo: better way to go about this?
-    set_vdrtools_global_pool_handle(None);
-    setup_ledger_components(None)?;
+
+    reset_ledger_components()?;
     Ok(())
 }
 
 #[cfg(test)]
 pub mod tests {
-    use crate::api_vcx::api_global::pool::{close_main_pool, open_main_pool, reset_global_ledger_components};
+    use crate::api_vcx::api_global::pool::{close_main_pool, open_main_pool, reset_ledger_components};
     use crate::api_vcx::api_global::profile::get_main_anoncreds_ledger_read;
+    use crate::api_vcx::api_global::wallet::close_main_wallet;
     use crate::api_vcx::api_global::wallet::test_utils::_create_and_open_wallet;
     use crate::errors::error::LibvcxErrorKind;
     use aries_vcx::aries_vcx_core::indy::ledger::pool::test_utils::create_testpool_genesis_txn_file;
@@ -159,13 +207,15 @@ pub mod tests {
         };
         open_main_pool(&config).await.unwrap();
         close_main_pool().await.unwrap();
-        reset_global_ledger_components().unwrap();
+        close_main_wallet().await.unwrap();
+        reset_ledger_components().unwrap();
     }
 
     #[tokio::test]
     #[ignore]
     async fn test_open_pool_fails_if_genesis_file_is_invalid() {
         let _setup = SetupEmpty::init();
+        _create_and_open_wallet().await.unwrap();
         let pool_name = format!("invalidpool_{}", uuid::Uuid::new_v4().to_string());
 
         // Write invalid genesis.txn
@@ -178,23 +228,33 @@ pub mod tests {
             pool_name: Some(pool_name.clone()),
             pool_config: None,
         };
+        #[cfg(feature = "ledger_vdrtools")]
         assert_eq!(
             open_main_pool(&pool_config).await.unwrap_err().kind(),
-            LibvcxErrorKind::PoolLedgerConnect
+            LibvcxErrorKind::InvalidGenesisTxnPath
         );
+        // todo: indy-vdr panics if the file is invalid, see: indy-vdr-0.3.4/src/pool/runner.rs:44:22
+        // #[cfg(feature = "ledger_indyvdr")]
+        // assert_eq!(
+        //     open_main_pool(&pool_config).await.unwrap_err().kind(),
+        //     LibvcxErrorKind::InvalidGenesisTxnPath
+        // );
         assert_eq!(
             get_main_anoncreds_ledger_read().unwrap_err().kind(),
             LibvcxErrorKind::NotReady
         );
 
+        #[cfg(feature = "ledger_vdrtools")]
         indy_delete_pool(&pool_name).await.unwrap();
-        reset_global_ledger_components().unwrap();
+        close_main_wallet().await.unwrap();
+        reset_ledger_components().unwrap();
     }
 
     #[tokio::test]
     #[ignore]
     async fn test_open_pool_fails_if_genesis_path_is_invalid() {
         let _setup = SetupDefaults::init();
+        _create_and_open_wallet().await.unwrap();
         let pool_name = format!("invalidpool_{}", uuid::Uuid::new_v4().to_string());
 
         let pool_config = PoolConfig {
@@ -202,13 +262,20 @@ pub mod tests {
             pool_name: Some(pool_name.clone()),
             pool_config: None,
         };
+        #[cfg(feature = "ledger_vdrtools")]
         assert_eq!(
             open_main_pool(&pool_config).await.unwrap_err().kind(),
             LibvcxErrorKind::InvalidGenesisTxnPath
+        );
+        #[cfg(feature = "ledger_indyvdr")]
+        assert_eq!(
+            open_main_pool(&pool_config).await.unwrap_err().kind(),
+            LibvcxErrorKind::IOError
         );
         assert_eq!(
             get_main_anoncreds_ledger_read().unwrap_err().kind(),
             LibvcxErrorKind::NotReady
         );
+        close_main_wallet().await.unwrap();
     }
 }

--- a/libvcx_core/src/api_vcx/api_global/profile.rs
+++ b/libvcx_core/src/api_vcx/api_global/profile.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, RwLockReadGuard};
 use crate::api_vcx::api_global::pool::{
     ledger_anoncreds_read, ledger_anoncreds_write, ledger_indy_read, ledger_indy_write,
 };
-use crate::api_vcx::api_global::wallet::{base_anoncreds, base_wallet};
+use crate::api_vcx::api_global::wallet::{global_base_anoncreds, global_base_wallet};
 use crate::errors::error::{LibvcxError, LibvcxErrorKind, LibvcxResult};
 use aries_vcx::aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
 use aries_vcx::aries_vcx_core::ledger::base_ledger::{
@@ -72,7 +72,7 @@ impl ProfileV2 for VcxGlobalsProfile {
     }
 
     fn inject_anoncreds(&self) -> LibvcxResult<Arc<dyn BaseAnonCreds>> {
-        let anoncreds = base_anoncreds.read()?;
+        let anoncreds = global_base_anoncreds.read()?;
         match anoncreds.as_ref() {
             None => Err(LibvcxError::from_msg(
                 LibvcxErrorKind::NotReady,
@@ -105,8 +105,8 @@ impl ProfileV2 for VcxGlobalsProfile {
     }
 
     fn inject_wallet(&self) -> LibvcxResult<Arc<dyn BaseWallet>> {
-        let global_base_wallet = base_wallet.read()?;
-        match global_base_wallet.as_ref() {
+        let base_wallet = global_base_wallet.read()?;
+        match base_wallet.as_ref() {
             None => Err(LibvcxError::from_msg(
                 LibvcxErrorKind::NotReady,
                 "Wallet is not initialized",
@@ -116,8 +116,8 @@ impl ProfileV2 for VcxGlobalsProfile {
     }
 
     fn try_inject_wallet(&self) -> LibvcxResult<Option<Arc<dyn BaseWallet>>> {
-        let global_base_wallet = base_wallet.read()?;
-        global_base_wallet
+        let base_wallet = global_base_wallet.read()?;
+        base_wallet
             .as_ref()
             .map(|w| Some(Arc::clone(w)))
             .ok_or_else(|| LibvcxError::from_msg(LibvcxErrorKind::NotReady, "Wallet is not initialized"))

--- a/libvcx_core/src/api_vcx/api_global/profile.rs
+++ b/libvcx_core/src/api_vcx/api_global/profile.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, RwLockReadGuard};
 
 use crate::api_vcx::api_global::pool::{
-    ledger_anoncreds_read, ledger_anoncreds_write, ledger_indy_read, ledger_indy_write,
+    global_ledger_anoncreds_read, global_ledger_anoncreds_write, global_ledger_indy_read, global_ledger_indy_write,
 };
 use crate::api_vcx::api_global::wallet::{global_base_anoncreds, global_base_wallet};
 use crate::errors::error::{LibvcxError, LibvcxErrorKind, LibvcxResult};
@@ -50,7 +50,7 @@ impl Debug for VcxGlobalsProfile {
 
 impl ProfileV2 for VcxGlobalsProfile {
     fn inject_indy_ledger_read(&self) -> LibvcxResult<Arc<dyn IndyLedgerRead>> {
-        let ledger = ledger_indy_read.read()?;
+        let ledger = global_ledger_indy_read.read()?;
         match ledger.as_ref() {
             None => Err(LibvcxError::from_msg(
                 LibvcxErrorKind::NotReady,
@@ -61,7 +61,7 @@ impl ProfileV2 for VcxGlobalsProfile {
     }
 
     fn inject_indy_ledger_write(&self) -> LibvcxResult<Arc<dyn IndyLedgerWrite>> {
-        let ledger = ledger_indy_write.read()?;
+        let ledger = global_ledger_indy_write.read()?;
         match ledger.as_ref() {
             None => Err(LibvcxError::from_msg(
                 LibvcxErrorKind::NotReady,
@@ -83,7 +83,7 @@ impl ProfileV2 for VcxGlobalsProfile {
     }
 
     fn inject_anoncreds_ledger_read(&self) -> LibvcxResult<Arc<dyn AnoncredsLedgerRead>> {
-        let ledger = ledger_anoncreds_read.read()?;
+        let ledger = global_ledger_anoncreds_read.read()?;
         match ledger.as_ref() {
             None => Err(LibvcxError::from_msg(
                 LibvcxErrorKind::NotReady,
@@ -94,7 +94,7 @@ impl ProfileV2 for VcxGlobalsProfile {
     }
 
     fn inject_anoncreds_ledger_write(&self) -> LibvcxResult<Arc<dyn AnoncredsLedgerWrite>> {
-        let ledger = ledger_anoncreds_write.read()?;
+        let ledger = global_ledger_anoncreds_write.read()?;
         match ledger.as_ref() {
             None => Err(LibvcxError::from_msg(
                 LibvcxErrorKind::NotReady,

--- a/libvcx_core/src/api_vcx/api_global/state.rs
+++ b/libvcx_core/src/api_vcx/api_global/state.rs
@@ -1,5 +1,5 @@
 use crate::api_vcx::api_global::agency_client::reset_main_agency_client;
-use crate::api_vcx::api_global::pool::{close_main_pool, reset_global_ledger_components};
+use crate::api_vcx::api_global::pool::{close_main_pool, reset_ledger_components};
 
 use crate::api_vcx::api_global::settings::get_config_value;
 use crate::api_vcx::api_global::wallet::close_main_wallet;
@@ -27,7 +27,7 @@ pub fn state_vcx_shutdown() {
 
     let _ = reset_config_values_ariesvcx();
     reset_main_agency_client();
-    match reset_global_ledger_components() {
+    match reset_ledger_components() {
         Ok(_) => {}
         Err(err) => {
             error!("Failed to reset global pool: {}", err);

--- a/libvcx_core/src/api_vcx/api_global/wallet.rs
+++ b/libvcx_core/src/api_vcx/api_global/wallet.rs
@@ -31,7 +31,7 @@ lazy_static! {
 }
 
 pub fn get_main_wallet_handle() -> LibvcxResult<WalletHandle> {
-    get_main_wallet().map(|wallet| WalletHandle(wallet.get_wallet_handle()))
+    get_main_wallet().map(|wallet| wallet.get_wallet_handle())
 }
 
 pub async fn export_main_wallet(path: &str, backup_key: &str) -> LibvcxResult<()> {
@@ -46,7 +46,7 @@ fn build_component_base_wallet(wallet_handle: WalletHandle) -> Arc<dyn BaseWalle
 fn build_component_anoncreds(base_wallet: Arc<dyn BaseWallet>) -> Arc<dyn BaseAnonCreds> {
     #[cfg(all(feature = "anoncreds_vdrtools"))]
     {
-        let wallet_handle = WalletHandle(base_wallet.get_wallet_handle());
+        let wallet_handle = base_wallet.get_wallet_handle();
         return Arc::new(IndySdkAnonCreds::new(wallet_handle));
     }
     #[cfg(all(feature = "anoncreds_credx"))]
@@ -90,7 +90,7 @@ pub async fn close_main_wallet() -> LibvcxResult<()> {
             warn!("Skipping wallet close, no global wallet component available.")
         }
         Some(wallet) => {
-            indy::wallet::close_wallet(WalletHandle(wallet.get_wallet_handle())).await?;
+            indy::wallet::close_wallet(wallet.get_wallet_handle()).await?;
             let mut b_wallet = global_base_wallet.write()?;
             *b_wallet = None;
         }

--- a/libvcx_core/src/api_vcx/api_global/wallet.rs
+++ b/libvcx_core/src/api_vcx/api_global/wallet.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use std::sync::RwLock;
 
 use aries_vcx::aries_vcx_core::anoncreds::base_anoncreds::BaseAnonCreds;
+#[cfg(all(feature = "anoncreds_credx"))]
+use aries_vcx::aries_vcx_core::anoncreds::credx_anoncreds::IndyCredxAnonCreds;
 use aries_vcx::aries_vcx_core::anoncreds::indy_anoncreds::IndySdkAnonCreds;
 use aries_vcx::aries_vcx_core::indy::wallet::{
     close_search_wallet, fetch_next_records_wallet, import, open_search_wallet, IssuerConfig, RestoreWalletConfigs,
@@ -24,8 +26,8 @@ use crate::errors::mapping_from_ariesvcx::map_ariesvcx_result;
 use crate::errors::mapping_from_ariesvcxcore::map_ariesvcx_core_result;
 
 lazy_static! {
-    pub static ref base_wallet: RwLock<Option<Arc<dyn BaseWallet>>> = RwLock::new(None);
-    pub static ref base_anoncreds: RwLock<Option<Arc<dyn BaseAnonCreds>>> = RwLock::new(None);
+    pub static ref global_base_wallet: RwLock<Option<Arc<dyn BaseWallet>>> = RwLock::new(None);
+    pub static ref global_base_anoncreds: RwLock<Option<Arc<dyn BaseAnonCreds>>> = RwLock::new(None);
 }
 
 pub fn get_main_wallet_handle() -> LibvcxResult<WalletHandle> {
@@ -37,14 +39,30 @@ pub async fn export_main_wallet(path: &str, backup_key: &str) -> LibvcxResult<()
     map_ariesvcx_core_result(indy::wallet::export_wallet(wallet_handle, path, backup_key).await)
 }
 
-fn setup_global_wallet(handle: WalletHandle) -> LibvcxResult<()> {
+fn build_component_base_wallet(wallet_handle: WalletHandle) -> Arc<dyn BaseWallet> {
+    return Arc::new(IndySdkWallet::new(wallet_handle));
+}
+
+fn build_component_anoncreds(base_wallet: Arc<dyn BaseWallet>) -> Arc<dyn BaseAnonCreds> {
+    #[cfg(all(feature = "anoncreds_vdrtools"))]
+    {
+        let wallet_handle = WalletHandle(base_wallet.get_wallet_handle());
+        return Arc::new(IndySdkAnonCreds::new(wallet_handle));
+    }
+    #[cfg(all(feature = "anoncreds_credx"))]
+    {
+        return Arc::new(IndyCredxAnonCreds::new(Arc::clone(&base_wallet)));
+    }
+}
+
+fn setup_global_wallet(wallet_handle: WalletHandle) -> LibvcxResult<()> {
     // new way
-    let base_wallet_impl: Arc<dyn BaseWallet> = Arc::new(IndySdkWallet::new(handle));
-    let mut b_wallet = base_wallet.write()?;
-    *b_wallet = Some(base_wallet_impl);
+    let base_wallet_impl = build_component_base_wallet(wallet_handle);
+    let mut b_wallet = global_base_wallet.write()?;
+    *b_wallet = Some(base_wallet_impl.clone());
     // anoncreds
-    let base_anoncreds_impl: Arc<dyn BaseAnonCreds> = Arc::new(IndySdkAnonCreds::new(handle));
-    let mut b_anoncreds = base_anoncreds.write()?;
+    let base_anoncreds_impl: Arc<dyn BaseAnonCreds> = build_component_anoncreds(base_wallet_impl);
+    let mut b_anoncreds = global_base_anoncreds.write()?;
     *b_anoncreds = Some(base_anoncreds_impl);
     Ok(())
 }
@@ -73,7 +91,7 @@ pub async fn close_main_wallet() -> LibvcxResult<()> {
         }
         Some(wallet) => {
             indy::wallet::close_wallet(WalletHandle(wallet.get_wallet_handle())).await?;
-            let mut b_wallet = base_wallet.write()?;
+            let mut b_wallet = global_base_wallet.write()?;
             *b_wallet = None;
         }
     }

--- a/libvcx_core/src/api_vcx/api_global/wallet.rs
+++ b/libvcx_core/src/api_vcx/api_global/wallet.rs
@@ -53,6 +53,10 @@ fn build_component_anoncreds(base_wallet: Arc<dyn BaseWallet>) -> Arc<dyn BaseAn
     {
         return Arc::new(IndyCredxAnonCreds::new(Arc::clone(&base_wallet)));
     }
+    #[cfg(not(any(feature = "anoncreds_vdrtools", feature = "anoncreds_credx")))]
+    {
+        panic!("No anoncreds implementation enabled by feature flag upon build");
+    }
 }
 
 fn setup_global_wallet(wallet_handle: WalletHandle) -> LibvcxResult<()> {

--- a/libvcx_core/src/api_vcx/api_handle/credential_def.rs
+++ b/libvcx_core/src/api_vcx/api_handle/credential_def.rs
@@ -173,13 +173,9 @@ pub mod tests {
             .await;
             let issuer_did = get_config_value(CONFIG_INSTITUTION_DID).unwrap();
 
-            let revocation_details = RevocationDetailsBuilder::default()
-                .support_revocation(true)
-                .tails_dir(get_temp_dir_path("tails.txt").to_str().unwrap())
-                .max_creds(2 as u32)
-                .build()
-                .unwrap();
-            let _revocation_details = serde_json::to_string(&revocation_details).unwrap();
+            let path = get_temp_dir_path("tails.txt");
+            std::fs::create_dir_all(&path).unwrap();
+
             let handle_cred_def = create("1".to_string(), schema_id, "tag1".to_string(), true)
                 .await
                 .unwrap();
@@ -189,7 +185,7 @@ pub mod tests {
                 issuer_did,
                 cred_def_id: get_cred_def_id(handle_cred_def).unwrap(),
                 tag: 1,
-                tails_dir: String::from(get_temp_dir_path("tails.txt").to_str().unwrap()),
+                tails_dir: String::from(path.to_str().unwrap()),
                 max_creds: 2,
             };
             let handle_rev_reg = revocation_registry::create(rev_reg_config).await.unwrap();

--- a/libvcx_core/src/api_vcx/api_handle/schema.rs
+++ b/libvcx_core/src/api_vcx/api_handle/schema.rs
@@ -275,6 +275,8 @@ pub mod tests {
             let err = create_and_publish_schema("id_2", schema_name, schema_version, data)
                 .await
                 .unwrap_err();
+            error!("err: {:?}", err);
+            // .unwrap_err();
 
             assert_eq!(err.kind(), LibvcxErrorKind::DuplicationSchema);
         })

--- a/libvcx_core/src/api_vcx/utils/devsetup.rs
+++ b/libvcx_core/src/api_vcx/utils/devsetup.rs
@@ -1,7 +1,9 @@
 use agency_client::agency_client::AgencyClient;
 use aries_vcx::aries_vcx_core::global::settings;
 use aries_vcx::aries_vcx_core::indy::ledger::pool::test_utils::create_testpool_genesis_txn_file;
-use aries_vcx::aries_vcx_core::indy::ledger::pool::{create_pool_ledger_config, indy_close_pool, indy_open_pool};
+use aries_vcx::aries_vcx_core::indy::ledger::pool::{
+    create_pool_ledger_config, indy_close_pool, indy_open_pool, PoolConfig,
+};
 use aries_vcx::aries_vcx_core::{PoolHandle, WalletHandle};
 use aries_vcx::global::settings::{
     set_config_value, CONFIG_GENESIS_PATH, CONFIG_INSTITUTION_DID, DEFAULT_DID, DEFAULT_GENESIS_PATH,
@@ -14,14 +16,13 @@ use aries_vcx::utils::devsetup::{init_test_logging, reset_global_state, setup_is
 use aries_vcx::utils::get_temp_dir_path;
 
 use crate::api_vcx::api_global::agency_client::{reset_main_agency_client, set_main_agency_client};
-use crate::api_vcx::api_global::pool::{close_main_pool, reset_global_ledger_components, setup_ledger_components};
+use crate::api_vcx::api_global::pool::{close_main_pool, setup_ledger_components};
 use crate::api_vcx::api_global::wallet::{close_main_wallet, setup_wallet};
 
 pub struct SetupGlobalsWalletPoolAgency {
     pub agency_client: AgencyClient,
     pub institution_did: String,
     pub wallet_handle: WalletHandle,
-    pub pool_handle: PoolHandle,
 }
 
 impl SetupGlobalsWalletPoolAgency {
@@ -30,16 +31,10 @@ impl SetupGlobalsWalletPoolAgency {
         init_test_logging();
         set_config_value(CONFIG_INSTITUTION_DID, DEFAULT_DID).unwrap();
         let (institution_did, wallet_handle, agency_client) = setup_issuer_wallet_and_agency_client().await;
-        let pool_name = Uuid::new_v4().to_string();
-        let genesis_path = get_temp_dir_path(DEFAULT_GENESIS_PATH).to_str().unwrap().to_string();
-        create_testpool_genesis_txn_file(&genesis_path);
-        create_pool_ledger_config(&pool_name, &genesis_path).unwrap();
-        let pool_handle = indy_open_pool(&pool_name, None).await.unwrap();
         SetupGlobalsWalletPoolAgency {
             agency_client,
             institution_did,
             wallet_handle,
-            pool_handle,
         }
     }
 
@@ -49,16 +44,25 @@ impl SetupGlobalsWalletPoolAgency {
     {
         let init = Self::init().await;
 
-        let pool_handle = init.pool_handle.clone();
+        let pool_name = Uuid::new_v4().to_string();
+        let genesis_path = get_temp_dir_path(DEFAULT_GENESIS_PATH).to_str().unwrap().to_string();
+        create_testpool_genesis_txn_file(&genesis_path);
+        create_pool_ledger_config(&pool_name, &genesis_path).unwrap();
+
         setup_wallet(init.wallet_handle).unwrap();
         set_main_agency_client(init.agency_client.clone());
-        setup_ledger_components(Some(pool_handle)).unwrap();
+        let pool_config = PoolConfig {
+            genesis_path,
+            pool_name: None,
+            pool_config: None,
+        };
+        setup_ledger_components(pool_name, &pool_config).await.unwrap();
 
         f(init).await;
 
         close_main_wallet();
         reset_main_agency_client();
-        indy_close_pool(pool_handle).await.unwrap();
+        close_main_pool().await.unwrap();
 
         reset_global_state();
     }

--- a/wrappers/vcx-napi-rs/Cargo.toml
+++ b/wrappers/vcx-napi-rs/Cargo.toml
@@ -11,6 +11,15 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 doctest = false
 
+[features]
+default = ["ledger_vdrtools", "anoncreds_vdrtools"]
+
+ledger_indyvdr = ["libvcx_core/ledger_indyvdr"]
+ledger_vdrtools = ["libvcx_core/ledger_vdrtools"]
+
+anoncreds_credx = ["libvcx_core/anoncreds_credx"]
+anoncreds_vdrtools = ["libvcx_core/anoncreds_vdrtools"]
+
 [dependencies]
 libvcx_core = { path = "../../libvcx_core"  }
 log = "0.4.16"


### PR DESCRIPTION
####  Note: the original PR https://github.com/hyperledger/aries-vcx/pull/888 got mis-merged into already merged branch, instead of being merged into `main`, hence I've recreated this PR with correct target branch

### `libvcx_core`
- Modify global state handling and init related functions to enable running both with legacy vdrtools and credx/indy-vdr setup

### `aries-vcx`
- tweak indyvdr error mapping

### New cargo features in `libvcx_core`, `libvcx`, `vcx-napi-rs`
- Added features `anoncreds_vdrtools` `anoncreds_credx` to select anoncreds implementation 
- Added features `ledger_vdrtools`, `ledger_indyvdr` to select ledger client implementation

### CI
- Leave only 1 code coverage job which runs both integration and unit tests in `aries-vcx`. The coverage jobs runs with modular libs profile


