### PR TITLE
Expose public key getter on verification method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,6 +1643,7 @@ dependencies = [
  "hex",
  "multibase",
  "pem 2.0.1",
+ "public_key",
  "serde",
  "serde_json",
  "uniresid",

--- a/did_doc/Cargo.toml
+++ b/did_doc/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 base64 = "0.21.2"
 bs58 = "0.5.0"
 did_parser = { path = "../did_parser" }
+public_key = { path = "../public_key" }
 hex = "0.4.3"
 multibase = "0.9.1"
 pem = "2.0.1"

--- a/did_doc/src/error.rs
+++ b/did_doc/src/error.rs
@@ -1,5 +1,7 @@
 use url::ParseError;
 
+use crate::schema::verification_method::VerificationMethodType;
+
 #[derive(Debug)]
 pub enum DidDocumentBuilderError {
     InvalidInput(String),
@@ -10,6 +12,8 @@ pub enum DidDocumentBuilderError {
     Base58DecodeError(bs58::decode::Error),
     Base64DecodeError(base64::DecodeError),
     HexDecodeError(hex::FromHexError),
+    UnsupportedVerificationMethodType(VerificationMethodType),
+    PublicKeyError(public_key::PublicKeyError),
 }
 
 impl std::fmt::Display for DidDocumentBuilderError {
@@ -39,6 +43,12 @@ impl std::fmt::Display for DidDocumentBuilderError {
             DidDocumentBuilderError::HexDecodeError(error) => {
                 write!(f, "Hex decode error: {}", error)
             }
+            DidDocumentBuilderError::UnsupportedVerificationMethodType(vm_type) => {
+                write!(f, "Unsupported verification method type: {}", vm_type)
+            }
+            DidDocumentBuilderError::PublicKeyError(error) => {
+                write!(f, "Public key error: {}", error)
+            }
         }
     }
 }
@@ -51,6 +61,7 @@ impl std::error::Error for DidDocumentBuilderError {
             DidDocumentBuilderError::Base58DecodeError(error) => Some(error),
             DidDocumentBuilderError::Base64DecodeError(error) => Some(error),
             DidDocumentBuilderError::HexDecodeError(error) => Some(error),
+            DidDocumentBuilderError::PublicKeyError(error) => Some(error),
             _ => None,
         }
     }
@@ -89,5 +100,11 @@ impl From<hex::FromHexError> for DidDocumentBuilderError {
 impl From<ParseError> for DidDocumentBuilderError {
     fn from(error: ParseError) -> Self {
         DidDocumentBuilderError::InvalidInput(error.to_string())
+    }
+}
+
+impl From<public_key::PublicKeyError> for DidDocumentBuilderError {
+    fn from(error: public_key::PublicKeyError) -> Self {
+        DidDocumentBuilderError::PublicKeyError(error)
     }
 }

--- a/did_doc/src/schema/verification_method/mod.rs
+++ b/did_doc/src/schema/verification_method/mod.rs
@@ -3,7 +3,7 @@ mod verification_method;
 mod verification_method_kind;
 mod verification_method_type;
 
-pub use public_key::PublicKeyField;
+pub use self::public_key::PublicKeyField;
 pub use verification_method::{
     CompleteVerificationMethodBuilder, IncompleteVerificationMethodBuilder, VerificationMethod,
 };

--- a/did_doc/src/schema/verification_method/public_key.rs
+++ b/did_doc/src/schema/verification_method/public_key.rs
@@ -58,8 +58,6 @@ impl PublicKeyField {
     pub fn base58(&self) -> Result<String, DidDocumentBuilderError> {
         Ok(bs58::encode(self.key_decoded()?).into_string())
     }
-
-    // TODO: This should expose a PublicKey getter
 }
 
 #[cfg(test)]

--- a/did_doc/src/schema/verification_method/verification_method_type.rs
+++ b/did_doc/src/schema/verification_method/verification_method_type.rs
@@ -1,8 +1,11 @@
 use std::fmt::Display;
 
+use public_key::KeyType;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+use crate::error::DidDocumentBuilderError;
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 pub enum VerificationMethodType {
     JsonWebKey2020,
     EcdsaSecp256k1VerificationKey2019,
@@ -43,6 +46,24 @@ impl Display for VerificationMethodType {
             VerificationMethodType::EcdsaSecp256k1RecoveryMethod2020 => {
                 write!(f, "EcdsaSecp256k1RecoveryMethod2020")
             }
+        }
+    }
+}
+
+impl TryFrom<VerificationMethodType> for KeyType {
+    type Error = DidDocumentBuilderError;
+
+    fn try_from(value: VerificationMethodType) -> Result<Self, Self::Error> {
+        match value {
+            VerificationMethodType::Ed25519VerificationKey2018
+            | VerificationMethodType::Ed25519VerificationKey2020 => Ok(KeyType::Ed25519),
+            VerificationMethodType::Bls12381G1Key2020 => Ok(KeyType::Bls12381g1),
+            VerificationMethodType::Bls12381G2Key2020 => Ok(KeyType::Bls12381g2),
+            VerificationMethodType::X25519KeyAgreementKey2019
+            | VerificationMethodType::X25519KeyAgreementKey2020 => Ok(KeyType::X25519),
+            _ => Err(DidDocumentBuilderError::UnsupportedVerificationMethodType(
+                value,
+            )),
         }
     }
 }

--- a/did_peer/src/numalgos/numalgo2/verification_method.rs
+++ b/did_peer/src/numalgos/numalgo2/verification_method.rs
@@ -50,7 +50,7 @@ pub fn get_key_by_verification_method(vm: &VerificationMethod) -> Result<Key, Di
         }
         t @ _ => return Err(DidPeerError::UnsupportedVerificationMethodType(t.to_owned())),
     };
-    Ok(Key::new(vm.public_key().key_decoded()?, key_type)?)
+    Ok(Key::new(vm.public_key_field().key_decoded()?, key_type)?)
 }
 
 fn build_verification_methods_from_type_and_key(
@@ -159,10 +159,10 @@ mod tests {
             let vms = get_verification_methods_by_key(key, &did(), PublicKeyEncoding::Multibase).unwrap();
             assert_eq!(vms.len(), 1);
             assert_eq!(
-                vms[0].public_key().key_decoded().unwrap(),
+                vms[0].public_key_field().key_decoded().unwrap(),
                 key.multicodec_prefixed_key()
             );
-            assert_ne!(vms[0].public_key().key_decoded().unwrap(), key.key());
+            assert_ne!(vms[0].public_key_field().key_decoded().unwrap(), key.key());
         }
 
         // ... and base58 encoded keys are not
@@ -170,10 +170,10 @@ mod tests {
             let vms = get_verification_methods_by_key(key, &did(), PublicKeyEncoding::Base58).unwrap();
             assert_eq!(vms.len(), 1);
             assert_ne!(
-                vms[0].public_key().key_decoded().unwrap(),
+                vms[0].public_key_field().key_decoded().unwrap(),
                 key.multicodec_prefixed_key()
             );
-            assert_eq!(vms[0].public_key().key_decoded().unwrap(), key.key());
+            assert_eq!(vms[0].public_key_field().key_decoded().unwrap(), key.key());
         }
 
         #[test]

--- a/did_resolver_sov/src/resolution/utils.rs
+++ b/did_resolver_sov/src/resolution/utils.rs
@@ -203,7 +203,7 @@ mod tests {
             "application/did+json"
         );
         if let PublicKeyField::Base58 { public_key_base58 } =
-            ddo.verification_method()[0].public_key()
+            ddo.verification_method()[0].public_key_field()
         {
             assert_eq!(
                 public_key_base58,


### PR DESCRIPTION
Introduces a `public_key::Key` getter in `VerificationMethod` to facilitate easy retrieval of the key representation derived from `VerificationMethod`.