### PR TITLE
Sync up nodejs state definitions

### DIFF
--- a/agents/node/vcxagent-core/test/utils/alice.js
+++ b/agents/node/vcxagent-core/test/utils/alice.js
@@ -127,7 +127,7 @@ module.exports.createAlice = async function createAlice (serviceEndpoint = 'http
     logger.debug(`acceptOobCredentialOffer >>> attached message: ${credOffer}`)
     await vcxAgent.serviceCredHolder.createCredentialFromOfferAndSendRequest(connectionId, holderCredentialId, credOffer)
     const state = await vcxAgent.serviceCredHolder.getState(holderCredentialId)
-    expect(state).toBe(HolderStateType.RequestSent)
+    expect(state).toBe(HolderStateType.RequestSet)
 
     await vcxAgent.agentShutdownVcx()
   }

--- a/agents/node/vcxagent-core/test/utils/faber.js
+++ b/agents/node/vcxagent-core/test/utils/faber.js
@@ -220,7 +220,7 @@ module.exports.createFaber = async function createFaber (serviceEndpoint = 'http
     await vcxAgent.agentInitVcx()
 
     logger.info('Issuer sending credential')
-    expect(await vcxAgent.serviceCredIssuer.sendCredential(issuerCredId, connectionId)).toBe(IssuerStateType.CredentialSent)
+    await vcxAgent.serviceCredIssuer.sendCredential(issuerCredId, connectionId)
     const revocationId = await vcxAgent.serviceCredIssuer.getRevocationId(issuerCredId)
     logger.info(`Sent credential with revocation id ${revocationId}`)
 

--- a/wrappers/node/src/api/common.ts
+++ b/wrappers/node/src/api/common.ts
@@ -134,9 +134,9 @@ export enum ConnectionStateType {
 
 export enum HolderStateType {
   Initial = 0,
-  ProposalSent = 1,
+  ProposalSet = 1,
   OfferReceived = 2,
-  RequestSent = 3,
+  RequestSet = 3,
   Finished = 4,
   Failed = 5,
 }
@@ -146,7 +146,7 @@ export enum IssuerStateType {
   ProposalReceived = 1,
   OfferSet = 2,
   RequestReceived = 4,
-  CredentialSent = 5,
+  CredentialSet = 5,
   Finished = 6,
   Failed = 7,
 }

--- a/wrappers/node/test/suite1/ariesvcx-credential.test.ts
+++ b/wrappers/node/test/suite1/ariesvcx-credential.test.ts
@@ -79,7 +79,7 @@ describe('Credential:', () => {
       const credential = await Credential.create(data);
       assert.equal(await credential.getState(), HolderStateType.OfferReceived);
       await credential.sendRequest({ connection });
-      assert.equal(await credential.getState(), HolderStateType.RequestSent);
+      assert.equal(await credential.getState(), HolderStateType.RequestSet);
     });
   });
 
@@ -88,7 +88,7 @@ describe('Credential:', () => {
       const data = await dataCredentialCreateWithOffer();
       const credential = await credentialCreateWithOffer(data);
       await credential.sendRequest({ connection: data.connection });
-      assert.equal(await credential.getState(), HolderStateType.RequestSent);
+      assert.equal(await credential.getState(), HolderStateType.RequestSet);
     });
   });
 


### PR DESCRIPTION
Update to NodeJS wrapper - between 0.58.0 and upcoming 0.59.0, we have made changes to states of issuer/holder state machines, but missed updating these in NodeJS wrapper. 
This PR fixes that.