### PR TITLE
Refactor ServiceBuilder

### DIFF
--- a/did_doc/src/schema/did_doc.rs
+++ b/did_doc/src/schema/did_doc.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 use did_parser::{Did, DidUrl};
 use serde::{Deserialize, Serialize};
@@ -40,6 +40,13 @@ pub struct DidDocument<E> {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(flatten)]
     extra: HashMap<String, Value>,
+}
+
+impl Display for DidDocument<()> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let json = serde_json::to_string(self).unwrap();
+        write!(f, "{}", json)
+    }
 }
 
 impl<E> DidDocument<E> {

--- a/did_doc/src/schema/service.rs
+++ b/did_doc/src/schema/service.rs
@@ -170,10 +170,7 @@ mod tests {
         .add_service_type(service_type.clone())
         .unwrap()
         .add_service_type(service_type.clone())
-        .unwrap()
-        .build();
-
-        assert_eq!(service.service_type(), &OneOrList::One(service_type));
+        .unwrap_err();
     }
 
     #[test]

--- a/did_doc/src/schema/service.rs
+++ b/did_doc/src/schema/service.rs
@@ -8,14 +8,12 @@ use super::{
 };
 use crate::error::DidDocumentBuilderError;
 
-pub type ServiceTypeAlias = OneOrList<String>;
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Service<E> {
     id: Uri,
     #[serde(rename = "type")]
-    service_type: ServiceTypeAlias,
+    service_type: OneOrList<String>,
     service_endpoint: Url,
     #[serde(flatten)]
     extra: E,
@@ -30,7 +28,7 @@ impl<E> Service<E> {
         &self.id
     }
 
-    pub fn service_type(&self) -> &ServiceTypeAlias {
+    pub fn service_type(&self) -> &OneOrList<String> {
         &self.service_type
     }
 
@@ -46,13 +44,6 @@ impl<E> Service<E> {
 #[derive(Debug)]
 pub struct ServiceBuilder<E> {
     id: Uri,
-    service_endpoint: Url,
-    extra: E,
-}
-
-#[derive(Debug)]
-pub struct ServiceBuilderWithServiceType<E> {
-    id: Uri,
     service_type: HashSet<String>,
     service_endpoint: Url,
     extra: E,
@@ -62,6 +53,7 @@ impl<E> ServiceBuilder<E> {
     pub fn new(id: Uri, service_endpoint: Url, extra: E) -> Self {
         Self {
             id,
+            service_type: Default::default(),
             service_endpoint,
             extra,
         }
@@ -70,54 +62,29 @@ impl<E> ServiceBuilder<E> {
     pub fn add_service_type(
         self,
         service_type: String,
-    ) -> Result<ServiceBuilderWithServiceType<E>, DidDocumentBuilderError> {
+    ) -> Result<ServiceBuilder<E>, DidDocumentBuilderError> {
         if service_type.is_empty() {
-            return Err(DidDocumentBuilderError::MissingField("type"));
+            return Err(DidDocumentBuilderError::InvalidInput(
+                "Invalid service type: empty string".into(),
+            ));
         }
-        let mut service_types = HashSet::new();
+        if self.service_type.contains(&service_type) {
+            return Err(DidDocumentBuilderError::InvalidInput(
+                "Service type was already included".into(),
+            ));
+        }
+        let mut service_types = self.service_type.clone();
         service_types.insert(service_type);
-        Ok(ServiceBuilderWithServiceType {
+        Ok(ServiceBuilder {
             id: self.id,
             service_type: service_types,
             service_endpoint: self.service_endpoint,
             extra: self.extra,
         })
-    }
-
-    pub fn add_service_types(
-        self,
-        service_types: Vec<String>,
-    ) -> Result<ServiceBuilderWithServiceType<E>, DidDocumentBuilderError> {
-        if service_types.is_empty() {
-            return Err(DidDocumentBuilderError::MissingField("type"));
-        }
-        let service_types = service_types.into_iter().collect::<HashSet<_>>();
-        Ok(ServiceBuilderWithServiceType {
-            id: self.id,
-            service_type: service_types,
-            service_endpoint: self.service_endpoint,
-            extra: self.extra,
-        })
-    }
-}
-
-impl<E> ServiceBuilderWithServiceType<E> {
-    pub fn add_service_type(
-        mut self,
-        service_type: String,
-    ) -> Result<Self, DidDocumentBuilderError> {
-        if service_type.is_empty() {
-            return Err(DidDocumentBuilderError::MissingField("type"));
-        }
-        self.service_type.insert(service_type);
-        Ok(self)
     }
 
     pub fn build(self) -> Service<E> {
         let service_type = match self.service_type.len() {
-            // SAFETY: The only way to get to this state is to add at least one service type
-            0 => unreachable!(),
-            // SAFETY: We know that the length is non-zero
             1 => OneOrList::One(self.service_type.into_iter().next().unwrap()),
             _ => OneOrList::List(self.service_type.into_iter().collect()),
         };

--- a/did_doc/src/schema/service.rs
+++ b/did_doc/src/schema/service.rs
@@ -162,14 +162,14 @@ mod tests {
         let service_endpoint = "http://example.com/endpoint";
         let service_type = "DIDCommMessaging".to_string();
 
-        let service = ServiceBuilder::<ExtraSov>::new(
+        ServiceBuilder::<ExtraSov>::new(
             id,
             service_endpoint.try_into().unwrap(),
             Default::default(),
         )
         .add_service_type(service_type.clone())
         .unwrap()
-        .add_service_type(service_type.clone())
+        .add_service_type(service_type)
         .unwrap_err();
     }
 

--- a/did_doc/src/schema/types/uri.rs
+++ b/did_doc/src/schema/types/uri.rs
@@ -73,8 +73,7 @@ mod tests {
     fn test_uri_clone() {
         let uri_str = "http://example.com";
         let uri = Uri::from_str(uri_str).unwrap();
-        let uri_clone = uri.clone();
-        assert_eq!(uri, uri_clone);
+        assert_eq!(uri, uri.clone());
     }
 
     #[test]

--- a/did_parser/src/did.rs
+++ b/did_parser/src/did.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{error::ParseError, utils::parse::parse_did_method_id, DidRange, DidUrl};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Did {
     did: String,
     method: Option<DidRange>,
@@ -67,6 +67,16 @@ impl FromStr for Did {
 impl Display for Did {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.did)
+    }
+}
+
+impl std::fmt::Debug for Did {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Did")
+            .field("did", &self.did)
+            .field("method", &self.method())
+            .field("id", &self.id())
+            .finish()
     }
 }
 

--- a/did_resolver_sov/src/resolution/utils.rs
+++ b/did_resolver_sov/src/resolution/utils.rs
@@ -81,13 +81,15 @@ pub(super) async fn ledger_response_to_ddo<E: Default>(
             .filter(|t| *t != DidSovServiceType::Unknown)
             .map(|t| t.to_string())
             .collect();
-        Service::builder(
+        let mut builder = Service::builder(
             service_id,
             endpoint.endpoint.as_str().try_into()?,
             Default::default(),
-        )
-        .add_service_types(service_types)?
-        .build()
+        );
+        for service_type in service_types {
+            builder = builder.add_service_type(service_type)?;
+        }
+        builder.build()
     };
 
     // TODO: Use multibase instead of base58


### PR DESCRIPTION
### Builder refactoring
- Remove extra alias indirection `ServiceTypeAlias` - all its usage (2 places) fits on one screen
- Remove `add_service_types` in favor of `add_service_type`. The removed function was only used once and easily replacable by its "singular" version
- Remove `ServiceBuilderWithServiceType` - ServiceType is in fact optional, as https://sovrin-foundation.github.io/sovrin/spec/did-method-spec-template.html says:
  > If the types field is present
  
  So requiring user to call one of the (originally 2 methods) is just not right. If we were to be just "opinionated" to require users of our builder to do so, it should follow same pattern as other required attributes such as `id`, `service_endpoint`, `extra`. 
- If `add_service_type` is called with the same value as been provided before, throw `InvalidInput` instead of quietly doing nothing
- If `add_service_type` is called with empty string, throw `InvalidInput` error 

Note:
Probably stating obvious, but I take it that `ServiceBuilder` was somewhat of a shortcut as we didn't intend to use builder macro libraries at the time, and building full blown state pattern builder by hand is cumbersome (hence why required attributes are part of `ServiceBuilder<E>::new(....)` constructor directly. Perhaps down the line we can adopt the same builder library as in messages crate.

### Additional
Squashed some additional tweak, don't want create crate X pull requests so I'll squash further smaller improvements here.
- Implement `Debug` for `Did`so it prints `Did { did: "did:foo:bar", method: Some("foo"), id: "bar" }` instead of previously `Did { did: "did:foo:bar", method: Some(4..7), id: 8..11 }` 
- Implement `Display` for `DidDocument` which prints the ddo as json