### PR TITLE
fix: didcomm message forwarding

### DIFF
--- a/aries/aries_vcx/src/utils/encryption_envelope.rs
+++ b/aries/aries_vcx/src/utils/encryption_envelope.rs
@@ -28,19 +28,25 @@ impl EncryptionEnvelope {
             did_doc
         );
 
-        let recipient_keys = json!(did_doc.recipient_keys()?).to_string();
+        let recipient_key = did_doc.recipient_keys()?
+            .first()
+            .cloned()
+            .ok_or(AriesVcxError::from_msg(
+                AriesVcxErrorKind::InvalidState,
+                format!("No recipient key found in DIDDoc: {:?}", did_doc),
+            ))?;
         let routing_keys = did_doc.routing_keys();
         let message = EncryptionEnvelope::encrypt_for_pairwise(
             wallet,
             message,
             sender_vk,
-            recipient_keys.clone(),
+            recipient_key.clone(),
         )
         .await?;
         EncryptionEnvelope::wrap_into_forward_messages(
             wallet,
             message,
-            recipient_keys,
+            recipient_key,
             routing_keys,
         )
         .await
@@ -57,9 +63,9 @@ impl EncryptionEnvelope {
             "Encrypting for pairwise; sender_vk: {:?}, recipient_key: {}",
             sender_vk, recipient_key
         );
-
+        let recipient_keys = json!([recipient_key.clone()]).to_string();
         wallet
-            .pack_message(sender_vk, &recipient_key, message)
+            .pack_message(sender_vk, &recipient_keys, message)
             .await
             .map_err(|err| err.into())
     }
@@ -70,19 +76,22 @@ impl EncryptionEnvelope {
         recipient_key: String,
         routing_keys: Vec<String>,
     ) -> VcxResult<Vec<u8>> {
-        let mut forward_to_key = recipient_key.clone();
+        let mut forward_to_key = recipient_key;
 
         for routing_key in routing_keys.iter() {
+            debug!(
+                "Wrapping message in forward message; forward_to_key: {}, routing_key: {}",
+                forward_to_key, routing_key
+            );
             message = EncryptionEnvelope::wrap_into_forward(
                 wallet,
                 message,
                 &forward_to_key,
                 routing_key,
             )
-            .await?;
+                .await?;
             forward_to_key = routing_key.clone();
         }
-
         Ok(message)
     }
 

--- a/aries/aries_vcx/src/utils/encryption_envelope.rs
+++ b/aries/aries_vcx/src/utils/encryption_envelope.rs
@@ -28,13 +28,15 @@ impl EncryptionEnvelope {
             did_doc
         );
 
-        let recipient_key = did_doc.recipient_keys()?
-            .first()
-            .cloned()
-            .ok_or(AriesVcxError::from_msg(
-                AriesVcxErrorKind::InvalidState,
-                format!("No recipient key found in DIDDoc: {:?}", did_doc),
-            ))?;
+        let recipient_key =
+            did_doc
+                .recipient_keys()?
+                .first()
+                .cloned()
+                .ok_or(AriesVcxError::from_msg(
+                    AriesVcxErrorKind::InvalidState,
+                    format!("No recipient key found in DIDDoc: {:?}", did_doc),
+                ))?;
         let routing_keys = did_doc.routing_keys();
         let message = EncryptionEnvelope::encrypt_for_pairwise(
             wallet,
@@ -43,14 +45,9 @@ impl EncryptionEnvelope {
             recipient_key.clone(),
         )
         .await?;
-        EncryptionEnvelope::wrap_into_forward_messages(
-            wallet,
-            message,
-            recipient_key,
-            routing_keys,
-        )
-        .await
-        .map(EncryptionEnvelope)
+        EncryptionEnvelope::wrap_into_forward_messages(wallet, message, recipient_key, routing_keys)
+            .await
+            .map(EncryptionEnvelope)
     }
 
     async fn encrypt_for_pairwise(
@@ -89,7 +86,7 @@ impl EncryptionEnvelope {
                 &forward_to_key,
                 routing_key,
             )
-                .await?;
+            .await?;
             forward_to_key = routing_key.clone();
         }
         Ok(message)


### PR DESCRIPTION
- Previous refactoring PR https://github.com/hyperledger/aries-vcx/pull/1070 introduced an error such that `to` field in the forward message ended up string containing JSON array (`"to": "[\"foobar\"]"`), rather than correctly just the key (`"to": "foobar"`)
- This PR fixes the issue
- The issue was detected as mediator tests started to fail
- This PR is to be followed by another PR restoring encryption envelope tests