### PR TITLE
Specify default libvcx feature flags

### DIFF
--- a/libvcx/Cargo.toml
+++ b/libvcx/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 
 [features]
 fatal_warnings = []
+default = ["ledger_vdrtools", "anoncreds_vdrtools"]
 
 ledger_indyvdr = ["libvcx_core/ledger_indyvdr"]
 ledger_vdrtools = ["libvcx_core/ledger_vdrtools"]

--- a/libvcx_core/src/api_vcx/api_global/pool.rs
+++ b/libvcx_core/src/api_vcx/api_global/pool.rs
@@ -114,7 +114,7 @@ async fn build_components_ledger(
     }
     #[cfg(not(any(feature = "ledger_indyvdr", feature = "ledger_vdrtools")))]
     {
-        panic!("No ledger implementation has been selected by feature flag upon build");
+        compile_error!("No ledger implementation has been selected by feature flag upon build");
     }
 }
 

--- a/libvcx_core/src/api_vcx/api_global/wallet.rs
+++ b/libvcx_core/src/api_vcx/api_global/wallet.rs
@@ -55,7 +55,7 @@ fn build_component_anoncreds(base_wallet: Arc<dyn BaseWallet>) -> Arc<dyn BaseAn
     }
     #[cfg(not(any(feature = "anoncreds_vdrtools", feature = "anoncreds_credx")))]
     {
-        panic!("No anoncreds implementation enabled by feature flag upon build");
+        compile_error!("No anoncreds implementation enabled by feature flag upon build");
     }
 }
 


### PR DESCRIPTION
- fix build for libvcx ios/java artifacts (no features flags are selected for ios/java builds, will fail in runtime)
- fail on compile if no implementation is selected via feature flags