### PR TITLE
fix(mediator-client): use standard endpoint intended for mediator clients

### DIFF
--- a/aries/agents/rust/mediator/src/aries_agent/client/mod.rs
+++ b/aries/agents/rust/mediator/src/aries_agent/client/mod.rs
@@ -54,7 +54,7 @@ impl<T: BaseWallet + 'static, P: MediatorPersistence> Agent<T, P> {
         .await
         .unwrap();
         let client_conn = client_conn
-            .prepare_request("http://response.http.alt".parse().unwrap(), vec![])
+            .prepare_request("didcomm:transport/queue".parse().unwrap(), vec![])
             .await
             .unwrap();
         // Extract the actual connection request message to be sent


### PR DESCRIPTION
https://github.com/decentralized-identity/didcomm-messaging/blob/main/extensions/return_route/main.md#queue-transport