### PR TITLE
Updated indy-credx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
  "derive_builder 0.12.0",
  "futures",
  "indy-api-types",
- "indy-credx 1.0.1",
+ "indy-credx",
  "indy-ledger-response-parser",
  "indy-vdr",
  "indy-vdr-proxy-client",
@@ -2615,27 +2615,7 @@ dependencies = [
  "thiserror",
  "ursa",
  "zeroize",
-]
-
-[[package]]
-name = "indy-credx"
-version = "0.3.1"
-source = "git+https://github.com/anonyome/indy-shared-rs.git?rev=7342bc624d23ece8845d1a701cd2cdc9cd401bb0#7342bc624d23ece8845d1a701cd2cdc9cd401bb0"
-dependencies = [
- "env_logger 0.7.1",
- "ffi-support",
- "indy-data-types 0.5.1 (git+https://github.com/anonyome/indy-shared-rs.git?rev=7342bc624d23ece8845d1a701cd2cdc9cd401bb0)",
- "indy-utils 0.5.1",
- "log",
- "once_cell",
- "rand 0.7.3",
- "regex",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "tempfile",
- "thiserror",
- "zeroize",
+ "zmq",
 ]
 
 [[package]]
@@ -2670,21 +2650,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "zeroize",
-]
-
-[[package]]
-name = "indy-data-types"
-version = "0.5.1"
-source = "git+https://github.com/anonyome/indy-shared-rs.git?rev=7342bc624d23ece8845d1a701cd2cdc9cd401bb0#7342bc624d23ece8845d1a701cd2cdc9cd401bb0"
-dependencies = [
- "hex",
- "indy-utils 0.5.1",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "ursa",
  "zeroize",
 ]
 
@@ -2748,7 +2713,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "hex",
- "indy-wql 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indy-wql",
  "once_cell",
  "rand 0.8.5",
  "regex",
@@ -2757,22 +2722,6 @@ dependencies = [
  "sha2 0.9.9",
  "thiserror",
  "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "indy-utils"
-version = "0.5.1"
-source = "git+https://github.com/anonyome/indy-shared-rs.git?rev=7342bc624d23ece8845d1a701cd2cdc9cd401bb0#7342bc624d23ece8845d1a701cd2cdc9cd401bb0"
-dependencies = [
- "bs58 0.4.0",
- "indy-wql 0.4.0 (git+https://github.com/anonyome/indy-shared-rs.git?rev=7342bc624d23ece8845d1a701cd2cdc9cd401bb0)",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha2 0.10.7",
- "thiserror",
  "zeroize",
 ]
 
@@ -2799,8 +2748,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "hex",
- "hex-literal",
- "indy-data-types 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indy-data-types 0.5.1",
  "indy-utils 0.5.0",
  "log",
  "once_cell",
@@ -2854,15 +2802,6 @@ name = "indy-wql"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aa37c6fbc387666de081f7e549e20aad2e165d545e7ba2cdb3c9a5a637c25a"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "indy-wql"
-version = "0.4.0"
-source = "git+https://github.com/anonyome/indy-shared-rs.git?rev=7342bc624d23ece8845d1a701cd2cdc9cd401bb0#7342bc624d23ece8845d1a701cd2cdc9cd401bb0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5493,7 +5432,7 @@ name = "wallet_migrator"
 version = "0.1.0"
 dependencies = [
  "aries_vcx_core",
- "indy-credx 0.3.1",
+ "indy-credx",
  "libvdrtools",
  "log",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
  "openssl",
  "rand 0.8.5",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -1722,6 +1722,8 @@ dependencies = [
  "async-trait",
  "did_resolver",
  "mockall",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -1911,25 +1913,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -1941,7 +1930,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "humantime 2.1.0",
+ "humantime",
  "is-terminal",
  "log",
  "regex",
@@ -2499,15 +2488,6 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -2615,7 +2595,6 @@ dependencies = [
  "thiserror",
  "ursa",
  "zeroize",
- "zmq",
 ]
 
 [[package]]
@@ -2633,7 +2612,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "thiserror",
  "zeroize",
 ]
@@ -2665,7 +2644,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "zeroize",
 ]
 
@@ -2748,6 +2727,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "hex",
+ "hex-literal",
  "indy-data-types 0.5.1",
  "indy-utils 0.5.0",
  "log",
@@ -2845,7 +2825,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.48.0",
@@ -3824,12 +3804,6 @@ dependencies = [
  "thiserror",
  "unsigned-varint",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "anoncreds-clsignatures"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f683463c4f5558a4eab7fe4625d94f08b7de9691453032bac43facf06fe46d2e"
+dependencies = [
+ "amcl",
+ "glass_pumpkin",
+ "log",
+ "num-bigint 0.4.3",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "openssl",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,7 +475,7 @@ dependencies = [
  "derive_builder 0.12.0",
  "futures",
  "indy-api-types",
- "indy-credx",
+ "indy-credx 1.0.1",
  "indy-ledger-response-parser",
  "indy-vdr",
  "indy-vdr-proxy-client",
@@ -1160,6 +1179,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1908,6 +1936,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime 2.1.0",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,6 +2293,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
+name = "glass_pumpkin"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e847fe780e2fd8aa993bef2124361c285349ff0e9315e8285f8126386b54a9"
+dependencies = [
+ "core2",
+ "num-bigint 0.4.3",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,6 +2639,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "indy-credx"
+version = "1.0.1"
+source = "git+https://github.com/hyperledger/indy-shared-rs?tag=v1.0.1#32a1943811e719540567769264e14f94e51c60ee"
+dependencies = [
+ "env_logger 0.10.0",
+ "ffi-support",
+ "indy-data-types 0.6.1",
+ "indy-utils 0.6.0",
+ "log",
+ "once_cell",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "indy-data-types"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,6 +2685,22 @@ dependencies = [
  "serde",
  "serde_json",
  "ursa",
+ "zeroize",
+]
+
+[[package]]
+name = "indy-data-types"
+version = "0.6.1"
+source = "git+https://github.com/hyperledger/indy-shared-rs?tag=v1.0.1#32a1943811e719540567769264e14f94e51c60ee"
+dependencies = [
+ "anoncreds-clsignatures",
+ "hex",
+ "indy-utils 0.6.0",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
  "zeroize",
 ]
 
@@ -2681,6 +2772,19 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.7",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "indy-utils"
+version = "0.6.0"
+source = "git+https://github.com/hyperledger/indy-shared-rs?tag=v1.0.1#32a1943811e719540567769264e14f94e51c60ee"
+dependencies = [
+ "bs58 0.5.0",
+ "once_cell",
+ "regex",
+ "serde",
  "thiserror",
  "zeroize",
 ]
@@ -2795,6 +2899,18 @@ name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "isolang"
@@ -3363,6 +3479,7 @@ dependencies = [
  "autocfg 1.1.0",
  "num-integer",
  "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5376,7 +5493,7 @@ name = "wallet_migrator"
 version = "0.1.0"
 dependencies = [
  "aries_vcx_core",
- "indy-credx",
+ "indy-credx 0.3.1",
  "libvdrtools",
  "log",
  "serde_json",

--- a/aries_vcx/Cargo.toml
+++ b/aries_vcx/Cargo.toml
@@ -18,8 +18,12 @@ modular_libs = ["aries_vcx_core/modular_libs"]
 # TODO: Remove using "vdrtools" feature flag for vdr_proxy_ledger once IndyCredxAnonCreds
 # is fully implemented
 vdr_proxy_ledger = ["aries_vcx_core/vdr_proxy_ledger", "vdrtools"]
+
+# Feature for allowing legacy proof verification
+legacy_proof = ["aries_vcx_core/legacy_proof"]
+
 # Used for testing the migrator
-migration = ["vdrtools", "modular_libs"]
+migration = ["vdrtools", "modular_libs", "legacy_proof"]
 
 [dependencies]
 agency_client = { path = "../agency_client" }

--- a/aries_vcx_core/Cargo.toml
+++ b/aries_vcx_core/Cargo.toml
@@ -27,7 +27,7 @@ indy-vdr = { git = "https://github.com/Patrik-Stas/indy-vdr.git", rev = "3cd499a
 # - monitor anoncred-rs (which will replace indy-credx) as the fix will likely go in here,
 # - monitor the issue for other fixes from the maintainers: https://github.com/hyperledger/indy-shared-rs/issues/20
 # - update libvdrtools to use =0.3.6 ursa
-indy-credx = { git = "https://github.com/anonyome/indy-shared-rs.git", rev = "7342bc624d23ece8845d1a701cd2cdc9cd401bb0", optional = true }
+indy-credx = { git = "https://github.com/hyperledger/indy-shared-rs", tag = "v1.0.1", optional = true }
 libvdrtools = { path = "../libvdrtools", optional = true }
 indy-api-types = { path = "../libvdrtools/indy-api-types" }
 async-trait = "0.1.68"

--- a/aries_vcx_core/Cargo.toml
+++ b/aries_vcx_core/Cargo.toml
@@ -11,10 +11,12 @@ vdrtools_wallet = ["dep:libvdrtools"]
 # Feature flag to include the 'modular library' dependencies (vdrtools alternatives; indy-vdr, indy-credx)
 modular_libs = ["dep:indy-credx"]
 vdr_proxy_ledger = ["modular_libs", "dep:indy-vdr-proxy-client"]
+# Feature flag to allow legacy proof verification
+legacy_proof = []
 
 [dependencies]
 agency_client = { path = "../agency_client" }
-indy-vdr = { version = "0.3.4", default-features = false, features = ["ffi", "log"], optional = true }
+indy-vdr = { git = "https://github.com/Patrik-Stas/indy-vdr.git", rev = "3cd499ad75", default-features = false, features = ["log"] }
 indy-credx = { git = "https://github.com/hyperledger/indy-shared-rs", tag = "v1.0.1", optional = true }
 libvdrtools = { path = "../libvdrtools", optional = true }
 indy-api-types = { path = "../libvdrtools/indy-api-types" }

--- a/aries_vcx_core/Cargo.toml
+++ b/aries_vcx_core/Cargo.toml
@@ -14,19 +14,7 @@ vdr_proxy_ledger = ["modular_libs", "dep:indy-vdr-proxy-client"]
 
 [dependencies]
 agency_client = { path = "../agency_client" }
-indy-vdr = { git = "https://github.com/Patrik-Stas/indy-vdr.git", rev = "3cd499ad75", default-features = false, features = ["log"] }
-# PATCH (TO MONITOR IN FUTURE): The following patch changes the `indy-data-types` (within indy-shared-rs) to depend on
-# `ursa "0.3.6"` rather than `ursa "=0.3.6"`. Currently, `libvdrtools` depends on `ursa "0.3.7"`, which causes a mismatch of
-# `indy-utils` versions, which causes some types within credx to fail. Details about the issue can be found here: https://github.com/hyperledger/indy-shared-rs/issues/20
-# `indy-data-types` depends on `ursa =0.3.6` due to a 'broken cl feature', see commmit: https://github.com/hyperledger/indy-shared-rs/commit/2403eed6449a3b5e347697b215a732fc33c014c0
-# however using ursa 0.3.7 does not seem to affect our usage of indy-credx currently. More testing would be ideal.
-# various combinations of indy-vdr and indy-credx have been tried to resolve the dependency mismatches, however this patch appears
-# to be the only quick solution.
-# Potential resolutions:
-# - wait for ursa 0.3.8+ to resolve the CL issue and update indy-shared-rs,
-# - monitor anoncred-rs (which will replace indy-credx) as the fix will likely go in here,
-# - monitor the issue for other fixes from the maintainers: https://github.com/hyperledger/indy-shared-rs/issues/20
-# - update libvdrtools to use =0.3.6 ursa
+indy-vdr = { version = "0.3.4", default-features = false, features = ["ffi", "log"], optional = true }
 indy-credx = { git = "https://github.com/hyperledger/indy-shared-rs", tag = "v1.0.1", optional = true }
 libvdrtools = { path = "../libvdrtools", optional = true }
 indy-api-types = { path = "../libvdrtools/indy-api-types" }

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -203,14 +203,27 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
                 new_regs
             });
 
-        Ok(credx::verifier::verify_presentation(
+        let output = credx::verifier::verify_presentation(
             &presentation,
             &pres_req,
             &hashmap_as_ref(&schemas),
             &hashmap_as_ref(&cred_defs),
             rev_reg_defs.as_ref().map(hashmap_as_ref).as_ref(),
             rev_regs.as_ref(),
-        )?)
+        )?;
+
+        #[cfg(feature = "legacy_proof")]
+        let output = output
+            || credx::verifier::verify_presentation_legacy(
+                &presentation,
+                &pres_req,
+                &hashmap_as_ref(&schemas),
+                &hashmap_as_ref(&cred_defs),
+                rev_reg_defs.as_ref().map(hashmap_as_ref).as_ref(),
+                rev_regs.as_ref(),
+            )?;
+
+        Ok(output)
     }
 
     async fn issuer_create_and_store_revoc_reg(

--- a/wallet_migrator/Cargo.toml
+++ b/wallet_migrator/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 aries_vcx_core = { path = "../aries_vcx_core", features = ["modular_libs"] }
-credx = { package = "indy-credx", git = "https://github.com/anonyome/indy-shared-rs.git", rev = "7342bc624d23ece8845d1a701cd2cdc9cd401bb0" }
+credx = { package = "indy-credx", git = "https://github.com/hyperledger/indy-shared-rs", tag = "v1.0.1" }
 vdrtools = { package = "libvdrtools", path = "../libvdrtools" }
 serde_json = "1.0.96"
 thiserror = "1.0.40"

--- a/wallet_migrator/src/vdrtools2credx/conv.rs
+++ b/wallet_migrator/src/vdrtools2credx/conv.rs
@@ -46,7 +46,9 @@ pub fn convert_cred_def_priv_key(mut record: Record) -> MigrationResult<Record> 
 pub fn convert_cred_def_correctness_proof(mut record: Record) -> MigrationResult<Record> {
     record.type_ = CATEGORY_CRED_KEY_CORRECTNESS_PROOF.to_owned();
     let old: vdrtools::CredentialDefinitionCorrectnessProof = serde_json::from_str(&record.value)?;
-    let new = credx::types::CredentialKeyCorrectnessProof { value: old.value };
+    let old_value = serde_json::to_string(&old.value)?;
+    let new_value = serde_json::from_str(&old_value)?;
+    let new = credx::types::CredentialKeyCorrectnessProof { value: new_value };
     record.value = serde_json::to_string(&new)?;
     Ok(record)
 }

--- a/wallet_migrator/src/vdrtools2credx/mod.rs
+++ b/wallet_migrator/src/vdrtools2credx/mod.rs
@@ -60,7 +60,10 @@ mod tests {
         CATEGORY_REV_REG, CATEGORY_REV_REG_DEF, CATEGORY_REV_REG_DEF_PRIV, CATEGORY_REV_REG_DELTA,
         CATEGORY_REV_REG_INFO,
     };
-    use credx::ursa::bn::BigNumber;
+    use credx::{
+        anoncreds_clsignatures::{bn::BigNumber, LinkSecret as ClLinkSecret},
+        types::LinkSecret,
+    };
     use serde_json::json;
     use vdrtools::{
         types::domain::wallet::{Config, Credentials, KeyDerivationMethod},
@@ -345,8 +348,8 @@ mod tests {
         let ms_decimal = get_wallet_item_raw(wallet_handle, CATEGORY_LINK_SECRET).await;
         let ms_bn = BigNumber::from_dec(&ms_decimal).unwrap();
 
-        let ursa_ms: credx::ursa::cl::MasterSecret = serde_json::from_value(json!({ "ms": ms_bn })).unwrap();
-        let _ = credx::types::MasterSecret { value: ursa_ms };
+        let ursa_ms: ClLinkSecret = serde_json::from_value(json!({ "ms": ms_bn })).unwrap();
+        let _ = LinkSecret { value: ursa_ms };
     }
 
     fn make_dummy_master_secret() -> vdrtools::MasterSecret {


### PR DESCRIPTION
Fixes #926 .

This introduces yet another feature flag, `legacy_proof`, because after a lot of digging the proof request and verification appear to change in credx in a way that's not backwards compatible. However, the feature flag enables a second check of the proof using the legacy method.

This is not the default behavior because people might not want to have this enabled at all times.