### PR TITLE
fix(aries-vcx): fixed dependency listing in README for `Cargo.toml`

### DIFF
--- a/aries_vcx/README.md
+++ b/aries_vcx/README.md
@@ -1,12 +1,12 @@
 # aries-vcx
-`aries-vcx` is more of a "library" rather than "framework". We strive to be not too 
-opinionated and simply provide building blocks for whatever you want to build. 
+`aries-vcx` is more of a "library" rather than "framework". We strive to be not too
+opinionated and simply provide building blocks for whatever you want to build.
 
-You can use `aries-vcx` to build both end-user products (mobile wallets in role of credential 
-holder and prover) or server (typically in role of issuer, verifier). 
+You can use `aries-vcx` to build both end-user products (mobile wallets in role of credential
+holder and prover) or server (typically in role of issuer, verifier).
 
 Generally, the crate allows you to:
-- create encrypted wallet, 
+- create encrypted wallet,
 - read/write from/to Indy ledger,
 - establish didcomm connections and exchange messages,
 - create and process Aries messages to drive Aries protocols.
@@ -18,21 +18,22 @@ Additionally, the following crates may be consumed independently of `aries-vcx`:
 
 ### Deprecation notice: Message mediation
 Aries-vcx contains built-in support for message mediation which is useful for mobile use cases. However,
-this feature (implemented via `MediatedConnection`) is now deprecated as it is tied to mediator 
+this feature (implemented via `MediatedConnection`) is now deprecated as it is tied to mediator
 implementation [vcxagency-node](https://github.com/AbsaOSS/vcxagencynode) which does not implement
 Aries [pick-up protocol](https://github.com/hyperledger/aries-rfcs/tree/main/features/0685-pickup-v2).
 
 # Getting started
-To use `aries-vcx` in your project, you need to add GitHub dependency to your `Cargo.toml`:
+To use `aries-vcx` in your project, you need to add GitHub dependency to your `Cargo.toml`, and best
+define a version through a `tag`:
 ```toml
-aries-vcx = { path = "https://github.com/hyperledger/aries-vcx" }
+aries-vcx = { tag = "0.57.1", git = "https://github.com/hyperledger/aries-vcx" }
 ```
 It's also advisable to follow these [instructions](TUTORIAL.md) to check your environment is properly configured.
 
 # Projects built with aries-vcx
-- [aries-vcx-agent](../agents/rust/aries-vcx-agent) - sample agent with local persistence. Used for cross-compatibility testing with other aries implementations. 
+- [aries-vcx-agent](../agents/rust/aries-vcx-agent) - sample agent with local persistence. Used for cross-compatibility testing with other aries implementations.
 - [unifii_aries_vcx](../uniffi_aries_vcx) - wrapper around `aries-vcx` to generate Swift and Kotlin wrappers for mobile use-cases
-- [libcx](../libvcx) (**deprecated**) - wrapper around `aries-vcx` to build Java, Objective-C, NodeJS wrappers. 
+- [libcx](../libvcx) (**deprecated**) - wrapper around `aries-vcx` to build Java, Objective-C, NodeJS wrappers.
 
 ## Implemented Aries protocols
 * ✅ Connection Protocol 1.0: [`https://didcomm.org/connections/1.0/*`](https://github.com/hyperledger/aries-rfcs/tree/master/features/0160-connection-protocol)
@@ -47,6 +48,6 @@ It's also advisable to follow these [instructions](TUTORIAL.md) to check your en
 ### State machines guidelines
 Please follow these [guidelines](./docs/guidelines.md) when implementing new state machines.
 
-## Architecture 
+## Architecture
 
 <img alt="AriesVCX architecture diagram" src="../docs/architecture/architecture_230104_ariesvcx.png"/>


### PR DESCRIPTION
Using path does not work and crates from git sources need be specified through `git=...`.