### PR TITLE
Use standard UnpackMessageOutput struct until finally needing to transform.

### DIFF
--- a/aries_vcx/src/common/signing.rs
+++ b/aries_vcx/src/common/signing.rs
@@ -8,7 +8,7 @@ use messages::msg_fields::protocols::connection::{
 };
 use time;
 
-use crate::{errors::error::prelude::*, global::settings};
+use crate::errors::error::prelude::*;
 
 async fn get_signature_data(
     wallet: &Arc<dyn BaseWallet>,
@@ -88,27 +88,6 @@ pub async fn decode_signed_connection_response(
         .map_err(|err| AriesVcxError::from_msg(AriesVcxErrorKind::InvalidJson, err.to_string()))?;
 
     Ok(connection)
-}
-
-pub async fn unpack_message_to_string(
-    wallet: &Arc<dyn BaseWallet>,
-    msg: &[u8],
-) -> VcxResult<String> {
-    if settings::indy_mocks_enabled() {
-        return Ok(String::new());
-    }
-    let unpack_msg = wallet.unpack_message(msg).await.map_err(|_| {
-        AriesVcxError::from_msg(
-            AriesVcxErrorKind::InvalidMessagePack,
-            "Failed to unpack message",
-        )
-    })?;
-    serde_json::to_string(&unpack_msg).map_err(|_| {
-        AriesVcxError::from_msg(
-            AriesVcxErrorKind::InvalidMessageFormat,
-            "Failed to convert message to utf8 string",
-        )
-    })
 }
 
 // #[cfg(test)]

--- a/libvcx_core/src/api_vcx/api_global/wallet.rs
+++ b/libvcx_core/src/api_vcx/api_global/wallet.rs
@@ -18,10 +18,10 @@ use aries_vcx::{
                 wallet::{close_wallet, create_and_open_wallet, delete_wallet, import},
                 IndySdkWallet, IssuerConfig, RestoreWalletConfigs, WalletConfig,
             },
+            structs_io::UnpackMessageOutput,
         },
         SearchHandle, WalletHandle,
     },
-    common::signing::unpack_message_to_string,
     global::settings::DEFAULT_LINK_SECRET_ALIAS,
     protocols::mediated_connection::pairwise_info::PairwiseInfo,
 };
@@ -167,9 +167,9 @@ pub async fn rotate_verkey_apply(did: &str, temp_vk: &str) -> LibvcxResult<()> {
     )
 }
 
-pub async fn wallet_unpack_message_to_string(payload: &[u8]) -> LibvcxResult<String> {
+pub async fn wallet_unpack_message(payload: &[u8]) -> LibvcxResult<UnpackMessageOutput> {
     let wallet = get_main_wallet()?;
-    map_ariesvcx_result(unpack_message_to_string(&wallet, payload).await)
+    map_ariesvcx_core_result(wallet.unpack_message(payload).await)
 }
 
 pub async fn wallet_create_and_store_did(seed: Option<&str>) -> LibvcxResult<PairwiseInfo> {

--- a/wrappers/vcx-napi-rs/src/api/wallet.rs
+++ b/wrappers/vcx-napi-rs/src/api/wallet.rs
@@ -72,9 +72,10 @@ pub async fn configure_issuer_wallet(enterprise_seed: String) -> napi::Result<St
 #[napi]
 pub async fn unpack(data: Buffer) -> napi::Result<String> {
     let data = data.as_ref();
-    wallet::wallet_unpack_message_to_string(data)
+    let unpacked = wallet::wallet_unpack_message(data)
         .await
-        .map_err(to_napi_err)
+        .map_err(to_napi_err)?;
+    serde_json::to_string(&unpacked).map_err(|err| napi::Error::from_reason(err.to_string()))
 }
 
 #[napi]


### PR DESCRIPTION
As [suggested in](https://github.com/hyperledger/aries-vcx/pull/992#discussion_r1337239159) review of #992 