### PR TITLE
Fix vdrproxy CI job intermittent failures

### DIFF
--- a/.github/actions/check-ports/action.yaml
+++ b/.github/actions/check-ports/action.yaml
@@ -20,7 +20,8 @@ runs:
     - name: "Check ports"
       shell: bash
       run: |
-        for p in ${{ inputs.ports }}; do
+        ports=${{ inputs.ports }}
+        for p in ${ports[@]}; do
           counter=0
 
           while [[ `nc -z localhost $p; echo $?` -ne 0 && $counter -ne ${{ inputs.tries }} ]]; do 

--- a/.github/actions/check-ports/action.yaml
+++ b/.github/actions/check-ports/action.yaml
@@ -8,7 +8,7 @@ inputs:
   tries:
     description: 'The max number of times to check whether each port is open'
     required: false
-    default: 20
+    default: 100
   interval:
     description: 'The interval to wait in between tries'
     required: false

--- a/.github/actions/check-ports/action.yaml
+++ b/.github/actions/check-ports/action.yaml
@@ -20,8 +20,7 @@ runs:
     - name: "Check ports"
       shell: bash
       run: |
-        ports="${{ inputs.ports }}"
-        for p in ${ports[@]}; do
+        for p in ${{ inputs.ports }}; do
           counter=0
 
           while [[ `nc -z localhost $p; echo $?` -ne 0 && $counter -ne ${{ inputs.tries }} ]]; do 
@@ -30,7 +29,7 @@ runs:
           done
 
           if [[ $counter -eq ${{ inputs.tries }} ]]; then
-            echo "Port ${{ inputs.port }} is unreachable!"
+            echo "Port $p is unreachable!"
             exit 1;
           fi
         done

--- a/.github/actions/check-ports/action.yaml
+++ b/.github/actions/check-ports/action.yaml
@@ -20,7 +20,7 @@ runs:
     - name: "Check ports"
       shell: bash
       run: |
-        ports=${{ inputs.ports }}
+        ports="${{ inputs.ports }}"
         for p in ${ports[@]}; do
           counter=0
 

--- a/.github/actions/check-ports/action.yaml
+++ b/.github/actions/check-ports/action.yaml
@@ -1,0 +1,35 @@
+name: "check-ports"
+description: 'Checks whether a space separated list of local ports is reachable'
+
+inputs:
+  ports:
+    description: 'The local ports to check'
+    required: true
+  tries:
+    description: 'The max number of times to check whether each port is open'
+    required: false
+    default: 20
+  interval:
+    description: 'The interval to wait in between tries'
+    required: false
+    default: 5
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Check ports"
+      shell: bash
+      run: |
+        for p in ${{ inputs.ports }}; do
+          counter=0
+
+          while [[ `nc -z localhost $p; echo $?` -ne 0 && $counter -ne ${{ inputs.tries }} ]]; do 
+            sleep ${{ inputs.interval }}
+            counter=$(( $counter + 1 ))
+          done
+
+          if [[ $counter -eq ${{ inputs.tries }} ]]; then
+            echo "Port ${{ inputs.port }} is unreachable!"
+            exit 1;
+          fi
+        done

--- a/.github/actions/setup-testing-nodejs/action.yml
+++ b/.github/actions/setup-testing-nodejs/action.yml
@@ -2,6 +2,9 @@ name: "setup-testing-nodejs"
 description: 'Install library deps, build libvcx'
 
 inputs:
+  rust-toolchain-version:
+    description: 'The Rust toolchain version to use'
+    required: true
   skip-docker-setup:
     description: 'If true, skip spinning up docker containers'
     required: false
@@ -23,7 +26,7 @@ runs:
         npm install -g npm@8.19.3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.65.0
+        toolchain: ${{ inputs.rust-toolchain-version }}
     - uses: Swatinem/rust-cache@v2
     - name: "Install dependencies"
       shell: bash

--- a/.github/actions/setup-testing-rust/action.yml
+++ b/.github/actions/setup-testing-rust/action.yml
@@ -50,4 +50,3 @@ runs:
       uses: ./.github/actions/check-ports
       with:
         ports: "3030"
-        tries: 10

--- a/.github/actions/setup-testing-rust/action.yml
+++ b/.github/actions/setup-testing-rust/action.yml
@@ -33,10 +33,10 @@ runs:
         docker run -d --name mysql     --network host -e MYSQL_ROOT_PASSWORD=mysecretpassword mysql:5.7.35
         docker run -d --name indypool  --network host ${{ env.DOCKER_IMAGE_POOL }}
     - name: "Start vdrproxy"
-      timeout-minutes: 5
       if: ${{ inputs.skip-vdrproxy-setup != 'true' }}
       shell: bash
       run: |
         docker run -d --name vdrproxy --network host ${{ env.DOCKER_IMAGE_VDRPROXY }} -p ${{ env.VDR_PROXY_PORT }} -g ${{ env.GENESIS_URL }}
-        while [[ `nc -z localhost ${{ env.VDR_PROXY_PORT }}; echo $?` -ne 0 ]]; do sleep 5; done
+        counter=0
+        while [[ `nc -z localhost ${{ env.VDR_PROXY_PORT }}; echo $?` -ne 0 && $counter -ne 60 ]]; do sleep 5; counter=$(( $counter + 1 )); done
 

--- a/.github/actions/setup-testing-rust/action.yml
+++ b/.github/actions/setup-testing-rust/action.yml
@@ -2,6 +2,9 @@ name: "setup-testing-rust"
 description: 'Setup host environment to run rust tests'
 
 inputs:
+  rust-toolchain-version:
+    description: 'The Rust toolchain version to use'
+    required: true
   skip-docker-setup:
     description: 'If true, skip spinning up docker containers'
     required: false
@@ -16,7 +19,7 @@ runs:
   steps:
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.65.0
+        toolchain: ${{ inputs.rust-toolchain-version }}
     - uses: Swatinem/rust-cache@v2
     - name: "Install dependencies"
       shell: bash
@@ -30,7 +33,10 @@ runs:
         docker run -d --name mysql     --network host -e MYSQL_ROOT_PASSWORD=mysecretpassword mysql:5.7.35
         docker run -d --name indypool  --network host ${{ env.DOCKER_IMAGE_POOL }}
     - name: "Start vdrproxy"
+      timeout: 5
       if: ${{ inputs.skip-vdrproxy-setup != 'true' }}
       shell: bash
       run: |
         docker run -d --name vdrproxy --network host ${{ env.DOCKER_IMAGE_VDRPROXY }} -p ${{ env.VDR_PROXY_PORT }} -g ${{ env.GENESIS_URL }}
+        while [[ `nc -z localhost ${{ env.VDR_PROXY_PORT }}; echo $?` -ne 0 ]]; do sleep 5; done
+

--- a/.github/actions/setup-testing-rust/action.yml
+++ b/.github/actions/setup-testing-rust/action.yml
@@ -20,23 +20,34 @@ runs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ inputs.rust-toolchain-version }}
+
     - uses: Swatinem/rust-cache@v2
     - name: "Install dependencies"
       shell: bash
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libsodium-dev libssl-dev libzmq3-dev
+
     - name: "Start indypool, mysql, agency"
       if: ${{ inputs.skip-docker-setup != 'true' }}
       shell: bash
       run: |
         docker run -d --name mysql     --network host -e MYSQL_ROOT_PASSWORD=mysecretpassword mysql:5.7.35
         docker run -d --name indypool  --network host ${{ env.DOCKER_IMAGE_POOL }}
+
+    - name: "Check indy ports"
+      uses: ./.github/actions/check-ports
+      with:
+        ports: "9701 9702 9703 9704 9705 9706 9707 9708"
+
     - name: "Start vdrproxy"
       if: ${{ inputs.skip-vdrproxy-setup != 'true' }}
       shell: bash
       run: |
         docker run -d --name vdrproxy --network host ${{ env.DOCKER_IMAGE_VDRPROXY }} -p ${{ env.VDR_PROXY_PORT }} -g ${{ env.GENESIS_URL }}
-        counter=0
-        while [[ `nc -z localhost ${{ env.VDR_PROXY_PORT }}; echo $?` -ne 0 && $counter -ne 60 ]]; do sleep 5; counter=$(( $counter + 1 )); done
 
+    - name: "Check vdrproxy port"
+      uses: ./.github/actions/check-ports
+      with:
+        ports: "3030"
+        tries: 10

--- a/.github/actions/setup-testing-rust/action.yml
+++ b/.github/actions/setup-testing-rust/action.yml
@@ -33,7 +33,7 @@ runs:
         docker run -d --name mysql     --network host -e MYSQL_ROOT_PASSWORD=mysecretpassword mysql:5.7.35
         docker run -d --name indypool  --network host ${{ env.DOCKER_IMAGE_POOL }}
     - name: "Start vdrproxy"
-      timeout: 5
+      timeout-minutes: 5
       if: ${{ inputs.skip-vdrproxy-setup != 'true' }}
       shell: bash
       run: |

--- a/.github/actions/setup-testing-rust/action.yml
+++ b/.github/actions/setup-testing-rust/action.yml
@@ -36,6 +36,7 @@ runs:
         docker run -d --name indypool  --network host ${{ env.DOCKER_IMAGE_POOL }}
 
     - name: "Check indy ports"
+      if: ${{ inputs.skip-docker-setup != 'true' }}
       uses: ./.github/actions/check-ports
       with:
         ports: "9701 9702 9703 9704 9705 9706 9707 9708"
@@ -47,6 +48,7 @@ runs:
         docker run -d --name vdrproxy --network host ${{ env.DOCKER_IMAGE_VDRPROXY }} -p ${{ env.VDR_PROXY_PORT }} -g ${{ env.GENESIS_URL }}
 
     - name: "Check vdrproxy port"
+      if: ${{ inputs.skip-vdrproxy-setup != 'true' }}
       uses: ./.github/actions/check-ports
       with:
         ports: "3030"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -318,6 +318,7 @@ jobs:
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
         with:
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
           skip-docker-setup: true
       - name: "Run workspace unit tests"
         run: RUST_TEST_THREADS=1 cargo test --workspace --lib --exclude aries-vcx-agent --exclude libvdrtools --exclude wallet_migrator --features ${{ matrix.features }}
@@ -336,6 +337,8 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
+        with:
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
       - name: "Run aries-vcx integration tests"
         run: RUST_TEST_THREADS=1 cargo test --manifest-path="aries_vcx/Cargo.toml" --features ${{ matrix.features }} -- --ignored;
 
@@ -347,6 +350,8 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
+        with:
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
       - name: "Run aries-vcx tests: mysql_test"
         run: RUST_TEST_THREADS=1 cargo test --manifest-path="aries_vcx/Cargo.toml" test_mysql -- --include-ignored;
 
@@ -369,6 +374,7 @@ jobs:
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
         with:
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
           skip-vdrproxy-setup: false
       - name: "Run aries-vcx tests: vdrproxy_test"
         run: RUST_TEST_THREADS=1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F vdr_proxy_ledger -- --ignored
@@ -386,6 +392,8 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
+        with:
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
       - name: "Run aries-vcx tests: pool_tests agency_pool_tests"
         run: |
           cargo test --manifest-path="wallet_migrator/Cargo.toml";
@@ -409,6 +417,8 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
+        with:
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
       - name: "Run libvcx_core integration tests"
         run: |
           RUST_TEST_THREADS=1 cargo test --features ${{ matrix.features }} --manifest-path="libvcx_core/Cargo.toml" -- --include-ignored;
@@ -422,6 +432,8 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
+        with:
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
       - name: "Run resolver tests"
         run: |
           RUST_TEST_THREADS=1 cargo test -p did_doc -p did_parser -p did_resolver -p did_resolver_registry -p did_resolver_sov -p did_resolver_web -p did_doc_sov -p did_key -p did_peer --test "*"
@@ -439,6 +451,7 @@ jobs:
       - name: "Setup NodeJS libvcx testing environment"
         uses: ./.github/actions/setup-testing-nodejs
         with:
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
           skip-docker-setup: true
           node-version: ${{ matrix.node-version }}
       - name: "Run tests"
@@ -457,6 +470,7 @@ jobs:
       - name: "Setup NodeJS libvcx testing environment"
         uses: ./.github/actions/setup-testing-nodejs
         with:
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
           node-version: ${{ matrix.node-version }}
       - name: "Run wrapper integration tests"
         run: (cd wrappers/node && npm run test:integration)


### PR DESCRIPTION
Attempts to fix the vdrproxy CI job by adding a health check action for the services ports.
Additionally, within the same action and some other, the Rust toolchain version was hardcoded, therefore tweaked the inputs to accept the version for consistency reasons.