### PR TITLE
fix(message_macros):  explicit lifetime declaration

### DIFF
--- a/aries/messages_macros/src/message_type.rs
+++ b/aries/messages_macros/src/message_type.rs
@@ -102,7 +102,7 @@ fn process_protocol(
 
         // Generate an impl with const PROTOCOL set the to the string literal passed in the macro
         // attribute
-        field_impls.push(quote! {impl #field { const PROTOCOL: &str = #protocol; }});
+        field_impls.push(quote! {impl #field { const PROTOCOL: &'static str = #protocol; }});
     }
 
     quote! {


### PR DESCRIPTION
Add explicit static lifetime rather than let the compiler guess. As per suggestion of lint `ELIDED_LIFETIMES_IN_ASSOCIATED_CONSTANT`

https://github.com/rust-lang/rust/issues/115010

This should fix the clippy warning we are seeing
(the ones point to `MessageType` trait derive macro)