### PR TITLE
Use a sequence of bytes (representing AriesMessage) as input for EncryptionEnvelope::create

### DIFF
--- a/aries_vcx/src/protocols/connection/generic/mod.rs
+++ b/aries_vcx/src/protocols/connection/generic/mod.rs
@@ -180,7 +180,13 @@ impl GenericConnection {
             AriesVcxErrorKind::NotReady,
             "No DidDoc present",
         ))?;
-        EncryptionEnvelope::create(wallet, message, Some(sender_verkey), did_doc).await
+        EncryptionEnvelope::create(
+            wallet,
+            json!(message).to_string().as_bytes(),
+            Some(sender_verkey),
+            did_doc,
+        )
+        .await
     }
 
     pub async fn send_message<T>(

--- a/aries_vcx/src/protocols/connection/mod.rs
+++ b/aries_vcx/src/protocols/connection/mod.rs
@@ -100,7 +100,13 @@ where
         message: &AriesMessage,
     ) -> VcxResult<EncryptionEnvelope> {
         let sender_verkey = &self.pairwise_info().pw_vk;
-        EncryptionEnvelope::create(wallet, message, Some(sender_verkey), self.their_did_doc()).await
+        EncryptionEnvelope::create(
+            wallet,
+            json!(message).to_string().as_bytes(),
+            Some(sender_verkey),
+            self.their_did_doc(),
+        )
+        .await
     }
 
     pub fn remote_did(&self) -> &str {

--- a/aries_vcx/src/utils/encryption_envelope.rs
+++ b/aries_vcx/src/utils/encryption_envelope.rs
@@ -10,7 +10,6 @@ use uuid::Uuid;
 
 use crate::{errors::error::prelude::*, global::settings, utils::constants};
 
-type AriesMessageBytes = [u8];
 #[derive(Debug)]
 pub struct EncryptionEnvelope(pub Vec<u8>);
 
@@ -19,7 +18,7 @@ impl EncryptionEnvelope {
     /// If did_doc includes routing_keys, then also wrap in appropriate layers of forward message.
     pub async fn create(
         wallet: &impl BaseWallet,
-        message: &AriesMessageBytes,
+        message: &[u8],
         pw_verkey: Option<&str>,
         did_doc: &AriesDidDoc,
     ) -> VcxResult<EncryptionEnvelope> {
@@ -44,7 +43,7 @@ impl EncryptionEnvelope {
 
     async fn encrypt_for_pairwise(
         wallet: &impl BaseWallet,
-        message: &AriesMessageBytes,
+        message: &[u8],
         pw_verkey: Option<&str>,
         did_doc: &AriesDidDoc,
     ) -> VcxResult<Vec<u8>> {

--- a/aries_vcx/src/utils/mod.rs
+++ b/aries_vcx/src/utils/mod.rs
@@ -56,8 +56,14 @@ pub async fn send_message(
         message,
         &did_doc
     );
-    let EncryptionEnvelope(envelope) =
-        EncryptionEnvelope::create(wallet, &message, Some(&sender_verkey), &did_doc).await?;
+
+    let EncryptionEnvelope(envelope) = EncryptionEnvelope::create(
+        wallet,
+        json!(message).to_string().as_bytes(),
+        Some(&sender_verkey),
+        &did_doc,
+    )
+    .await?;
 
     // TODO: Extract from agency client
     agency_client::httpclient::post_message(
@@ -81,7 +87,8 @@ pub async fn send_message_anonymously(
         &did_doc
     );
     let EncryptionEnvelope(envelope) =
-        EncryptionEnvelope::create(wallet, message, None, did_doc).await?;
+        EncryptionEnvelope::create(wallet, json!(message).to_string().as_bytes(), None, did_doc)
+            .await?;
 
     agency_client::httpclient::post_message(
         envelope,


### PR DESCRIPTION

This makes it more general, allowing use of the utility methods without worrying about the exact structure of `AriesMessage` passed in. In doing so, allows for also wrapping message types not yet recognized in aries_vcx.