### PR TITLE
Enhance `aries_vcx` crate readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
           sudo apt-get install -y libsodium-dev libssl-dev libzmq3-dev
       - name: "Verify clippy across the entire workspace with default features"
         run: |
-          cargo clippy -p aries-vcx --features legacy_proof --features ${{ matrix.backend }} --no-default-features
+          cargo clippy -p aries_vcx --features legacy_proof --features ${{ matrix.backend }} --no-default-features
         env:
           RUSTFLAGS: -D warnings
 
@@ -237,7 +237,7 @@ jobs:
         run: |
           RUSTFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests' \
           RUSTDOCFLAGS='-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests' \
-          RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --package aries-vcx -F vdrtools_wallet credx -- --ignored;
+          RUST_TEST_THREADS=1 CARGO_INCREMENTAL=0 TEST_POOL_IP=127.0.0.1 cargo test --package aries_vcx -F vdrtools_wallet credx -- --ignored;
 
           mkdir -p /tmp/artifacts/coverage
           grcov ./target/debug/ -s . -t lcov --llvm --branch --ignore-not-existing -o /tmp/artifacts/coverage/coverage.lcov
@@ -294,7 +294,7 @@ jobs:
         uses: ./.github/actions/setup-testing-rust
         with:
           rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
-      - name: "Run aries-vcx tests: mysql_test"
+      - name: "Run aries_vcx tests: mysql_test"
         run: RUST_TEST_THREADS=1 cargo test --manifest-path="aries_vcx/Cargo.toml" test_mysql -- --include-ignored;
 
   test-integration-aries-vcx-vdrproxy:
@@ -318,7 +318,7 @@ jobs:
         with:
           rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
           skip-vdrproxy-setup: false
-      - name: "Run aries-vcx tests: vdrproxy_test"
+      - name: "Run aries_vcx tests: vdrproxy_test"
         run: RUST_TEST_THREADS=1 cargo test --manifest-path="aries_vcx/Cargo.toml" -F vdr_proxy_ledger credx -- --ignored
       - name: "Collect docker logs on failure"
         if: failure()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
-name = "aries-vcx"
+name = "aries-vcx-agent"
+version = "0.61.0"
+dependencies = [
+ "aries_vcx",
+ "aries_vcx_core",
+ "async-trait",
+ "derive_builder",
+ "log",
+ "serde",
+ "serde_json",
+ "shared_vcx",
+ "thiserror",
+ "url",
+ "uuid 1.5.0",
+]
+
+[[package]]
+name = "aries_vcx"
 version = "0.61.0"
 dependencies = [
  "agency_client",
@@ -356,23 +373,6 @@ dependencies = [
  "url",
  "uuid 1.5.0",
  "wallet_migrator",
-]
-
-[[package]]
-name = "aries-vcx-agent"
-version = "0.61.0"
-dependencies = [
- "aries-vcx",
- "aries_vcx_core",
- "async-trait",
- "derive_builder",
- "log",
- "serde",
- "serde_json",
- "shared_vcx",
- "thiserror",
- "url",
- "uuid 1.5.0",
 ]
 
 [[package]]
@@ -1511,7 +1511,7 @@ dependencies = [
 name = "did_resolver_sov"
 version = "0.1.0"
 dependencies = [
- "aries-vcx",
+ "aries_vcx",
  "aries_vcx_core",
  "async-trait",
  "chrono",
@@ -2719,7 +2719,7 @@ name = "libvcx_core"
 version = "0.61.0"
 dependencies = [
  "agency_client",
- "aries-vcx",
+ "aries_vcx",
  "aries_vcx_core",
  "async-trait",
  "cfg-if",
@@ -2898,7 +2898,7 @@ name = "mediator"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "aries-vcx",
+ "aries_vcx",
  "aries_vcx_core",
  "async-trait",
  "axum",
@@ -5042,7 +5042,7 @@ dependencies = [
 name = "uniffi_aries_vcx"
 version = "0.61.0"
 dependencies = [
- "aries-vcx",
+ "aries_vcx",
  "async-trait",
  "diddoc_legacy",
  "once_cell",

--- a/agents/rust/aries-vcx-agent/Cargo.toml
+++ b/agents/rust/aries-vcx-agent/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 
 [dependencies]
 serde = "1.0.145"
-aries-vcx = { path = "../../../aries_vcx" }
+aries_vcx = { path = "../../../aries_vcx" }
 aries_vcx_core = { path = "../../../aries_vcx_core", features = ["credx", "vdrtools_wallet"] }
 shared_vcx = { path = "../../../shared_vcx" }
 async-trait = "0.1.64"

--- a/agents/rust/mediator/Cargo.toml
+++ b/agents/rust/mediator/Cargo.toml
@@ -11,7 +11,7 @@ client = []
 
 [dependencies]
 anyhow = "1.0.75"
-aries-vcx = { path = "../../../aries_vcx" }
+aries_vcx = { path = "../../../aries_vcx" }
 aries_vcx_core = { path = "../../../aries_vcx_core", features = [
     "vdrtools_wallet",
 ] }

--- a/aries_vcx/Cargo.toml
+++ b/aries_vcx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "aries-vcx"
+name = "aries_vcx"
 version.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/aries_vcx/README.md
+++ b/aries_vcx/README.md
@@ -1,29 +1,21 @@
-# aries-vcx
-`aries-vcx` is more of a "library" rather than "framework". We strive to be not too
-opinionated and simply provide building blocks for whatever you want to build.
+# `aries_vcx` crate
+Provides basic tools to build didcomm/aries enabled application in Rust. This can include native mobile apps, or 
+webservers for VC issuance/verification, didcomm mediator service etc. 
 
-You can use `aries-vcx` to build both end-user products (mobile wallets in role of credential
-holder and prover) or server (typically in role of issuer, verifier).
+#### What this crate can do for you
+- Create encrypted wallet.
+- Read/write from/to Indy ledger.
+- Establish didcomm connections and exchange messages.
+- Create and process Aries messages to drive Aries protocols (especially for VC issuance and presentation).
 
-Generally, the crate allows you to:
-- create encrypted wallet,
-- read/write from/to Indy ledger,
-- establish didcomm connections and exchange messages,
-- create and process Aries messages to drive Aries protocols.
-
-## `aries-vcx` components
-Additionally, the following crates may be consumed independently of `aries-vcx`:
-- [messages](../messages) - crate for building and parsing Aries messages
-- [diddoc](../diddoc) - crate to work with DIDDocs
-
-### Deprecation notice: Message mediation
-Aries-vcx contains built-in support for message mediation which is useful for mobile use cases. However,
-this feature (implemented via `MediatedConnection`) is now deprecated as it is tied to mediator
-implementation [vcxagency-node](https://github.com/AbsaOSS/vcxagencynode) which does not implement
-Aries [pick-up protocol](https://github.com/hyperledger/aries-rfcs/tree/main/features/0685-pickup-v2).
+#### What does crate does NOT DO for you
+- Provide message outbounds - `aries_vcx` helps you to create correct response & encrypt it, but you have to take care 
+  of sending it to the right place.
+- Automatic inbound processing - you have to take care of receiving messages and passing them to `aries_vcx` for processing.
+  You need to keep track of your ongoing aries "conversations" and match incoming messages (typically based on message thread id).
 
 # Getting started
-To use `aries-vcx` in your project, you need to add GitHub dependency to your `Cargo.toml`, and best
+To use `aries_vcx` in your project, you need to add GitHub dependency to your `Cargo.toml`, and best
 define a version through a `tag`:
 ```toml
 aries-vcx = { tag = "0.61.0", git = "https://github.com/hyperledger/aries-vcx" }
@@ -31,8 +23,9 @@ aries-vcx = { tag = "0.61.0", git = "https://github.com/hyperledger/aries-vcx" }
 It's also advisable to follow these [instructions](TUTORIAL.md) to check your environment is properly configured.
 
 # Projects built with aries-vcx
-- [aries-vcx-agent](../agents/rust/aries-vcx-agent) - sample agent with local persistence. Used for cross-compatibility testing with other aries implementations.
-- [unifii_aries_vcx](../uniffi_aries_vcx) - wrapper around `aries-vcx` to generate Swift and Kotlin wrappers for mobile use-cases
+- [mediator](../agents/rust/mediator) - Message mediator web service, useful for mobile device to receive messages while the device is offline.
+- [unifii_aries_vcx](../uniffi_aries_vcx) - Mobile wrapper to autogenerate Swift and Kotlin wrappers. Also comes with sample native mobile app.
+- [aries-vcx-agent](../agents/rust/aries-vcx-agent) - Sample agent framework adding persistence and message matching on top of `aries_vcx`. Used for cross-compatibility testing with other aries implementations.
 
 ## Implemented Aries protocols
 * ✅ Connection Protocol 1.0: [`https://didcomm.org/connections/1.0/*`](https://github.com/hyperledger/aries-rfcs/tree/master/features/0160-connection-protocol)

--- a/did_resolver_sov/Cargo.toml
+++ b/did_resolver_sov/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0.40"
 url = "2.3.1"
 
 [dev-dependencies]
-aries-vcx = { path = "../aries_vcx" }
+aries_vcx = { path = "../aries_vcx" }
 tokio = { version = "1.27.0", default-features = false, features = ["macros", "rt"] }
 uuid = "1.3.1"
 test_utils = {path = "../tools/test_utils", features = ["vdrtools_wallet"] }

--- a/libvcx_core/Cargo.toml
+++ b/libvcx_core/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0.97"
 serde_json = "1.0.40"
 serde_derive = "1.0.97"
 futures = { version = "0.3", default-features = false }
-aries-vcx = { path = "../aries_vcx", features = ["credx", "vdrtools_wallet"] }
+aries_vcx = { path = "../aries_vcx", features = ["credx", "vdrtools_wallet"] }
 aries_vcx_core = { path = "../aries_vcx_core" }
 diddoc_legacy = { path = "../diddoc_legacy" }
 thiserror = "1.0.37"

--- a/uniffi_aries_vcx/core/Cargo.toml
+++ b/uniffi_aries_vcx/core/Cargo.toml
@@ -17,7 +17,7 @@ path = "uniffi-bindgen.rs"
 
 [dependencies]
 uniffi = { version = "0.23.0", features = ["cli"] }
-aries-vcx = { path = "../../aries_vcx", features = [
+aries_vcx = { path = "../../aries_vcx", features = [
     "vdrtools_wallet",
     "credx",
 ] }


### PR DESCRIPTION
- Rewrote `aries_vcx` crate readme
- Rename `aries-vcx` package to `aries_vcx`, looking at most of are other crates, it seems that underscore is "the way" :-) I like it though

Also want to point out the distinction between `aries-vcx` and `aries_vcx`:
- `aries-vcx` being name of the HL project currently containing variety of useful components, not particularly tied to aries itself - such as crates `did`, `did_doc`, `did_peer` and number of others
- `aries_vcx` is the main, but also just one of many crates in the repo