### PR TITLE
Fix profile building in tests, considering vdrtools is default feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,6 +336,7 @@ jobs:
         run: |
           cargo test --manifest-path="wallet_migrator/Cargo.toml";
           RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs -- --include-ignored;
+          RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs_revocations -- --include-ignored;
 
   test-integration-libvcx:
     needs: workflow-setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,7 +336,6 @@ jobs:
         run: |
           cargo test --manifest-path="wallet_migrator/Cargo.toml";
           RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs -- --include-ignored;
-          RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs_revocations -- --include-ignored;
 
   test-integration-libvcx:
     needs: workflow-setup

--- a/aries_vcx/src/common/primitives/mod.rs
+++ b/aries_vcx/src/common/primitives/mod.rs
@@ -21,7 +21,6 @@ pub mod integration_tests {
     #[tokio::test]
     #[ignore]
     async fn test_pool_rev_reg_def_fails_for_cred_def_created_without_revocation() {
-        // todo: does not need agency setup
         SetupProfile::run(|setup| async move {
             // Cred def is created with support_revocation=false,
             // revoc_reg_def will fail in libindy because cred_Def doesn't have revocation keys
@@ -44,6 +43,9 @@ pub mod integration_tests {
             )
             .await;
 
+            #[cfg(feature = "modular_libs")]
+            assert_eq!(rc.unwrap_err().kind(), AriesVcxErrorKind::InvalidState);
+            #[cfg(not(feature = "modular_libs"))]
             assert_eq!(rc.unwrap_err().kind(), AriesVcxErrorKind::InvalidInput);
         })
         .await;

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -171,6 +171,7 @@ pub async fn dev_setup_issuer_wallet_and_agency_client() -> (String, WalletHandl
 }
 
 pub async fn dev_setup_wallet_indy(key_seed: &str) -> (String, WalletHandle) {
+    info!("dev_setup_wallet_indy >>");
     let config_wallet = WalletConfig {
         wallet_name: format!("wallet_{}", uuid::Uuid::new_v4().to_string()),
         wallet_key: settings::DEFAULT_WALLET_KEY.into(),
@@ -193,6 +194,7 @@ pub async fn dev_setup_wallet_indy(key_seed: &str) -> (String, WalletHandle) {
 
 #[cfg(feature = "vdrtools")]
 pub async fn dev_build_profile_vdrtools(genesis_file_path: String, wallet: Arc<IndySdkWallet>) -> Arc<dyn Profile> {
+    info!("dev_build_profile_vdrtools >>");
     let vcx_pool_config = VcxPoolConfig {
         genesis_file_path: genesis_file_path.clone(),
         indy_vdr_config: None,
@@ -215,6 +217,7 @@ pub async fn dev_build_profile_vdrtools(genesis_file_path: String, wallet: Arc<I
 
 #[cfg(feature = "modular_libs")]
 pub fn dev_build_profile_modular(genesis_file_path: String, wallet: Arc<IndySdkWallet>) -> Arc<dyn Profile> {
+    info!("dev_build_profile_modular >>");
     let vcx_pool_config = VcxPoolConfig {
         genesis_file_path: genesis_file_path.clone(),
         indy_vdr_config: None,
@@ -228,6 +231,7 @@ pub async fn dev_build_profile_vdr_proxy_ledger(wallet: Arc<IndySdkWallet>) -> A
     use crate::core::profile::vdr_proxy_profile::VdrProxyProfile;
     use aries_vcx_core::VdrProxyClient;
     use std::env;
+    info!("dev_build_profile_vdr_proxy_ledger >>");
 
     let client_url = env::var("VDR_PROXY_CLIENT_URL").unwrap_or_else(|_| "http://127.0.0.1:3030".to_string());
     let client = VdrProxyClient::new(&client_url).unwrap();
@@ -237,6 +241,11 @@ pub async fn dev_build_profile_vdr_proxy_ledger(wallet: Arc<IndySdkWallet>) -> A
 
 pub async fn dev_build_featured_profile(genesis_file_path: String, wallet: Arc<IndySdkWallet>) -> Arc<dyn Profile> {
     // In case of migration test setup, we are starting with vdrtools, then we migrate
+    #[cfg(feature = "migration")]
+    return {
+        info!("SetupProfile >> using indy profile");
+        dev_build_profile_vdrtools(genesis_file_path, wallet).await
+    };
     #[cfg(feature = "modular_libs")]
     return {
         info!("SetupProfile >> using modular profile");

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -256,7 +256,7 @@ pub async fn dev_build_featured_profile(genesis_file_path: String, wallet: Arc<I
         info!("SetupProfile >> using vdr proxy profile");
         dev_build_profile_vdr_proxy_ledger(wallet).await
     };
-    #[cfg(any(feature = "vdrtools", feature = "migration"))]
+    #[cfg(feature = "vdrtools")]
     return {
         info!("SetupProfile >> using indy profile");
         dev_build_profile_vdrtools(genesis_file_path, wallet).await

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -237,11 +237,6 @@ pub async fn dev_build_profile_vdr_proxy_ledger(wallet: Arc<IndySdkWallet>) -> A
 
 pub async fn dev_build_featured_profile(genesis_file_path: String, wallet: Arc<IndySdkWallet>) -> Arc<dyn Profile> {
     // In case of migration test setup, we are starting with vdrtools, then we migrate
-    #[cfg(any(feature = "vdrtools", feature = "migration"))]
-    return {
-        info!("SetupProfile >> using indy profile");
-        dev_build_profile_vdrtools(genesis_file_path, wallet).await
-    };
     #[cfg(feature = "modular_libs")]
     return {
         info!("SetupProfile >> using modular profile");
@@ -251,6 +246,11 @@ pub async fn dev_build_featured_profile(genesis_file_path: String, wallet: Arc<I
     return {
         info!("SetupProfile >> using vdr proxy profile");
         dev_build_profile_vdr_proxy_ledger(wallet).await
+    };
+    #[cfg(any(feature = "vdrtools", feature = "migration"))]
+    return {
+        info!("SetupProfile >> using indy profile");
+        dev_build_profile_vdrtools(genesis_file_path, wallet).await
     };
 }
 


### PR DESCRIPTION
- When profile is selected dynamically based on feature flags (in testing), it would previously always select always `vdrtools` profile, regardless of `modular_libs` feature being enabled.
- This bug was probably brought in some of the relatively recent test setup / feature refactoring.
- Nevertheless the modular libs (which were apparently not being tested in CI since introduction of the bug) are passing fine ✅ 

Proper solution though, should be removing `vdrtools` as default feature
- had a quick shot at it, but it's a bit trickier, as tests require vdrtools wallet regardless of whether we are running with credx/vdrtools anoncreds
- it's possible to address, but figured it'll be easier just to wait out for vdrtools anoncreds to die out