### PR TITLE
Allow parsing unqualified DIDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,7 @@ name = "did_parser"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "shared_vcx",
 ]
 
 [[package]]

--- a/did_parser/Cargo.toml
+++ b/did_parser/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 serde = "1.0.160"
+shared_vcx = { path = "../shared_vcx" } # TODO: Remove as soon as migration to qualified DIDs is complete

--- a/did_parser/src/did.rs
+++ b/did_parser/src/did.rs
@@ -100,11 +100,6 @@ impl<'de> Deserialize<'de> for Did {
 
 impl From<Did> for DidUrl {
     fn from(did: Did) -> Self {
-        Self::from_did_parts(
-            did.did().to_string(),
-            0..did.did.len(),
-            did.method.unwrap(),
-            did.id,
-        )
+        Self::from_did_parts(did.did().to_string(), 0..did.did.len(), did.method, did.id)
     }
 }

--- a/did_parser/src/did.rs
+++ b/did_parser/src/did.rs
@@ -10,7 +10,7 @@ use crate::{error::ParseError, utils::parse::parse_did_method_id, DidRange};
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Did {
     did: String,
-    method: DidRange,
+    method: Option<DidRange>,
     id: DidRange,
 }
 
@@ -30,8 +30,8 @@ impl Did {
         self.did.as_ref()
     }
 
-    pub fn method(&self) -> &str {
-        self.did[self.method.clone()].as_ref()
+    pub fn method(&self) -> Option<&str> {
+        self.method.as_ref().map(|range| &self.did[range.clone()])
     }
 
     pub fn id(&self) -> &str {
@@ -39,7 +39,11 @@ impl Did {
     }
 
     pub(crate) fn from_parts(did: String, method: DidRange, id: DidRange) -> Self {
-        Self { did, method, id }
+        Self {
+            did,
+            method: Some(method),
+            id,
+        }
     }
 }
 
@@ -69,7 +73,7 @@ impl Default for Did {
     fn default() -> Self {
         Self {
             did: "did:example:123456789abcdefghi".to_string(),
-            method: 4..11,
+            method: Some(4..11),
             id: 12..30,
         }
     }
@@ -96,6 +100,11 @@ impl<'de> Deserialize<'de> for Did {
 
 impl From<Did> for DidUrl {
     fn from(did: Did) -> Self {
-        Self::from_did_parts(did.did().to_string(), 0..did.did.len(), did.method, did.id)
+        Self::from_did_parts(
+            did.did().to_string(),
+            0..did.did.len(),
+            did.method.unwrap(),
+            did.id,
+        )
     }
 }

--- a/did_parser/src/did_url.rs
+++ b/did_parser/src/did_url.rs
@@ -30,7 +30,7 @@ impl DidUrl {
             (None, None, None)
         } else {
             let (did, method, id) = parse_did_method_id(&did_url)?;
-            (Some(did), Some(method), Some(id))
+            (Some(did), method, Some(id))
         };
 
         let mut path = None;

--- a/did_parser/src/did_url.rs
+++ b/did_parser/src/did_url.rs
@@ -174,13 +174,13 @@ impl DidUrl {
     pub(crate) fn from_did_parts(
         did_url: String,
         did: DidRange,
-        method: DidRange,
+        method: Option<DidRange>,
         id: DidRange,
     ) -> Self {
         Self {
             did_url,
             did: Some(did),
-            method: Some(method),
+            method,
             id: Some(id),
             path: None,
             fragment: None,

--- a/did_parser/src/utils/parse.rs
+++ b/did_parser/src/utils/parse.rs
@@ -97,10 +97,11 @@ fn parse_unqualified(did_url: &str) -> Result<(DidRange, Option<DidRange>, DidRa
         ));
     }
 
-    shared_vcx::validation::did::validate_did(&did_url)
+    let id = did_url.split("#").next().unwrap_or(did_url);
+    shared_vcx::validation::did::validate_did(id)
         .map_err(|_| ParseError::InvalidInput("Unqualified DID failed validation"))?;
 
-    let id_range = 0..did_url.len();
+    let id_range = 0..id.len();
 
     validate_did_url(did_url, id_range.clone())?;
 

--- a/did_parser/tests/did/negative.rs
+++ b/did_parser/tests/did/negative.rs
@@ -16,4 +16,5 @@ test_cases_negative! {
     test_failure_case1: ""
     test_failure_case2: "not-a-did"
     test_failure_case3: "did:example"
+    test_failure_case4: "2ZHFFhtTD6hJqzux"
 }

--- a/did_parser/tests/did/positive.rs
+++ b/did_parser/tests/did/positive.rs
@@ -27,4 +27,9 @@ test_cases_positive! {
         "did:web:w3c-ccg.github.io",
         Some("web"),
         "w3c-ccg.github.io"
+    test_case3:
+        "2ZHFFhzA2XtTD6hJqzL7ux",
+        "2ZHFFhzA2XtTD6hJqzL7ux",
+        None,
+        "2ZHFFhzA2XtTD6hJqzL7ux"
 }

--- a/did_parser/tests/did/positive.rs
+++ b/did_parser/tests/did/positive.rs
@@ -20,11 +20,11 @@ test_cases_positive! {
     test_case1:
         "did:example:123456789abcdefghi",
         "did:example:123456789abcdefghi",
-        "example",
+        Some("example"),
         "123456789abcdefghi"
     test_case2:
         "did:web:w3c-ccg.github.io",
         "did:web:w3c-ccg.github.io",
-        "web",
+        Some("web"),
         "w3c-ccg.github.io"
 }

--- a/did_parser/tests/did_url/positive.rs
+++ b/did_parser/tests/did_url/positive.rs
@@ -312,4 +312,14 @@ test_cases_positive! {
         None,
         HashMap::new(),
         HashMap::new()
+
+    test_case22:
+        "2ZHFFhzA2XtTD6hJqzL7ux#1",
+        Some("2ZHFFhzA2XtTD6hJqzL7ux"),
+        None,
+        Some("2ZHFFhzA2XtTD6hJqzL7ux"),
+        None,
+        Some("1"),
+        HashMap::new(),
+        HashMap::new()
 }

--- a/did_resolver_registry/src/error.rs
+++ b/did_resolver_registry/src/error.rs
@@ -3,12 +3,16 @@ use std::error::Error;
 #[derive(Debug)]
 pub enum DidResolverRegistryError {
     UnsupportedMethod,
+    UnqualifiedDid,
 }
 
 impl std::fmt::Display for DidResolverRegistryError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             DidResolverRegistryError::UnsupportedMethod => write!(f, "Unsupported DID method"),
+            DidResolverRegistryError::UnqualifiedDid => {
+                write!(f, "Attempted to resolve unqualified DID")
+            }
         }
     }
 }

--- a/did_resolver_registry/src/lib.rs
+++ b/did_resolver_registry/src/lib.rs
@@ -104,7 +104,9 @@ impl ResolverRegistry {
         did: &Did,
         options: &DidResolutionOptions<GenericMap>,
     ) -> Result<DidResolutionOutput<GenericMap>, GenericError> {
-        let method = did.method();
+        let method = did
+            .method()
+            .ok_or(DidResolverRegistryError::UnsupportedMethod)?;
         match self.resolvers.get(method) {
             Some(resolver) => resolver.resolve(did, options).await,
             None => Err(Box::new(DidResolverRegistryError::UnsupportedMethod)),
@@ -154,7 +156,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_error() {
         let did = Did::parse("did:example:1234".to_string()).unwrap();
-        let method = did.method().to_string();
+        let method = did.method().unwrap().to_string();
 
         let mut mock_resolver = MockDummyDidResolver::new();
         mock_resolver
@@ -188,7 +190,7 @@ mod tests {
     async fn test_resolve_success() {
         let did = "did:example:1234";
         let parsed_did = Did::parse(did.to_string()).unwrap();
-        let method = parsed_did.method().to_string();
+        let method = parsed_did.method().unwrap().to_string();
 
         let mut mock_resolver = MockDummyDidResolver::new();
         mock_resolver
@@ -256,7 +258,7 @@ mod tests {
     async fn test_resolve_after_registering_resolver() {
         let did = "did:example:1234";
         let parsed_did = Did::parse(did.to_string()).unwrap();
-        let method = parsed_did.method().to_string();
+        let method = parsed_did.method().unwrap().to_string();
 
         let mut mock_resolver = MockDummyDidResolver::new();
         mock_resolver

--- a/did_resolver_sov/src/resolution/resolver.rs
+++ b/did_resolver_sov/src/resolution/resolver.rs
@@ -47,9 +47,12 @@ impl DidResolvable for DidSovResolver {
                 )));
             }
         }
-        if parsed_did.method() != "sov" {
+        let method = parsed_did.method().ok_or_else(|| {
+            DidSovError::InvalidDid("Attempted to resolve unqualified did".to_string())
+        })?;
+        if method != "sov" {
             return Err(Box::new(DidSovError::MethodNotSupported(
-                parsed_did.method().to_string(),
+                method.to_string(),
             )));
         }
         if !is_valid_sovrin_did_id(parsed_did.id()) {

--- a/did_resolver_web/src/resolution/resolver.rs
+++ b/did_resolver_web/src/resolution/resolver.rs
@@ -73,8 +73,11 @@ where
         did: &Did,
         options: &DidResolutionOptions<Self::ExtraFieldsOptions>,
     ) -> Result<DidResolutionOutput<()>, GenericError> {
-        if did.method() != "web" {
-            return Err(Box::new(DidWebError::MethodNotSupported(did.method().to_string())));
+        let method = did
+            .method()
+            .ok_or_else(|| DidWebError::InvalidDid("Attempted to resolve unqualified did".to_string()))?;
+        if method != "web" {
+            return Err(Box::new(DidWebError::MethodNotSupported(method.to_string())));
         }
 
         if let Some(accept) = options.accept() {


### PR DESCRIPTION
Enables parsing of unqualified DIDs in `did_parser`, a temporary measure for the purposes of gracefully transitioning to using fully qualified DIDs, and will be reverted once the transition is complete.