### PR TITLE
CI: Do not publish napi wrapper when running in fork PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -909,7 +909,7 @@ jobs:
     needs:
       - workflow-setup
       - build-napi
-    if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
+    if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' && needs.workflow-setup.outputs.IS_FORK == 'false' }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/publish-napi


### PR DESCRIPTION
Should prevent this https://github.com/hyperledger/aries-vcx/pull/884 kind of failures