### PR TITLE
Release 0.58.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "agency_client"
-version = "0.57.1"
+version = "0.58.0"
 dependencies = [
  "android_logger",
  "async-trait",
@@ -416,7 +416,7 @@ checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "aries-vcx"
-version = "0.57.1"
+version = "0.58.0"
 dependencies = [
  "agency_client",
  "android_logger",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "aries-vcx-agent"
-version = "0.57.1"
+version = "0.58.0"
 dependencies = [
  "aries-vcx",
  "aries_vcx_core",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "diddoc_legacy"
-version = "0.57.1"
+version = "0.58.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "libvcx_core"
-version = "0.57.1"
+version = "0.58.0"
 dependencies = [
  "agency_client",
  "aries-vcx",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "messages"
-version = "0.57.1"
+version = "0.58.0"
 dependencies = [
  "chrono",
  "derive_more",
@@ -4461,7 +4461,7 @@ dependencies = [
 
 [[package]]
 name = "shared_vcx"
-version = "0.57.1"
+version = "0.58.0"
 dependencies = [
  "bs58 0.4.0",
  "lazy_static",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi_aries_vcx"
-version = "0.57.1"
+version = "0.58.0"
 dependencies = [
  "aries-vcx",
  "async-trait",
@@ -5353,7 +5353,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vcx-napi-rs"
-version = "0.57.1"
+version = "0.58.0"
 dependencies = [
  "chrono",
  "libvcx_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.57.1"
+version = "0.58.0"
 authors = ["Absa Group Limited", "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>"]
 description = "Library to work with Aries protocols & collection of supporting components"
 license = "Apache-2.0"

--- a/aries_vcx/README.md
+++ b/aries_vcx/README.md
@@ -26,7 +26,7 @@ Aries [pick-up protocol](https://github.com/hyperledger/aries-rfcs/tree/main/fea
 To use `aries-vcx` in your project, you need to add GitHub dependency to your `Cargo.toml`, and best
 define a version through a `tag`:
 ```toml
-aries-vcx = { tag = "0.57.1", git = "https://github.com/hyperledger/aries-vcx" }
+aries-vcx = { tag = "0.58.0", git = "https://github.com/hyperledger/aries-vcx" }
 ```
 It's also advisable to follow these [instructions](TUTORIAL.md) to check your environment is properly configured.
 

--- a/wrappers/node/package-lock.json
+++ b/wrappers/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/node-vcx-wrapper",
-  "version": "0.57.1",
+  "version": "0.58.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/node-vcx-wrapper",
-      "version": "0.57.1",
+      "version": "0.58.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hyperledger/vcx-napi-rs": "file:../vcx-napi-rs",

--- a/wrappers/node/package.json
+++ b/wrappers/node/package.json
@@ -3,7 +3,7 @@
   "name": "@hyperledger/node-vcx-wrapper",
   "description": "NodeJS wrapper Aries Framework",
   "license": "Apache-2.0",
-  "version": "0.57.1",
+  "version": "0.58.0",
   "directories": {
     "test": "test",
     "build": "dist",


### PR DESCRIPTION
- First release with removed libvcx-c, libcx java and ios wrappers. See https://github.com/hyperledger/aries-vcx/pull/943