### PR TITLE
Modular did:key representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ name = "did_doc_sov"
 version = "0.1.0"
 dependencies = [
  "did_doc",
+ "did_key",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -659,7 +659,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1303,7 +1303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
 dependencies = [
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1421,7 +1421,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1465,7 +1465,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core 0.20.1",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1630,6 +1630,17 @@ name = "did_doc_sov"
 version = "0.1.0"
 dependencies = [
  "did_doc",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "did_key"
+version = "0.1.0"
+dependencies = [
+ "did_parser",
+ "public_key",
  "serde",
  "serde_json",
  "thiserror",
@@ -2148,7 +2159,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3137,7 +3148,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shared_vcx",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3481,7 +3492,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -4293,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.167"
+version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
+checksum = "5d25439cd7397d044e2748a6fe2432b5e85db703d6d097bd014b3c0ad1ebff0b"
 dependencies = [
  "serde_derive",
 ]
@@ -4311,20 +4322,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.167"
+version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
+checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa 1.0.6",
  "ryu",
@@ -4738,9 +4749,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4795,22 +4806,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -4893,7 +4904,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -5006,7 +5017,7 @@ dependencies = [
  "darling 0.20.1",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -5415,7 +5426,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
  "wasm-bindgen-shared",
 ]
 
@@ -5449,7 +5460,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5732,7 +5743,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.27",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "uniffi_aries_vcx/core",
     "did_doc",
     "did_peer",
+    "did_key",
     "did_doc_sov",
     "did_parser",
     "did_resolver",

--- a/did_doc_sov/Cargo.toml
+++ b/did_doc_sov/Cargo.toml
@@ -3,10 +3,9 @@ name = "did_doc_sov"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 did_doc = { path = "../did_doc" }
+did_key = { path = "../did_key" }
 serde = { version = "1.0.159", default-features = false, features = ["derive"] }
 serde_json = "1.0.95"
 thiserror = "1.0.40"

--- a/did_doc_sov/src/extra_fields/mod.rs
+++ b/did_doc_sov/src/extra_fields/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use did_doc::did_parser::DidUrl;
+use did_key::DidKey;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::error::DidDocumentSovError;
@@ -66,6 +67,7 @@ impl Serialize for AcceptType {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum KeyKind {
+    DidKey(DidKey),
     Reference(DidUrl),
     Value(String),
 }
@@ -75,6 +77,7 @@ impl Display for KeyKind {
         match self {
             KeyKind::Reference(did_url) => write!(f, "{}", did_url),
             KeyKind::Value(value) => write!(f, "{}", value),
+            KeyKind::DidKey(did_key) => write!(f, "{}", did_key),
         }
     }
 }

--- a/did_key/Cargo.toml
+++ b/did_key/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "did_key"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+public_key = { path = "../public_key" }
+did_parser = { path = "../did_parser" }
+serde = "1.0.175"
+serde_json = "1.0.103"
+thiserror = "1.0.44"

--- a/did_key/src/error.rs
+++ b/did_key/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DidKeyError {
+    #[error("Public key error: {0}")]
+    PublicKeyError(#[from] public_key::PublicKeyError),
+    #[error("DID parser error: {0}")]
+    DidParserError(#[from] did_parser::ParseError),
+}

--- a/did_key/src/lib.rs
+++ b/did_key/src/lib.rs
@@ -1,0 +1,134 @@
+pub mod error;
+
+use core::fmt;
+use std::fmt::Display;
+
+use did_parser::Did;
+use error::DidKeyError;
+use public_key::Key;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DidKey {
+    key: Key,
+    did: Did,
+}
+
+impl DidKey {
+    pub fn parse<T>(did: T) -> Result<DidKey, DidKeyError>
+    where
+        Did: TryFrom<T>,
+        <Did as TryFrom<T>>::Error: Into<DidKeyError>,
+    {
+        let did: Did = did.try_into().map_err(Into::into)?;
+        let key = Key::from_fingerprint(did.id())?;
+
+        Ok(Self { key, did })
+    }
+
+    pub fn key(&self) -> &Key {
+        &self.key
+    }
+
+    pub fn did(&self) -> &Did {
+        &self.did
+    }
+}
+
+impl TryFrom<Key> for DidKey {
+    type Error = DidKeyError;
+
+    fn try_from(key: Key) -> Result<Self, Self::Error> {
+        let did = Did::parse(format!("did:key:{}", key.fingerprint()))?;
+        Ok(Self { key, did })
+    }
+}
+
+impl Display for DidKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.did)
+    }
+}
+
+impl Serialize for DidKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.did.did())
+    }
+}
+
+impl<'de> Deserialize<'de> for DidKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        DidKey::parse(s).map_err(de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn _valid_key_base58_fingerprint() -> String {
+        "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK".to_string()
+    }
+
+    fn _valid_did_key_string() -> String {
+        format!("did:key:{}", _valid_key_base58_fingerprint())
+    }
+
+    fn _invalid_did_key_string() -> String {
+        "did:key:somenonsense".to_string()
+    }
+
+    fn _valid_did_key() -> DidKey {
+        DidKey {
+            key: Key::from_fingerprint(&_valid_key_base58_fingerprint()).unwrap(),
+            did: Did::parse(_valid_did_key_string()).unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_serialize() {
+        assert_eq!(
+            format!("\"{}\"", _valid_did_key_string()),
+            serde_json::to_string(&_valid_did_key()).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_deserialize() {
+        assert_eq!(
+            _valid_did_key(),
+            serde_json::from_str::<DidKey>(&format!("\"{}\"", _valid_did_key_string())).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_deserialize_error() {
+        assert!(serde_json::from_str::<DidKey>(&_invalid_did_key_string()).is_err());
+    }
+
+    #[test]
+    fn test_parse() {
+        assert_eq!(_valid_did_key(), DidKey::parse(_valid_did_key_string()).unwrap(),);
+    }
+
+    #[test]
+    fn test_parse_error() {
+        assert!(DidKey::parse(_invalid_did_key_string()).is_err());
+    }
+
+    #[test]
+    fn test_try_from_key() {
+        assert_eq!(
+            _valid_did_key(),
+            DidKey::try_from(Key::from_fingerprint(&_valid_key_base58_fingerprint()).unwrap()).unwrap(),
+        );
+    }
+}


### PR DESCRIPTION
Adds a struct representing a `did:key`, which can then be used, for example, in the services entries of the OOB invitations or did-exchange requests as per the respective RFCs.