### PR TITLE
Release 0.59.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "agency_client"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "async-trait",
  "env_logger 0.9.3",
@@ -414,7 +414,7 @@ checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "aries-vcx"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "agency_client",
  "android_logger",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "aries-vcx-agent"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "aries-vcx",
  "aries_vcx_core",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "diddoc_legacy"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "libvcx_core"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "agency_client",
  "aries-vcx",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "messages"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "chrono",
  "derive_more",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "shared_vcx"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bs58 0.4.0",
  "lazy_static",
@@ -5131,7 +5131,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi_aries_vcx"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "aries-vcx",
  "async-trait",
@@ -5376,7 +5376,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vcx-napi-rs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "chrono",
  "libvcx_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.59.0"
+version = "0.59.1"
 authors = ["Absa Group Limited", "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>"]
 description = "Library to work with Aries protocols & collection of supporting components"
 license = "Apache-2.0"

--- a/aries_vcx/README.md
+++ b/aries_vcx/README.md
@@ -26,7 +26,7 @@ Aries [pick-up protocol](https://github.com/hyperledger/aries-rfcs/tree/main/fea
 To use `aries-vcx` in your project, you need to add GitHub dependency to your `Cargo.toml`, and best
 define a version through a `tag`:
 ```toml
-aries-vcx = { tag = "0.59.0", git = "https://github.com/hyperledger/aries-vcx" }
+aries-vcx = { tag = "0.59.1", git = "https://github.com/hyperledger/aries-vcx" }
 ```
 It's also advisable to follow these [instructions](TUTORIAL.md) to check your environment is properly configured.
 

--- a/wrappers/node/package-lock.json
+++ b/wrappers/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/node-vcx-wrapper",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/node-vcx-wrapper",
-      "version": "0.59.0",
+      "version": "0.59.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hyperledger/vcx-napi-rs": "file:../vcx-napi-rs",

--- a/wrappers/node/package.json
+++ b/wrappers/node/package.json
@@ -3,7 +3,7 @@
   "name": "@hyperledger/node-vcx-wrapper",
   "description": "NodeJS wrapper Aries Framework",
   "license": "Apache-2.0",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "directories": {
     "test": "test",
     "build": "dist",


### PR DESCRIPTION
This is a patch release to "seal" changes in vdrtools -> credx wallet migration

Release `0.60.0` will have `vdrtools -> credx` migration removed, as well as entire anoncreds portion of `vdrtools` (leaving only vdrtools wallet)