### PR TITLE
fix android compilation by providing libzmq to be dynamically linked

### DIFF
--- a/uniffi_aries_vcx/scripts/android.utils.sh
+++ b/uniffi_aries_vcx/scripts/android.utils.sh
@@ -214,6 +214,7 @@ build_uniffi() {
     pushd "${UNIFFI_ROOT}/core"
         cargo build --lib --target=${TRIPLET}
         cp "$(realpath ${ARIES_VCX_ROOT}/target/${TRIPLET}/debug/libuniffi_vcx.so)" "$(realpath ${ABI_PATH}/libuniffi_vcx.so)"
+        cp "$(realpath ${LIBZMQ_LIB_DIR}/libzmq.so})" "$(realpath ${ABI_PATH}/libzmq.so)"
     popd
 }
 


### PR DESCRIPTION
Modify scripts to enable dynamic linking with libzmq by default on android