### PR TITLE
Minimize dependency on tokio

### DIFF
--- a/aries_vcx/Cargo.toml
+++ b/aries_vcx/Cargo.toml
@@ -51,7 +51,6 @@ uuid = { version = "0.8", default-features = false, features = ["v4"] }
 strum = "0.16.0"
 strum_macros = "0.16.0"
 derive_builder = "0.10.2"
-tokio = { version = "1.20.4" }
 thiserror = "1.0.37"
 url = { version = "2.3", features = ["serde"] }
 

--- a/aries_vcx/src/common/proofs/verifier/verifier.rs
+++ b/aries_vcx/src/common/proofs/verifier/verifier.rs
@@ -277,7 +277,7 @@ pub mod integration_tests {
             false,
         )
         .await;
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        std::thread::sleep(Duration::from_millis(500));
 
         let cred_id = create_and_write_credential(
             anoncreds_issuer,

--- a/aries_vcx/src/common/test_utils.rs
+++ b/aries_vcx/src/common/test_utils.rs
@@ -46,7 +46,7 @@ pub async fn create_and_write_test_schema(
         .publish_schema(&schema_json, submitter_did, None)
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(1000)).await;
+    std::thread::sleep(Duration::from_millis(500));
     Schema::create_from_ledger_json(&schema_json, "", &schema_id).unwrap()
 }
 

--- a/aries_vcx_core/Cargo.toml
+++ b/aries_vcx_core/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "1.0.40"
 lazy_static = "1.4.0"
 derive_builder = "0.12.0"
 uuid = { version = "1.3.0", default-features = false, features = ["v4"] }
-tokio = { version = "1.20" }
+tokio = { version = "1.20.5", features = ["sync"], default-features = false }
 indy-vdr-proxy-client = { git = "https://github.com/hyperledger/indy-vdr.git", rev = "879e29e", optional = true }
 indy-ledger-response-parser = { path = "../indy_ledger_response_parser" }
 lru = { version = "0.10.0"  }


### PR DESCRIPTION
Addressing https://github.com/hyperledger/aries-vcx/issues/947

- In `aries_vcx`, swapped tokio async sleeps for std blocking sleeps. This is okay because the sleep are only in test setup code, and these we run tests in single thread. If we gain capability to run tests in parallel, with a bit of effort, this can easily be update back to tokio sleeps (just need to properly feature flag the test setup code, which isn't the case today)

- in `aries_vcx_core`, swapped Mutex around cache for std lock. There was no need for tokio mutex, as the locks are not held across an await point
- in `aris_vcx_core`, the tokio import dependency is still declared, but limited to `sync` feature (for `upshot` module use by indy client implementations (`indy_vdr` tools internals require passing callbacks, not sure how difficult would those be to convert to async functions instead ) )

There's no changes visible to lock file because we declare dependency on tokio in other workspace projects (like uniffi, libvcx), but in external projects consuming `aries-vcx`, this should trim dependency tree (and likelyhood of dependency conflicts)