### PR TITLE
Prover: fix credx credential retrieval

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,6 +336,7 @@ jobs:
         run: |
           cargo test --manifest-path="wallet_migrator/Cargo.toml";
           RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs -- --include-ignored;
+          RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs_revocations -- --include-ignored;
 
   test-integration-libvcx:
     needs: workflow-setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,7 +336,6 @@ jobs:
         run: |
           cargo test --manifest-path="wallet_migrator/Cargo.toml";
           RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs -- --include-ignored;
-          RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F migration --test test_creds_proofs_revocations -- --include-ignored;
 
   test-integration-libvcx:
     needs: workflow-setup

--- a/aries_vcx/src/handlers/proof_presentation/prover.rs
+++ b/aries_vcx/src/handlers/proof_presentation/prover.rs
@@ -58,7 +58,7 @@ impl Prover {
         let json_retrieved_credentials = anoncreds
             .prover_get_credentials_for_proof_req(&presentation_request)
             .await?;
-
+        trace!("Prover::retrieve_credentials >>> presentation_request: {presentation_request}, json_retrieved_credentials: {json_retrieved_credentials}");
         Ok(serde_json::from_str(&json_retrieved_credentials)?)
     }
 

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -665,79 +665,6 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
-    async fn test_agency_pool_proof_should_be_validated_even_if_at_least_one_of_restrictions_set_is_valid() {
-        SetupPoolDirectory::run(|setup| async move {
-            let mut institution = create_faber_trustee(setup.genesis_file_path.clone()).await;
-            let mut consumer = create_alice(setup.genesis_file_path).await;
-
-            let (consumer_to_institution, institution_to_consumer) =
-                create_connected_connections(&mut consumer, &mut institution).await;
-            let (schema_id, cred_def_id, _rev_reg_id, _cred_def, _rev_reg, _credential_handle) =
-                issue_address_credential(
-                    &mut consumer,
-                    &mut institution,
-                    &consumer_to_institution,
-                    &institution_to_consumer,
-                )
-                .await;
-
-            #[cfg(feature = "migration")]
-            institution.migrate().await;
-
-            let requested_attrs_string = serde_json::to_string(&json!([
-            {
-                "name": "address1",
-                "restrictions": [{
-                  "issuer_did": "abcdef0000000000000000"
-                },
-                {
-                  "issuer_did": institution.institution_did,
-                  "schema_id": schema_id,
-                }]
-            }
-            ]))
-            .unwrap();
-
-            info!(
-                "test_proof_should_be_validated :: Going to seng proof request with attributes {}",
-                &requested_attrs_string
-            );
-            let mut verifier = send_proof_request(
-                &mut institution,
-                &institution_to_consumer,
-                &requested_attrs_string,
-                "[]",
-                "{}",
-                None,
-            )
-            .await;
-
-            #[cfg(feature = "migration")]
-            consumer.migrate().await;
-
-            prover_select_credentials_and_send_proof(&mut consumer, &consumer_to_institution, None, None).await;
-
-            info!("test_proof_should_be_validated :: verifier :: going to verify proof");
-            verifier_update_with_mediator(
-                &mut verifier,
-                &institution.profile.inject_wallet(),
-                &institution.profile.inject_anoncreds_ledger_read(),
-                &institution.profile.inject_anoncreds(),
-                &institution.agency_client,
-                &institution_to_consumer,
-            )
-            .await
-            .unwrap();
-            assert_eq!(
-                verifier.get_verification_status(),
-                PresentationVerificationStatus::Valid
-            );
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    #[ignore]
     async fn test_agency_pool_proof_with_predicates_should_be_validated() {
         SetupPoolDirectory::run(|setup| async move {
             let mut institution = create_faber_trustee(setup.genesis_file_path.clone()).await;
@@ -826,18 +753,12 @@ mod tests {
             #[cfg(feature = "migration")]
             institution.migrate().await;
 
-            let requested_preds_string = serde_json::to_string(&json!([
-            {
+            let requested_preds_string = serde_json::to_string(&json!([{
                 "name": "zip",
                 "p_type": ">=",
                 "p_value": 85000
             }]))
             .unwrap();
-
-            info!(
-                "test_basic_proof :: Going to seng proof request with attributes {}",
-                &requested_preds_string
-            );
 
             send_proof_request(
                 &mut institution,
@@ -858,6 +779,60 @@ mod tests {
             assert!(selected_credentials.credential_for_referent.is_empty());
         })
         .await;
+    }
+
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_agency_pool_it_should_select_credentials_for_satisfiable_restriction() {
+        SetupPoolDirectory::run(|setup| async move {
+            let mut institution = create_faber_trustee(setup.genesis_file_path.clone()).await;
+            let mut consumer = create_alice(setup.genesis_file_path).await;
+
+            let (consumer_to_institution, institution_to_consumer) =
+                create_connected_connections(&mut consumer, &mut institution).await;
+            issue_address_credential(
+                &mut consumer,
+                &mut institution,
+                &consumer_to_institution,
+                &institution_to_consumer,
+            )
+                .await;
+
+            #[cfg(feature = "migration")]
+            institution.migrate().await;
+
+            let requested_attrs_string = serde_json::to_string(&json!([
+            {
+                "name": "address1",
+                "restrictions": [{
+                  "issuer_did": "abcdef0000000000000000",
+                },
+                {
+                  "issuer_did": institution.institution_did,
+                }]
+            }]))
+                .unwrap();
+
+            send_proof_request(
+                &mut institution,
+                &institution_to_consumer,
+                &requested_attrs_string,
+                "[]",
+                "{}",
+                None,
+            )
+                .await;
+
+            #[cfg(feature = "migration")]
+            consumer.migrate().await;
+
+            let mut prover = create_proof(&mut consumer, &consumer_to_institution, None).await;
+            let selected_credentials =
+                prover_select_credentials(&mut prover, &mut consumer, &consumer_to_institution, None).await;
+            assert_eq!(selected_credentials.credential_for_referent.is_empty(), false);
+        })
+            .await;
     }
 
     #[tokio::test]

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -733,6 +733,8 @@ mod tests {
         .await;
     }
 
+    // todo: credx implementation does not support checking credential value in respect to predicate
+    #[cfg(not(feature = "modular_libs"))]
     #[tokio::test]
     #[ignore]
     async fn test_agency_pool_it_should_fail_to_select_credentials_for_predicate() {
@@ -776,6 +778,7 @@ mod tests {
             let mut prover = create_proof(&mut consumer, &consumer_to_institution, None).await;
             let selected_credentials =
                 prover_select_credentials(&mut prover, &mut consumer, &consumer_to_institution, None).await;
+
             assert!(selected_credentials.credential_for_referent.is_empty());
         })
         .await;

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -781,7 +781,6 @@ mod tests {
         .await;
     }
 
-
     #[tokio::test]
     #[ignore]
     async fn test_agency_pool_it_should_select_credentials_for_satisfiable_restriction() {
@@ -797,10 +796,7 @@ mod tests {
                 &consumer_to_institution,
                 &institution_to_consumer,
             )
-                .await;
-
-            #[cfg(feature = "migration")]
-            institution.migrate().await;
+            .await;
 
             let requested_attrs_string = serde_json::to_string(&json!([
             {
@@ -812,7 +808,7 @@ mod tests {
                   "issuer_did": institution.institution_did,
                 }]
             }]))
-                .unwrap();
+            .unwrap();
 
             send_proof_request(
                 &mut institution,
@@ -822,17 +818,14 @@ mod tests {
                 "{}",
                 None,
             )
-                .await;
-
-            #[cfg(feature = "migration")]
-            consumer.migrate().await;
+            .await;
 
             let mut prover = create_proof(&mut consumer, &consumer_to_institution, None).await;
             let selected_credentials =
                 prover_select_credentials(&mut prover, &mut consumer, &consumer_to_institution, None).await;
             assert_eq!(selected_credentials.credential_for_referent.is_empty(), false);
         })
-            .await;
+        .await;
     }
 
     #[tokio::test]

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -679,7 +679,7 @@ mod tests {
                     &consumer_to_institution,
                     &institution_to_consumer,
                 )
-                    .await;
+                .await;
 
             #[cfg(feature = "migration")]
             institution.migrate().await;
@@ -696,7 +696,7 @@ mod tests {
                 }]
             }
             ]))
-                .unwrap();
+            .unwrap();
 
             info!(
                 "test_proof_should_be_validated :: Going to seng proof request with attributes {}",
@@ -710,7 +710,7 @@ mod tests {
                 "{}",
                 None,
             )
-                .await;
+            .await;
 
             #[cfg(feature = "migration")]
             consumer.migrate().await;
@@ -726,14 +726,14 @@ mod tests {
                 &institution.agency_client,
                 &institution_to_consumer,
             )
-                .await
-                .unwrap();
+            .await
+            .unwrap();
             assert_eq!(
                 verifier.get_verification_status(),
                 PresentationVerificationStatus::Valid
             );
         })
-            .await;
+        .await;
     }
 
     #[tokio::test]

--- a/aries_vcx/tests/test_creds_proofs.rs
+++ b/aries_vcx/tests/test_creds_proofs.rs
@@ -587,10 +587,10 @@ mod tests {
         accept_cred_proposal, accept_cred_proposal_1, accept_offer, accept_proof_proposal, attr_names,
         create_and_send_nonrevocable_cred_offer, create_connected_connections, create_proof, decline_offer,
         generate_and_send_proof, issue_address_credential, prover_select_credentials,
-        prover_select_credentials_and_fail_to_generate_proof, prover_select_credentials_and_send_proof,
-        receive_proof_proposal_rejection, reject_proof_proposal, retrieved_to_selected_credentials_simple,
-        send_cred_proposal, send_cred_proposal_1, send_cred_req, send_credential, send_proof_proposal,
-        send_proof_proposal_1, send_proof_request, verifier_create_proof_and_send_request, verify_proof,
+        prover_select_credentials_and_send_proof, receive_proof_proposal_rejection, reject_proof_proposal,
+        retrieved_to_selected_credentials_simple, send_cred_proposal, send_cred_proposal_1, send_cred_req,
+        send_credential, send_proof_proposal, send_proof_proposal_1, send_proof_request,
+        verifier_create_proof_and_send_request, verify_proof,
     };
 
     #[tokio::test]
@@ -852,8 +852,10 @@ mod tests {
             #[cfg(feature = "migration")]
             consumer.migrate().await;
 
-            prover_select_credentials_and_fail_to_generate_proof(&mut consumer, &consumer_to_institution, None, None)
-                .await;
+            let mut prover = create_proof(&mut consumer, &consumer_to_institution, None).await;
+            let selected_credentials =
+                prover_select_credentials(&mut prover, &mut consumer, &consumer_to_institution, None).await;
+            assert!(selected_credentials.credential_for_referent.is_empty());
         })
         .await;
     }

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -1131,6 +1131,7 @@ pub mod test_utils {
             .retrieve_credentials(&alice.profile.inject_anoncreds())
             .await
             .unwrap();
+        info!("prover_select_credentials >> retrieved_credentials: {retrieved_credentials:?}");
         let selected_credentials = match requested_values {
             Some(requested_values) => {
                 let credential_data = prover.presentation_request_data().unwrap();
@@ -1373,7 +1374,7 @@ pub mod test_utils {
         with_tails: bool,
     ) -> SelectedCredentials {
         info!(
-            "test_real_proof >>> retrieved matching credentials {:?}",
+            "retrieved_to_selected_credentials_simple >>> retrieved matching credentials {:?}",
             retrieved_credentials
         );
         let mut selected_credentials = SelectedCredentials::default();
@@ -1399,7 +1400,7 @@ pub mod test_utils {
         with_tails: bool,
     ) -> SelectedCredentials {
         info!(
-            "test_real_proof >>> retrieved matching credentials {:?}",
+            "retrieved_to_selected_credentials_specific >>> retrieved matching credentials {:?}",
             retrieved_credentials
         );
         let credential_data: Value = serde_json::from_str(credential_data).unwrap();

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -1143,12 +1143,11 @@ pub mod test_utils {
         selected_credentials
     }
 
-    pub async fn prover_select_credentials_and_send_proof_and_assert(
+    pub async fn prover_select_credentials_and_send_proof(
         alice: &mut Alice,
         consumer_to_institution: &MediatedConnection,
         request_name: Option<&str>,
         preselected_credentials: Option<&str>,
-        expected_prover_state: ProverState,
     ) {
         let mut prover = create_proof(alice, consumer_to_institution, request_name).await;
         let selected_credentials =
@@ -1158,23 +1157,7 @@ pub mod test_utils {
             &selected_credentials
         );
         generate_and_send_proof(alice, &mut prover, consumer_to_institution, selected_credentials).await;
-        assert_eq!(expected_prover_state, prover.get_state());
-    }
-
-    pub async fn prover_select_credentials_and_send_proof(
-        consumer: &mut Alice,
-        consumer_to_institution: &MediatedConnection,
-        request_name: Option<&str>,
-        preselected_credentials: Option<&str>,
-    ) {
-        prover_select_credentials_and_send_proof_and_assert(
-            consumer,
-            consumer_to_institution,
-            request_name,
-            preselected_credentials,
-            ProverState::PresentationSent,
-        )
-        .await
+        assert_eq!(ProverState::PresentationSent, prover.get_state());
     }
 
     pub async fn connect_using_request_sent_to_public_agent(

--- a/aries_vcx/tests/utils/scenarios.rs
+++ b/aries_vcx/tests/utils/scenarios.rs
@@ -1177,22 +1177,6 @@ pub mod test_utils {
         .await
     }
 
-    pub async fn prover_select_credentials_and_fail_to_generate_proof(
-        consumer: &mut Alice,
-        consumer_to_institution: &MediatedConnection,
-        request_name: Option<&str>,
-        requested_values: Option<&str>,
-    ) {
-        prover_select_credentials_and_send_proof_and_assert(
-            consumer,
-            consumer_to_institution,
-            request_name,
-            requested_values,
-            ProverState::PresentationPreparationFailed,
-        )
-        .await
-    }
-
     pub async fn connect_using_request_sent_to_public_agent(
         alice: &mut Alice,
         faber: &mut Faber,

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -160,12 +160,13 @@ impl IndyCredxAnonCreds {
 
         let wql_query = if let Some(restrictions) = restrictions {
             match restrictions {
-                Value::Array(mut arr) => {
-                    arr.extend(attrs);
-                    json!({ "$and": arr })
+                Value::Array(restrictions) => {
+                    let restrictions_wql = json!({ "$or": restrictions });
+                    attrs.push(restrictions_wql);
+                    json!({ "$and": attrs })
                 }
-                Value::Object(obj) => {
-                    attrs.push(Value::Object(obj));
+                Value::Object(restriction) => {
+                    attrs.push(Value::Object(restriction));
                     json!({ "$and": attrs })
                 }
                 _ => json!(attrs),

--- a/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
+++ b/aries_vcx_core/src/anoncreds/credx_anoncreds.rs
@@ -169,10 +169,13 @@ impl IndyCredxAnonCreds {
                     attrs.push(Value::Object(restriction));
                     json!({ "$and": attrs })
                 }
-                _ => json!(attrs),
+                _ => Err(AriesVcxCoreError::from_msg(
+                    AriesVcxCoreErrorKind::InvalidInput,
+                    "Invalid attribute restrictions (must be array or an object)",
+                ))?,
             }
         } else {
-            json!(attrs)
+            json!({ "$and": attrs })
         };
 
         let wql_query = serde_json::to_string(&wql_query)?;
@@ -751,7 +754,7 @@ impl BaseAnonCreds for IndyCredxAnonCreds {
                     .map(|v| v.try_as_str().map(_normalize_attr_name))
                     .collect::<Result<_, _>>()?,
                 _ => Err(AriesVcxCoreError::from_msg(
-                    AriesVcxCoreErrorKind::InvalidAttributesStructure,
+                    AriesVcxCoreErrorKind::InvalidInput,
                     "exactly one of 'name' or 'names' must be present",
                 ))?,
             };


### PR DESCRIPTION
- Fixes retrieval of credentials for prover. When multiple restriction objects are specified, they should be treated as `OR` instead of `AND`. Verifier is asking prover to satisfy at least 1 restriction object, not all of them.

- Adds test `test_agency_pool_it_should_select_credentials_for_satisfiable_restriction` which was failing without modifications to WQL made in the PR. Passes with the modifications. See anoncreds spec https://hyperledger.github.io/anoncreds-spec/#restrictions

> A boolean expression is formed by ORing and ANDing the source credential properties. The following JSON is an example. Any of the source credential properties listed above can be used in the expression components:
> 
>       "restrictions": [
>         {
>           "issuer_did": "<did>",
>           "schema_id": "id"
>         },
>         {
>           "cred_def_id" : "<id>",
>           "attr::color::marker": "1",
>           "attr::color::value" : "red"
>         }
>       ]
> The properties in each list item are AND’d together, and the array elements are OR’d together. As such, the example above defines the logical expression:
> 
> The attributes must come from a source verifiable credential such that:
>    issuer_did = <did> AND
>      schema_id = <id>
>    OR
>    cred_def_id = <id> AND
>       the credential must contain an attribute name "color" AND
>       the credential must contain an attribute name "color" with the attribute value "red"

- Test refactoring also uncovered that test `test_agency_pool_it_should_fail_to_select_credentials_for_predicate` is not working with credx implementation; see: https://github.com/hyperledger/aries-vcx/issues/962