### PR TITLE
Add fixed nightly toolchain version for the formatting job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,9 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-05-08
           components: rustfmt
+          override: true
       - name: "Verify code formatting"
         run: |
           cargo +nightly fmt --check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           override: true
       - name: "Verify code formatting"
         run: |
-          cargo +nightly fmt --check
+          cargo +nightly-2023-05-08 fmt --check
 
   workflow-setup:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Sets in stone the nightly version of the toolchain used in the formatting CI job.