### PR TITLE
draft: cleanup logging dependencies

### DIFF
--- a/aries_vcx/Cargo.toml
+++ b/aries_vcx/Cargo.toml
@@ -65,7 +65,6 @@ backtrace = { optional = true, version = "0.3" }
 
 [dev-dependencies]
 test_utils = { path = "../tools/test_utils" }
-libvcx_logger = { path = "../tools/libvcx_logger" }
 wallet_migrator = { path = "../wallet_migrator" }
 async-channel = "1.7.1"
 tokio = { version = "1.20", features = ["rt", "macros", "rt-multi-thread"] }

--- a/aries_vcx/tests/test_mysql_wallet.rs
+++ b/aries_vcx/tests/test_mysql_wallet.rs
@@ -13,12 +13,10 @@ mod dbtests {
             IndySdkWallet, WalletConfig, WalletConfigBuilder,
         },
     };
-    use libvcx_logger::LibvcxDefaultLogger;
 
     #[tokio::test]
     #[ignore]
     async fn test_mysql_init_issuer_with_mysql_wallet() -> Result<(), Box<dyn Error>> {
-        LibvcxDefaultLogger::init_testing_logger();
         let db_name = format!("mysqltest_{}", uuid::Uuid::new_v4()).replace('-', "_");
         let storage_config = json!({
             "read_host": "localhost",

--- a/tools/libvcx_logger/Cargo.toml
+++ b/tools/libvcx_logger/Cargo.toml
@@ -13,6 +13,3 @@ aries_vcx_core = { path = "../../aries_vcx_core" }
 chrono = "0.4"
 env_logger = "0.10"
 log = "0.4"
-
-[target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.13.3"


### PR DESCRIPTION
Incrementally addressing https://github.com/hyperledger/aries-vcx/issues/1012 (considering file reorg PR)

Outstanding:
- `libvcx_logger` should not exists, each top level crate such as `libvcx_core`, `uniffi` or backchannel shall setup env logger (or other log macro implementations) themselves.