### PR TITLE
CI: Fix toolchain version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
     branches:
+      - main
+  pull_request:
+    branches:
       - "**"
 
 env:
@@ -90,6 +93,22 @@ jobs:
           echo "SKIP_NAPI_M1 ${{ needs.workflow-setup.outputs.SKIP_NAPI_M1 }}"
           echo "SKIP_CI ${{ needs.workflow-setup.outputs.SKIP_CI }}"
           echo "DOCKER_IMG_CACHED_VDRPROXY ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_VDRPROXY }}"
+
+  clippy_version:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Git checkout"
+        uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          components: clippy
+      - name: "Verify clippy version"
+        run: |
+          echo "cargo version:"
+          cargo --version
+          echo "clippy version:"
+          cargo clippy --version
 
   workspace_clippy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ env:
 
   DOCKER_REPO_LOCAL_VDRPROXY: vdrproxy
 
-  RUST_TOOLCHAIN_VERSON: 1.70.0
+  RUST_TOOLCHAIN_VERSION: 1.74.1
   NODE_VERSION: 18.x
 
 jobs:
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
       - name: "Construct CI run-info"
         id: run-info
         uses: ./.github/actions/construct-run-info
@@ -94,23 +94,6 @@ jobs:
           echo "SKIP_CI ${{ needs.workflow-setup.outputs.SKIP_CI }}"
           echo "DOCKER_IMG_CACHED_VDRPROXY ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_VDRPROXY }}"
 
-  clippy_version:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Git checkout"
-        uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSON }}
-          default: true
-          components: clippy
-      - name: "Verify clippy version"
-        run: |
-          echo "cargo version:"
-          cargo --version
-          echo "clippy version:"
-          cargo clippy --version
-
   workspace_clippy:
     runs-on: ubuntu-20.04
     steps:
@@ -118,7 +101,8 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
           components: clippy
       - name: "Install dependencies"
         shell: bash
@@ -141,7 +125,8 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
           components: clippy
       - name: "Install dependencies"
         shell: bash
@@ -164,7 +149,8 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
           components: clippy
       - name: "Install dependencies"
         shell: bash
@@ -283,7 +269,8 @@ jobs:
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
         with:
-          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
           skip-docker-setup: true
       - name: "Run workspace unit tests"
         run: RUST_TEST_THREADS=1 cargo test --workspace --lib --exclude aries-vcx-agent --exclude libvdrtools --exclude wallet_migrator --exclude mediator
@@ -297,7 +284,8 @@ jobs:
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
         with:
-          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
       - name: "Run aries-vcx integration tests"
         run: cargo test --manifest-path="aries/aries_vcx/Cargo.toml" -F vdrtools_wallet,credx -- --ignored;
 
@@ -310,7 +298,8 @@ jobs:
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
         with:
-          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
       - name: "Run aries_vcx tests: mysql_test"
         run: cargo test --manifest-path="aries/aries_vcx/Cargo.toml" test_mysql -- --include-ignored;
 
@@ -333,7 +322,8 @@ jobs:
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
         with:
-          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
           skip-vdrproxy-setup: false
       - name: "Run aries_vcx tests: vdrproxy_test"
         run: cargo test --manifest-path="aries/aries_vcx/Cargo.toml" -F vdr_proxy_ledger,credx -- --ignored
@@ -353,7 +343,8 @@ jobs:
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
         with:
-          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
       - name: "Run libvcx_core integration tests"
         run: |
           RUST_TEST_THREADS=1 cargo test --manifest-path="aries/misc/legacy/libvcx_core/Cargo.toml" -- --include-ignored;
@@ -368,7 +359,8 @@ jobs:
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
         with:
-          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
       - name: "Run resolver tests"
         run: |
           cargo test --examples -p did_doc -p did_parser -p did_resolver -p did_resolver_registry -p did_resolver_sov -p did_resolver_web -p did_doc_sov -p did_key -p did_peer --test "*"
@@ -386,7 +378,8 @@ jobs:
       - name: "Setup NodeJS libvcx testing environment"
         uses: ./.github/actions/setup-testing-nodejs
         with:
-          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
           node-version: ${{ matrix.node-version }}
       - name: "Run wrapper integration tests"
         run: (cd aries/wrappers/node && npm run test:integration)
@@ -521,7 +514,8 @@ jobs:
           target: ${{ matrix.settings.target }}
           build: ${{ matrix.settings.build }}
           node-version: ${{ env.NODE_VERSION }}
-          rust-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          rust-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          default: true
 
   publish-napi:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,6 +102,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          default: true
           components: clippy
       - name: "Verify clippy version"
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   push:
     branches:
-      - main
-  pull_request:
-    branches:
       - "**"
 
 env:

--- a/.github/workflows/mediator.pr.yml
+++ b/.github/workflows/mediator.pr.yml
@@ -19,7 +19,7 @@ env:
 
   DOCKER_REPO_LOCAL_VDRPROXY: vdrproxy
 
-  RUST_TOOLCHAIN_VERSON: 1.70.0
+  RUST_TOOLCHAIN_VERSION: 1.70.0
   NODE_VERSION: 18.x
 
 jobs:
@@ -44,7 +44,7 @@ jobs:
       - name: "Setup rust testing environment"
         uses: ./.github/actions/setup-testing-rust
         with:
-          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSON }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
           skip-docker-setup: true
           skip-vdrproxy-setup: true
       - name: Install prerequisites (sqlx)

--- a/aries/aries_vcx/src/global/settings.rs
+++ b/aries/aries_vcx/src/global/settings.rs
@@ -4,6 +4,6 @@ pub static DEFAULT_DID: &str = "2hoqvcwupRTUNkXn6ArYzs";
 pub static DEFAULT_WALLET_BACKUP_KEY: &str = "backup_wallet_key";
 pub static DEFAULT_WALLET_KEY: &str = "8dvfYSt5d1taSd6yJdpjq4emkwsPDDLYxkNFysFD2cZY";
 pub static WALLET_KDF_RAW: &str = "RAW";
-pub static WALLET_KDF_ARGON2I_MOD: &str = "ARGON2I_MOD";
 pub static WALLET_KDF_ARGON2I_INT: &str = "ARGON2I_INT";
+pub static WALLET_KDF_ARGON2I_MOD: &str = "ARGON2I_MOD";
 pub static WALLET_KDF_DEFAULT: &str = WALLET_KDF_ARGON2I_MOD;

--- a/aries/aries_vcx/src/global/settings.rs
+++ b/aries/aries_vcx/src/global/settings.rs
@@ -4,6 +4,6 @@ pub static DEFAULT_DID: &str = "2hoqvcwupRTUNkXn6ArYzs";
 pub static DEFAULT_WALLET_BACKUP_KEY: &str = "backup_wallet_key";
 pub static DEFAULT_WALLET_KEY: &str = "8dvfYSt5d1taSd6yJdpjq4emkwsPDDLYxkNFysFD2cZY";
 pub static WALLET_KDF_RAW: &str = "RAW";
-pub static WALLET_KDF_ARGON2I_INT: &str = "ARGON2I_INT";
 pub static WALLET_KDF_ARGON2I_MOD: &str = "ARGON2I_MOD";
+pub static WALLET_KDF_ARGON2I_INT: &str = "ARGON2I_INT";
 pub static WALLET_KDF_DEFAULT: &str = WALLET_KDF_ARGON2I_MOD;


### PR DESCRIPTION
- It turns out we have to either specify `default` or `override` in `action-rs/toolchain@v1`https://github.com/actions-rs/toolchain?tab=readme-ov-file#inputs  - we did not set these up. As result, we been in fact using latest version of toolchain
- Fixed toolchain version at `1.74.1` which should still pass clippy verification without errors. Update to `1.75.0` triggers some new clippy warnings. 