### PR TITLE
Update dependencies and AriesMessage Deserialize impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -462,7 +462,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1053,7 +1053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
 dependencies = [
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1171,7 +1171,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1215,7 +1215,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core 0.20.1",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1887,7 +1887,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2843,7 +2843,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shared_vcx",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3178,7 +3178,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3420,9 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -3435,9 +3435,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -3954,9 +3954,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
 dependencies = [
  "serde_derive",
 ]
@@ -3972,20 +3972,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "itoa 1.0.6",
  "ryu",
@@ -4372,9 +4372,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4444,7 +4444,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -4514,7 +4514,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -4619,13 +4619,14 @@ dependencies = [
 
 [[package]]
 name = "transitive"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba619eb29705c11fe64d8c883f782ca95fc2174bd872675f1fd7ab8966da757"
+checksum = "e31e716441126fedb8baecc6717d79467ccdbdfdd7eed33ba47850f53402ec57"
 dependencies = [
+ "darling 0.20.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -5034,7 +5035,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
@@ -5068,7 +5069,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5351,7 +5352,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.23",
 ]
 
 [[package]]

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -9,16 +9,16 @@ license.workspace = true
 doctest = false
 
 [dependencies]
-serde = { version = "1.0.97", features = ["derive"] }
+serde = { version = "1.0.167", features = ["derive"] }
 chrono = { version = "0.4.23", features = ["serde"] }
 lazy_static = "1.3"
-serde_json = "1.0.40"
+serde_json = "1.0.100"
 url = { version = "2.3", features = ["serde"] }
 strum = "0.24.1"
 strum_macros = "0.24.3"
 thiserror = "1.0.37"
 derive_more = "0.99.17"
-transitive = "0.4.2"
+transitive = "0.5.0"
 isolang = { version = "2.2.0" }
 messages_macros = { path = "../messages_macros" }
 diddoc_legacy = { path = "../diddoc_legacy" }

--- a/messages/src/misc/utils.rs
+++ b/messages/src/misc/utils.rs
@@ -1,8 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{de::Error, Deserializer, Serialize};
 
-pub const MSG_TYPE: &str = "@type";
-
 /// Used for creating a deserialization error.
 /// Some messages, or rather, message types, are not meant
 /// to be used as standalone messages.

--- a/messages/src/msg_types/protocols/basic_message.rs
+++ b/messages/src/msg_types/protocols/basic_message.rs
@@ -1,7 +1,7 @@
 use derive_more::From;
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum BasicMessageType {
     V1(BasicMessageTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, PartialEq, Transitive, MessageType)]
 #[transitive(into(BasicMessageType, Protocol))]
 #[msg_type(major = 1)]
 pub enum BasicMessageTypeV1 {

--- a/messages/src/msg_types/protocols/connection.rs
+++ b/messages/src/msg_types/protocols/connection.rs
@@ -1,7 +1,7 @@
 use derive_more::{From, TryInto};
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum ConnectionType {
     V1(ConnectionTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, TryInto, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, TryInto, PartialEq, Transitive, MessageType)]
 #[transitive(into(ConnectionType, Protocol))]
 #[msg_type(major = 1)]
 pub enum ConnectionTypeV1 {

--- a/messages/src/msg_types/protocols/cred_issuance.rs
+++ b/messages/src/msg_types/protocols/cred_issuance.rs
@@ -1,7 +1,7 @@
 use derive_more::{From, TryInto};
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum CredentialIssuanceType {
     V1(CredentialIssuanceTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, TryInto, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, TryInto, PartialEq, Transitive, MessageType)]
 #[transitive(into(CredentialIssuanceType, Protocol))]
 #[msg_type(major = 1)]
 pub enum CredentialIssuanceTypeV1 {

--- a/messages/src/msg_types/protocols/discover_features.rs
+++ b/messages/src/msg_types/protocols/discover_features.rs
@@ -1,7 +1,7 @@
 use derive_more::From;
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum DiscoverFeaturesType {
     V1(DiscoverFeaturesTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, PartialEq, Transitive, MessageType)]
 #[transitive(into(DiscoverFeaturesType, Protocol))]
 #[msg_type(major = 1)]
 pub enum DiscoverFeaturesTypeV1 {

--- a/messages/src/msg_types/protocols/notification.rs
+++ b/messages/src/msg_types/protocols/notification.rs
@@ -1,7 +1,7 @@
 use derive_more::From;
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum NotificationType {
     V1(NotificationTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, PartialEq, Transitive, MessageType)]
 #[transitive(into(NotificationType, Protocol))]
 #[msg_type(major = 1)]
 pub enum NotificationTypeV1 {

--- a/messages/src/msg_types/protocols/out_of_band.rs
+++ b/messages/src/msg_types/protocols/out_of_band.rs
@@ -1,7 +1,7 @@
 use derive_more::From;
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum OutOfBandType {
     V1(OutOfBandTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, PartialEq, Transitive, MessageType)]
 #[transitive(into(OutOfBandType, Protocol))]
 #[msg_type(major = 1)]
 pub enum OutOfBandTypeV1 {

--- a/messages/src/msg_types/protocols/present_proof.rs
+++ b/messages/src/msg_types/protocols/present_proof.rs
@@ -1,7 +1,7 @@
 use derive_more::{From, TryInto};
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum PresentProofType {
     V1(PresentProofTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, TryInto, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, TryInto, PartialEq, Transitive, MessageType)]
 #[transitive(into(PresentProofType, Protocol))]
 #[msg_type(major = 1)]
 pub enum PresentProofTypeV1 {

--- a/messages/src/msg_types/protocols/report_problem.rs
+++ b/messages/src/msg_types/protocols/report_problem.rs
@@ -1,7 +1,7 @@
 use derive_more::From;
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum ReportProblemType {
     V1(ReportProblemTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, PartialEq, Transitive, MessageType)]
 #[transitive(into(ReportProblemType, Protocol))]
 #[msg_type(major = 1)]
 pub enum ReportProblemTypeV1 {

--- a/messages/src/msg_types/protocols/revocation.rs
+++ b/messages/src/msg_types/protocols/revocation.rs
@@ -1,7 +1,7 @@
 use derive_more::From;
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum RevocationType {
     V2(RevocationTypeV2),
 }
 
-#[derive(Copy, Clone, Debug, From, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, PartialEq, Transitive, MessageType)]
 #[transitive(into(RevocationType, Protocol))]
 #[msg_type(major = 2)]
 pub enum RevocationTypeV2 {

--- a/messages/src/msg_types/protocols/routing.rs
+++ b/messages/src/msg_types/protocols/routing.rs
@@ -1,7 +1,7 @@
 use derive_more::From;
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum RoutingType {
     V1(RoutingTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, PartialEq, Transitive, MessageType)]
 #[transitive(into(RoutingType, Protocol))]
 #[msg_type(major = 1)]
 pub enum RoutingTypeV1 {

--- a/messages/src/msg_types/protocols/signature.rs
+++ b/messages/src/msg_types/protocols/signature.rs
@@ -1,7 +1,7 @@
 use derive_more::{From, TryInto};
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::MsgKindType;
@@ -12,7 +12,7 @@ pub enum SignatureType {
     V1(SignatureTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, TryInto, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, TryInto, PartialEq, Transitive, MessageType)]
 #[transitive(into(SignatureType, Protocol))]
 #[msg_type(major = 1)]
 pub enum SignatureTypeV1 {

--- a/messages/src/msg_types/protocols/trust_ping.rs
+++ b/messages/src/msg_types/protocols/trust_ping.rs
@@ -1,7 +1,7 @@
 use derive_more::From;
 use messages_macros::MessageType;
 use strum_macros::{AsRefStr, EnumString};
-use transitive::TransitiveFrom;
+use transitive::Transitive;
 
 use super::Protocol;
 use crate::msg_types::{role::Role, MsgKindType};
@@ -12,7 +12,7 @@ pub enum TrustPingType {
     V1(TrustPingTypeV1),
 }
 
-#[derive(Copy, Clone, Debug, From, PartialEq, TransitiveFrom, MessageType)]
+#[derive(Copy, Clone, Debug, From, PartialEq, Transitive, MessageType)]
 #[transitive(into(TrustPingType, Protocol))]
 #[msg_type(major = 1)]
 pub enum TrustPingTypeV1 {


### PR DESCRIPTION
Fixes #893.

Also updates `transitive` dependency and simplifies the `Deserialize` impl for `AriesMessage` to require less of `serde`'s internal components. 

Now only `Content` and `ContentDeserializer` are used merely at a type level, and these have been around for a very long time and are pretty much stable.