### PR TITLE
Remove `tokio`, `android_logger` deps from agency_client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,6 @@ dependencies = [
 name = "agency_client"
 version = "0.58.0"
 dependencies = [
- "android_logger",
  "async-trait",
  "env_logger 0.9.3",
  "lazy_static",
@@ -280,7 +279,6 @@ dependencies = [
  "serde_json",
  "shared_vcx",
  "thiserror",
- "tokio",
  "url",
  "uuid 0.8.2",
 ]

--- a/agency_client/Cargo.toml
+++ b/agency_client/Cargo.toml
@@ -26,9 +26,3 @@ url = { version = "2.3", features = ["serde"] }
 uuid = { version = "0.8", default-features = false, features = ["v4"]}
 thiserror = "1.0.37"
 shared_vcx = { path = "../shared_vcx" }
-
-[target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.5"
-
-[dev-dependencies]
-tokio = { version = "1.20", features = [ "rt", "macros" ] }

--- a/agency_client/src/messages/create_key.rs
+++ b/agency_client/src/messages/create_key.rs
@@ -86,20 +86,6 @@ mod tests {
             .unwrap();
     }
 
-    #[tokio::test]
-    #[cfg(feature = "general_test")]
-    async fn test_parse_create_keys_v2_response() {
-        let _setup = SetupMocks::init();
-
-        let for_did = "11235yBzrpJQmNyZzgoTqB";
-        let for_verkey = "EkVTa7SCJ5SntpYyX7CSb2pcBhiVGT9kWSagA8a9T69A";
-        let client = AgencyClient::new();
-        let (res_did, res_vk) = client.create_connection_agent(for_did, for_verkey).await.unwrap();
-
-        assert_eq!(res_did, "MNepeSWtGfhnv8jLB1sFZC");
-        assert_eq!(res_vk, "C73MRnns4qUjR5N4LRwTyiXVPKPrA5q4LCT8PZzxVdt9");
-    }
-
     #[test]
     #[cfg(feature = "general_test")]
     fn test_create_key_set_invalid_did_errors() {


### PR DESCRIPTION
- removes tokio dependency at cost of one test (very low value)
- also removed unused `android_logger` dependency