### PR TITLE
Release/0.57.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "agency_client"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "android_logger",
  "async-trait",
@@ -391,7 +391,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "aries-vcx"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "agency_client",
  "android_logger",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "aries-vcx-agent"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "aries-vcx",
  "aries_vcx_core",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "diddoc_legacy"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "libvcx"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "agency_client",
  "android_logger",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "libvcx_core"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "agency_client",
  "aries-vcx",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "messages"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "chrono",
  "derive_more",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "shared_vcx"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "bs58 0.4.0",
  "lazy_static",
@@ -5072,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi_aries_vcx"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "aries-vcx",
  "async-trait",
@@ -5316,7 +5316,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vcx-napi-rs"
-version = "0.57.0"
+version = "0.57.1"
 dependencies = [
  "chrono",
  "libvcx_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.57.0"
+version = "0.57.1"
 authors = ["Absa Group Limited", "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>"]
 description = "Absa's fork of HL LibVCX"
 license = "Apache-2.0"

--- a/wrappers/node/package-lock.json
+++ b/wrappers/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/node-vcx-wrapper",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/node-vcx-wrapper",
-      "version": "0.57.0",
+      "version": "0.57.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hyperledger/vcx-napi-rs": "file:../vcx-napi-rs",

--- a/wrappers/node/package.json
+++ b/wrappers/node/package.json
@@ -3,7 +3,7 @@
   "name": "@hyperledger/node-vcx-wrapper",
   "description": "NodeJS wrapper Aries Framework",
   "license": "Apache-2.0",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "directories": {
     "test": "test",
     "build": "dist",


### PR DESCRIPTION
Previous release https://github.com/hyperledger/aries-vcx/releases/tag/0.57.0 was incorrectly built for ios/java libvcx artifacts, as the anoncreds and ledger implementation was not selected in built time, causing library to fail upon calling basic functions.
The issue has been fixed in this release.