### PR TITLE
Connection protocol: add encrypt_message, remove auto-problem-report sending

### DIFF
--- a/agents/rust/aries-vcx-agent/src/services/connection.rs
+++ b/agents/rust/aries-vcx-agent/src/services/connection.rs
@@ -98,7 +98,6 @@ impl ServiceConnections {
                 request,
                 self.service_endpoint.clone(),
                 vec![],
-                &HttpClient,
             )
             .await?;
 
@@ -122,7 +121,7 @@ impl ServiceConnections {
     pub async fn accept_response(&self, thread_id: &str, response: Response) -> AgentResult<()> {
         let invitee: Connection<_, _> = self.connections.get(thread_id)?.try_into()?;
         let invitee = invitee
-            .handle_response(&self.profile.inject_wallet(), response, &HttpClient)
+            .handle_response(&self.profile.inject_wallet(), response)
             .await?;
 
         self.connections.insert(thread_id, invitee.into())?;

--- a/aries_vcx/src/common/credentials/mod.rs
+++ b/aries_vcx/src/common/credentials/mod.rs
@@ -112,7 +112,7 @@ mod integration_tests {
 
             assert_eq!(prover_cred.schema_id, schema.schema_id);
             assert_eq!(prover_cred.cred_def_id, cred_def.get_cred_def_id());
-            assert_eq!(prover_cred.cred_rev_id.unwrap().to_string(), cred_rev_id);
+            assert_eq!(prover_cred.cred_rev_id.unwrap(), cred_rev_id);
             assert_eq!(prover_cred.rev_reg_id.unwrap(), rev_reg.rev_reg_id);
         })
         .await;

--- a/aries_vcx/src/core/profile/ledger.rs
+++ b/aries_vcx/src/core/profile/ledger.rs
@@ -65,7 +65,7 @@ pub fn indyvdr_build_ledger_read(
     let response_cacher = Arc::new(InMemoryResponseCacher::new(cache_config));
 
     let config_read = IndyVdrLedgerReadConfig {
-        request_submitter: request_submitter.clone(),
+        request_submitter,
         response_parser,
         response_cacher,
         protocol_version: ProtocolVersion::node_1_4(),

--- a/aries_vcx/src/handlers/proof_presentation/types.rs
+++ b/aries_vcx/src/handlers/proof_presentation/types.rs
@@ -135,7 +135,7 @@ impl SelectedCredentials {
         with_tails_dir: Option<String>,
     ) {
         self.credential_for_referent.insert(
-            referent.to_string(),
+            referent,
             SelectedCredentialForReferent {
                 credential: SelectedCredentialForReferentCredential::from(retrieved_cred),
                 tails_dir: with_tails_dir,

--- a/aries_vcx/src/protocols/connection/generic/mod.rs
+++ b/aries_vcx/src/protocols/connection/generic/mod.rs
@@ -8,7 +8,7 @@ use diddoc_legacy::aries::diddoc::AriesDidDoc;
 use messages::AriesMessage;
 
 pub use self::thin_state::{State, ThinState};
-use super::{trait_bounds::BootstrapDidDoc, wrap_and_send_msg};
+use super::trait_bounds::BootstrapDidDoc;
 use crate::{
     errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult},
     handlers::util::AnyInvitation,
@@ -172,9 +172,6 @@ impl GenericConnection {
         }
     }
 
-    // todo: GenericConnection deals with States - but we have bunch of useful methods implemented
-    //       on Connection<I, S>, like in thies case, method "encrypt_message" - but we are unable
-    //       to reuse that here and end up reimplementing the same logic. Think about how to solve that.
     pub async fn encrypt_message(
         &self,
         wallet: &Arc<dyn BaseWallet>,
@@ -197,13 +194,16 @@ impl GenericConnection {
     where
         T: Transport,
     {
-        let sender_verkey = &self.pairwise_info().pw_vk;
         let did_doc = self.their_did_doc().ok_or(AriesVcxError::from_msg(
             AriesVcxErrorKind::NotReady,
             "No DidDoc present",
         ))?;
 
-        wrap_and_send_msg(wallet, message, sender_verkey, did_doc, transport).await
+        let msg = self.encrypt_message(wallet, message).await?.0;
+        let service_endpoint = did_doc.get_endpoint().ok_or_else(|| {
+            AriesVcxError::from_msg(AriesVcxErrorKind::InvalidUrl, "No URL in DID Doc")
+        })?;
+        transport.send_message(msg, service_endpoint).await
     }
 }
 
@@ -448,10 +448,7 @@ mod connection_serde_tests {
             .decorators(decorators)
             .build();
 
-        let con = con
-            .handle_response(&wallet, response, &MockTransport)
-            .await
-            .unwrap();
+        let con = con.handle_response(&wallet, response).await.unwrap();
 
         con.send_message(&wallet, &con.get_ack().into(), &MockTransport)
             .await
@@ -500,15 +497,9 @@ mod connection_serde_tests {
             .decorators(decorators)
             .build();
 
-        con.handle_request(
-            &wallet,
-            request,
-            new_service_endpoint,
-            new_routing_keys,
-            &MockTransport,
-        )
-        .await
-        .unwrap()
+        con.handle_request(&wallet, request, new_service_endpoint, new_routing_keys)
+            .await
+            .unwrap()
     }
 
     async fn make_inviter_completed() -> InviterConnection<InviterCompleted> {

--- a/aries_vcx/src/protocols/connection/generic/mod.rs
+++ b/aries_vcx/src/protocols/connection/generic/mod.rs
@@ -172,6 +172,9 @@ impl GenericConnection {
         }
     }
 
+    // todo: GenericConnection deals with States - but we have bunch of useful methods implemented
+    //       on Connection<I, S>, like in thies case, method "encrypt_message" - but we are unable
+    //       to reuse that here and end up reimplementing the same logic. Think about how to solve that.
     pub async fn encrypt_message(
         &self,
         wallet: &Arc<dyn BaseWallet>,

--- a/aries_vcx/src/protocols/connection/invitee/mod.rs
+++ b/aries_vcx/src/protocols/connection/invitee/mod.rs
@@ -192,8 +192,6 @@ impl InviteeConnection<Requested> {
             "Cannot handle response: remote verkey not found",
         ))?;
 
-        // todo: if response decoding fails, we should return error which can be easily
-        //       distinguished by upper layer to possibly send problem report
         let did_doc = decode_signed_connection_response(wallet, response.content, their_vk)
             .await?
             .did_doc;

--- a/aries_vcx/src/protocols/connection/inviter/mod.rs
+++ b/aries_vcx/src/protocols/connection/inviter/mod.rs
@@ -27,7 +27,6 @@ use crate::{
     errors::error::VcxResult,
     handlers::util::{verify_thread_id, AnyInvitation},
     protocols::connection::trait_bounds::ThreadId,
-    transport::Transport,
 };
 
 pub type InviterConnection<S> = Connection<Inviter, S>;
@@ -181,11 +180,6 @@ impl InviterConnection<Invited> {
         // There must be some other way to validate the thread ID other than cloning the entire
         // Request
         verify_thread_id(self.thread_id(), &request.clone().into())?;
-
-        // todo: if request validation fails, we should return error which can be easily
-        //       distinguished by upper layer to possibly send problem report
-        //       Although in this case, since the did_doc itself is invalid, it's questionable if
-        // it's       make any sense for caller to even try that.
         request.content.connection.did_doc.validate()?;
 
         // Generate new pairwise info that will be used from this point on

--- a/aries_vcx/src/protocols/connection/mod.rs
+++ b/aries_vcx/src/protocols/connection/mod.rs
@@ -102,6 +102,15 @@ where
         self.state.their_did_doc()
     }
 
+    pub async fn encrypt_message(
+        &self,
+        wallet: &Arc<dyn BaseWallet>,
+        message: &AriesMessage,
+    ) -> VcxResult<EncryptionEnvelope> {
+        let sender_verkey = &self.pairwise_info().pw_vk;
+        EncryptionEnvelope::create(wallet, message, Some(sender_verkey), &self.their_did_doc()).await
+    }
+
     pub fn remote_did(&self) -> &str {
         &self.their_did_doc().id
     }

--- a/aries_vcx/src/protocols/connection/mod.rs
+++ b/aries_vcx/src/protocols/connection/mod.rs
@@ -6,28 +6,22 @@ pub mod pairwise_info;
 mod serializable;
 mod trait_bounds;
 
-use std::{error::Error, sync::Arc};
+use std::sync::Arc;
 
 use aries_vcx_core::wallet::base_wallet::BaseWallet;
-use chrono::Utc;
 use diddoc_legacy::aries::diddoc::AriesDidDoc;
 use messages::{
-    decorators::{thread::Thread, timing::Timing},
-    msg_fields::protocols::{
-        connection::problem_report::{
-            ProblemReport, ProblemReportContent, ProblemReportDecorators,
-        },
-        discover_features::{disclose::Disclose, query::QueryContent, ProtocolDescriptor},
+    msg_fields::protocols::discover_features::{
+        disclose::Disclose, query::QueryContent, ProtocolDescriptor,
     },
     AriesMessage,
 };
-use uuid::Uuid;
 
 pub use self::generic::{GenericConnection, State, ThinState};
 use self::{
     generic::GenericState,
     pairwise_info::PairwiseInfo,
-    trait_bounds::{CompletedState, HandleProblem, TheirDidDoc, ThreadId},
+    trait_bounds::{CompletedState, TheirDidDoc, ThreadId},
 };
 use crate::{
     errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult},
@@ -108,8 +102,7 @@ where
         message: &AriesMessage,
     ) -> VcxResult<EncryptionEnvelope> {
         let sender_verkey = &self.pairwise_info().pw_vk;
-        EncryptionEnvelope::create(wallet, message, Some(sender_verkey), &self.their_did_doc())
-            .await
+        EncryptionEnvelope::create(wallet, message, Some(sender_verkey), self.their_did_doc()).await
     }
 
     pub fn remote_did(&self) -> &str {

--- a/aries_vcx/src/protocols/proof_presentation/verifier/state_machine.rs
+++ b/aries_vcx/src/protocols/proof_presentation/verifier/state_machine.rs
@@ -282,9 +282,7 @@ impl VerifierSM {
                                 (state, presentation, PresentationVerificationStatus::Invalid)
                                     .into(),
                             ),
-                            _ => {
-                                VerifierFullState::Finished((state, problem_report.clone()).into())
-                            }
+                            _ => VerifierFullState::Finished((state, problem_report).into()),
                         }
                     }
                 }

--- a/aries_vcx/src/utils/devsetup.rs
+++ b/aries_vcx/src/utils/devsetup.rs
@@ -176,7 +176,7 @@ pub fn dev_build_profile_vdrtools(
 ) -> Arc<dyn Profile> {
     info!("dev_build_profile_vdrtools >>");
     let vcx_pool_config = VcxPoolConfig {
-        genesis_file_path: genesis_file_path.clone(),
+        genesis_file_path,
         indy_vdr_config: None,
         response_cache_config: None,
     };
@@ -185,10 +185,10 @@ pub fn dev_build_profile_vdrtools(
         build_ledger_components(wallet.clone(), vcx_pool_config).unwrap();
     let anoncreds_ledger_read: Arc<dyn AnoncredsLedgerRead> = ledger_read.clone();
     let anoncreds_ledger_write: Arc<dyn AnoncredsLedgerWrite> = ledger_write.clone();
-    let indy_ledger_read: Arc<dyn IndyLedgerRead> = ledger_read.clone();
-    let indy_ledger_write: Arc<dyn IndyLedgerWrite> = ledger_write.clone();
+    let indy_ledger_read: Arc<dyn IndyLedgerRead> = ledger_read;
+    let indy_ledger_write: Arc<dyn IndyLedgerWrite> = ledger_write;
     Arc::new(VdrtoolsProfile::init(
-        wallet.clone(),
+        wallet,
         anoncreds_ledger_read,
         anoncreds_ledger_write,
         indy_ledger_read,
@@ -203,7 +203,7 @@ pub fn dev_build_profile_modular(
 ) -> Arc<dyn Profile> {
     info!("dev_build_profile_modular >>");
     let vcx_pool_config = VcxPoolConfig {
-        genesis_file_path: genesis_file_path.clone(),
+        genesis_file_path,
         indy_vdr_config: None,
         response_cache_config: None,
     };

--- a/aries_vcx/tests/utils/migration.rs
+++ b/aries_vcx/tests/utils/migration.rs
@@ -36,7 +36,7 @@ impl Migratable for TestAgent {
         let old_wh = self.profile.wallet_handle().unwrap();
         let new_wh = migrate_to_new_wallet(old_wh).await;
         let wallet = Arc::new(IndySdkWallet::new(new_wh));
-        self.profile = dev_build_profile_modular(self.genesis_file_path.clone(), wallet.clone());
+        self.profile = dev_build_profile_modular(self.genesis_file_path.clone(), wallet);
     }
 }
 

--- a/aries_vcx/tests/utils/scenarios/connection.rs
+++ b/aries_vcx/tests/utils/scenarios/connection.rs
@@ -58,15 +58,14 @@ async fn establish_connection_from_invite(
             &faber.profile.inject_wallet(),
             request,
             "http://dummy.org".parse().unwrap(),
-            vec![],
-            &DummyHttpClient,
+            vec![]
         )
         .await
         .unwrap();
     let response = inviter.get_connection_response_msg();
 
     let invitee = invitee
-        .handle_response(&alice.profile.inject_wallet(), response, &DummyHttpClient)
+        .handle_response(&alice.profile.inject_wallet(), response)
         .await
         .unwrap();
     let ack = invitee.get_ack();

--- a/aries_vcx/tests/utils/scenarios/connection.rs
+++ b/aries_vcx/tests/utils/scenarios/connection.rs
@@ -58,7 +58,7 @@ async fn establish_connection_from_invite(
             &faber.profile.inject_wallet(),
             request,
             "http://dummy.org".parse().unwrap(),
-            vec![]
+            vec![],
         )
         .await
         .unwrap();
@@ -94,7 +94,7 @@ pub async fn create_connections_via_oob_invite(
         .unwrap();
     // TODO: Create a key and write on ledger instead
     let inviter_pairwise_info = PairwiseInfo {
-        pw_did: ddo.clone().id.clone(),
+        pw_did: ddo.clone().id,
         pw_vk: ddo.recipient_keys().unwrap().first().unwrap().to_string(),
     };
     establish_connection_from_invite(alice, faber, invitation, inviter_pairwise_info).await
@@ -120,7 +120,7 @@ pub async fn create_connections_via_public_invite(
         .unwrap();
     // TODO: Create a key and write on ledger instead
     let inviter_pairwise_info = PairwiseInfo {
-        pw_did: ddo.clone().id.clone(),
+        pw_did: ddo.clone().id,
         pw_vk: ddo.recipient_keys().unwrap().first().unwrap().to_string(),
     };
     establish_connection_from_invite(alice, faber, public_invite.clone(), inviter_pairwise_info)

--- a/did_doc/src/schema/verification_method/mod.rs
+++ b/did_doc/src/schema/verification_method/mod.rs
@@ -230,7 +230,7 @@ mod tests {
 
         let vm =
             VerificationMethod::builder(id.clone(), controller.clone(), verification_method_type)
-                .add_public_key_multibase(public_key_multibase.clone())
+                .add_public_key_multibase(public_key_multibase)
                 .build();
 
         assert_eq!(vm.id(), &id);
@@ -255,7 +255,7 @@ mod tests {
 
         let vm =
             VerificationMethod::builder(id.clone(), controller.clone(), verification_method_type)
-                .add_public_key_multibase(public_key_multibase.clone())
+                .add_public_key_multibase(public_key_multibase)
                 .build();
 
         assert_eq!(vm.id(), &id);
@@ -298,10 +298,9 @@ mod tests {
         let verification_method_type = create_valid_verification_key_type();
         let public_key_multibase_expected = create_valid_multibase();
 
-        let vm =
-            VerificationMethod::builder(id.clone(), controller.clone(), verification_method_type)
-                .add_public_key_multibase(public_key_multibase_expected.clone())
-                .build();
+        let vm = VerificationMethod::builder(id, controller, verification_method_type)
+            .add_public_key_multibase(public_key_multibase_expected.clone())
+            .build();
 
         match vm.public_key_field() {
             PublicKeyField::Multibase {

--- a/did_doc_sov/src/lib.rs
+++ b/did_doc_sov/src/lib.rs
@@ -114,7 +114,7 @@ impl DidDocumentSovBuilder {
     }
 
     pub fn add_service(mut self, service: ServiceSov) -> Self {
-        self.services.push(service.clone());
+        self.services.push(service);
         self
     }
 

--- a/did_peer/src/numalgos/numalgo2/resolve/helpers.rs
+++ b/did_peer/src/numalgos/numalgo2/resolve/helpers.rs
@@ -159,7 +159,7 @@ fn build_service_aip1(
         service.service_endpoint().parse()?,
         ExtraFieldsSov::AIP1(ExtraFieldsAIP1::default()),
     )
-    .add_service_type(service_type.to_string())?
+    .add_service_type(service_type)?
     .build())
 }
 
@@ -174,7 +174,7 @@ fn build_service_didcommv2(
     let extra = ExtraFieldsSov::DIDCommV2(extra_builder.build());
     Ok(
         Service::<ExtraFieldsSov>::builder(id, service.service_endpoint().parse()?, extra)
-            .add_service_type(service_type.to_string())?
+            .add_service_type(service_type)?
             .build(),
     )
 }
@@ -247,7 +247,7 @@ mod tests {
             .parse()
             .unwrap();
         let mut index = 0;
-        let ddo_builder = DidDocumentBuilder::<ExtraFieldsSov>::new(did.clone());
+        let ddo_builder = DidDocumentBuilder::<ExtraFieldsSov>::new(did);
         let built_ddo =
             process_service_element(purposeless_service_element, ddo_builder, &mut index)
                 .unwrap()
@@ -272,7 +272,7 @@ mod tests {
             .parse()
             .unwrap();
         let mut index = 0;
-        let ddo_builder = DidDocumentBuilder::<ExtraFieldsSov>::new(did.clone());
+        let ddo_builder = DidDocumentBuilder::<ExtraFieldsSov>::new(did);
         let built_ddo =
             process_service_element(purposeless_service_element, ddo_builder, &mut index)
                 .unwrap()

--- a/did_peer/src/numalgos/numalgo2/verification_method.rs
+++ b/did_peer/src/numalgos/numalgo2/verification_method.rs
@@ -80,7 +80,7 @@ fn build_verification_methods_from_bls_multikey(
 
     let vm1 = add_public_key_to_builder(
         VerificationMethod::builder(
-            id1.to_owned(),
+            id1,
             did.to_owned(),
             VerificationMethodType::Bls12381G1Key2020,
         ),

--- a/did_peer/src/peer_did/numalgos/traits.rs
+++ b/did_peer/src/peer_did/numalgos/traits.rs
@@ -19,7 +19,7 @@ pub trait Numalgo: Sized + Default {
     {
         let did: Did = did.try_into().map_err(Into::into)?;
 
-        let numalgo_char = did.id().chars().nth(0).ok_or_else(|| {
+        let numalgo_char = did.id().chars().next().ok_or_else(|| {
             DidPeerError::DidValidationError(format!(
                 "Invalid did: unable to read numalgo character in did {}",
                 did.did()

--- a/did_resolver_sov/src/resolution/utils.rs
+++ b/did_resolver_sov/src/resolution/utils.rs
@@ -96,7 +96,7 @@ pub(super) async fn ledger_response_to_ddo<E: Default>(
         did.to_string().try_into()?,
         VerificationMethodType::Ed25519VerificationKey2018,
     )
-    .add_public_key_base58(verkey.to_string())
+    .add_public_key_base58(verkey)
     .build();
 
     let ddo = DidDocument::builder(ddo_id)

--- a/libvcx_core/src/api_vcx/api_global/pool.rs
+++ b/libvcx_core/src/api_vcx/api_global/pool.rs
@@ -115,9 +115,9 @@ async fn build_components_ledger(
     ));
     let taa_configurator: Arc<dyn TaaConfigurator> = ledger_write.clone();
     let anoncreds_write: Arc<dyn AnoncredsLedgerWrite> = ledger_write.clone();
-    let indy_write: Arc<dyn IndyLedgerWrite> = ledger_write.clone();
+    let indy_write: Arc<dyn IndyLedgerWrite> = ledger_write;
     let anoncreds_read: Arc<dyn AnoncredsLedgerRead> = ledger_read.clone();
-    let indy_read: Arc<dyn IndyLedgerRead> = ledger_read.clone();
+    let indy_read: Arc<dyn IndyLedgerRead> = ledger_read;
     Ok((
         anoncreds_read,
         anoncreds_write,

--- a/libvcx_core/src/api_vcx/api_handle/connection.rs
+++ b/libvcx_core/src/api_vcx/api_handle/connection.rs
@@ -288,7 +288,6 @@ pub async fn process_request(
                 LibvcxError::from_msg(LibvcxErrorKind::InvalidUrl, err.to_string())
             })?,
             routing_keys,
-            &HttpClient,
         )
         .await?;
 
@@ -300,9 +299,7 @@ pub async fn process_response(handle: u32, response: &str) -> LibvcxResult<()> {
 
     let con = get_cloned_connection(&handle)?;
     let response = deserialize(response)?;
-    let con = con
-        .handle_response(&get_main_wallet()?, response, &HttpClient)
-        .await?;
+    let con = con.handle_response(&get_main_wallet()?, response).await?;
 
     insert_connection(handle, con)
 }

--- a/libvcx_core/src/api_vcx/api_handle/schema.rs
+++ b/libvcx_core/src/api_vcx/api_handle/schema.rs
@@ -169,7 +169,7 @@ pub mod test_utils {
         info!("schema: {:?}", schema);
         assert_eq!(schema.schema_id, schema_id.to_string());
 
-        let mut schema_data = schema.data.clone();
+        let mut schema_data = schema.data;
         schema_data.sort();
         let mut vec_data: Vec<String> = serde_json::from_str(data).unwrap();
         vec_data.sort();

--- a/uniffi_aries_vcx/core/src/handlers/connection.rs
+++ b/uniffi_aries_vcx/core/src/handlers/connection.rs
@@ -147,13 +147,7 @@ impl Connection {
 
         block_on(async {
             let new_conn = connection
-                .handle_request(
-                    &profile.inner.inject_wallet(),
-                    request,
-                    url,
-                    routing_keys,
-                    &HttpClient,
-                )
+                .handle_request(&profile.inner.inject_wallet(), request, url, routing_keys)
                 .await?;
 
             *handler = VcxGenericConnection::from(new_conn);
@@ -178,7 +172,7 @@ impl Connection {
 
         block_on(async {
             let new_conn = connection
-                .handle_response(&profile.inner.inject_wallet(), response, &HttpClient)
+                .handle_response(&profile.inner.inject_wallet(), response)
                 .await?;
             *handler = VcxGenericConnection::from(new_conn);
 


### PR DESCRIPTION
Addition:
- Add `encrypt_message` on `impl<I, S> Connection<I, S> where S: TheirDidDoc`

Breaking change:
- For `InviteeConnection<Requested>` method `handle_response`, remove automatic problem-report sending in case of error processing `connection-response` message. The caller should, like in other protocols, inspect Error result returned and decide to send (or not) problem report
- Same applies for `InviterConnection<Invited> ` method `handle_request` processing of `connection-request`. 
- Remove methods defined on `Connection` for to dispatch problem report messages