### PR TITLE
fix(aries_vcx): change log msg after fn arg rename

### DIFF
--- a/aries/aries_vcx/src/utils/encryption_envelope.rs
+++ b/aries/aries_vcx/src/utils/encryption_envelope.rs
@@ -22,7 +22,7 @@ impl EncryptionEnvelope {
         did_doc: &AriesDidDoc,
     ) -> VcxResult<EncryptionEnvelope> {
         trace!(
-            "EncryptionEnvelope::create >>> message: {:?}, pw_verkey: {:?}, did_doc: {:?}",
+            "EncryptionEnvelope::create >>> message: {:?}, sender_vk: {:?}, did_doc: {:?}",
             message,
             sender_vk,
             did_doc


### PR DESCRIPTION
Encryption envelope was refactored in #1070,
but one log message is out of sync with the new naming.