### PR TITLE
refactor: rename EntryTags to RecordTags

### DIFF
--- a/aries/aries_vcx_core/src/anoncreds/credx_anoncreds/mod.rs
+++ b/aries/aries_vcx_core/src/anoncreds/credx_anoncreds/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     },
     wallet::{
         base_wallet::{record::Record, search_filter::SearchFilter, BaseWallet, RecordWallet},
-        entry_tags::EntryTags,
+        record_tags::RecordTags,
     },
 };
 
@@ -83,7 +83,7 @@ impl RecordWallet for WalletAdapter {
         &self,
         category: &str,
         name: &str,
-        new_tags: EntryTags,
+        new_tags: RecordTags,
     ) -> VcxCoreResult<()> {
         self.0.update_record_tags(category, name, new_tags).await
     }

--- a/aries/aries_vcx_core/src/wallet/agency_client_wallet.rs
+++ b/aries/aries_vcx_core/src/wallet/agency_client_wallet.rs
@@ -12,12 +12,10 @@ use super::{
         did_data::DidData, record::Record, search_filter::SearchFilter, BaseWallet, DidWallet,
         RecordWallet,
     },
+    record_tags::RecordTags,
     structs_io::UnpackMessageOutput,
 };
-use crate::{
-    errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult},
-    wallet::entry_tags::EntryTags,
-};
+use crate::errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult};
 
 #[derive(Debug)]
 pub struct AgencyClientWallet {
@@ -41,7 +39,7 @@ impl RecordWallet for AgencyClientWallet {
         &self,
         category: &str,
         name: &str,
-        new_tags: EntryTags,
+        new_tags: RecordTags,
     ) -> VcxCoreResult<()> {
         Err(unimplemented_agency_client_wallet_method(
             "update_record_tags",

--- a/aries/aries_vcx_core/src/wallet/base_wallet/mod.rs
+++ b/aries/aries_vcx_core/src/wallet/base_wallet/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use public_key::Key;
 
-use super::entry_tags::EntryTags;
+use super::record_tags::RecordTags;
 use crate::{
     errors::error::VcxCoreResult,
     wallet::{
@@ -54,7 +54,7 @@ pub trait RecordWallet {
         &self,
         category: &str,
         name: &str,
-        new_tags: EntryTags,
+        new_tags: RecordTags,
     ) -> VcxCoreResult<()>;
 
     async fn update_record_value(
@@ -82,7 +82,7 @@ mod tests {
         errors::error::AriesVcxCoreErrorKind,
         wallet::{
             base_wallet::{DidWallet, Record, RecordWallet},
-            entry_tags::EntryTags,
+            record_tags::RecordTags,
         },
     };
 
@@ -264,8 +264,8 @@ mod tests {
         let category = "my";
         let value1 = "xxx";
         let value2 = "yyy";
-        let tags1: EntryTags = vec![("a".into(), "b".into())].into();
-        let tags2 = EntryTags::default();
+        let tags1: RecordTags = vec![("a".into(), "b".into())].into();
+        let tags2 = RecordTags::default();
 
         let record = Record::builder()
             .name(name.into())
@@ -297,7 +297,7 @@ mod tests {
         let category = "my";
         let value1 = "xxx";
         let value2 = "yyy";
-        let tags: EntryTags = vec![("a".into(), "b".into())].into();
+        let tags: RecordTags = vec![("a".into(), "b".into())].into();
 
         let record = Record::builder()
             .name(name.into())
@@ -324,8 +324,8 @@ mod tests {
         let name = "foo";
         let category = "my";
         let value = "xxx";
-        let tags1: EntryTags = vec![("a".into(), "b".into())].into();
-        let tags2: EntryTags = vec![("c".into(), "d".into())].into();
+        let tags1: RecordTags = vec![("a".into(), "b".into())].into();
+        let tags2: RecordTags = vec![("c".into(), "d".into())].into();
 
         let record = Record::builder()
             .name(name.into())

--- a/aries/aries_vcx_core/src/wallet/base_wallet/record.rs
+++ b/aries/aries_vcx_core/src/wallet/base_wallet/record.rs
@@ -1,6 +1,6 @@
 use typed_builder::TypedBuilder;
 
-use crate::wallet::entry_tags::EntryTags;
+use crate::wallet::record_tags::RecordTags;
 
 #[derive(Debug, Default, Clone, TypedBuilder)]
 pub struct Record {
@@ -8,7 +8,7 @@ pub struct Record {
     name: String,
     value: String,
     #[builder(default)]
-    tags: EntryTags,
+    tags: RecordTags,
 }
 
 impl Record {
@@ -24,7 +24,7 @@ impl Record {
         &self.category
     }
 
-    pub fn tags(&self) -> &EntryTags {
+    pub fn tags(&self) -> &RecordTags {
         &self.tags
     }
 }

--- a/aries/aries_vcx_core/src/wallet/indy/indy_record_wallet.rs
+++ b/aries/aries_vcx_core/src/wallet/indy/indy_record_wallet.rs
@@ -9,8 +9,8 @@ use crate::{
     errors::error::{AriesVcxCoreError, VcxCoreResult},
     wallet::{
         base_wallet::{record::Record, search_filter::SearchFilter, RecordWallet},
-        entry_tags::EntryTags,
         indy::IndySdkWallet,
+        record_tags::RecordTags,
     },
 };
 
@@ -55,7 +55,7 @@ impl RecordWallet for IndySdkWallet {
         &self,
         category: &str,
         name: &str,
-        new_tags: EntryTags,
+        new_tags: RecordTags,
     ) -> VcxCoreResult<()> {
         Ok(Locator::instance()
             .non_secret_controller

--- a/aries/aries_vcx_core/src/wallet/indy/indy_tags.rs
+++ b/aries/aries_vcx_core/src/wallet/indy/indy_tags.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::wallet::entry_tags::{EntryTag, EntryTags};
+use crate::wallet::record_tags::{RecordTag, RecordTags};
 
 pub(crate) struct IndyTags(HashMap<String, String>);
 
@@ -13,17 +13,17 @@ impl IndyTags {
         self.0
     }
 
-    pub fn from_entry_tags(tags: EntryTags) -> Self {
+    pub fn from_entry_tags(tags: RecordTags) -> Self {
         let mut map = HashMap::new();
         let tags_vec: Vec<_> = tags.into_iter().collect();
         map.extend(tags_vec);
         Self(map)
     }
 
-    pub fn into_entry_tags(self) -> EntryTags {
-        let mut items: Vec<EntryTag> = self.0.into_iter().collect();
+    pub fn into_entry_tags(self) -> RecordTags {
+        let mut items: Vec<RecordTag> = self.0.into_iter().collect();
         items.sort();
 
-        EntryTags::new(items)
+        RecordTags::new(items)
     }
 }

--- a/aries/aries_vcx_core/src/wallet/mock_wallet.rs
+++ b/aries/aries_vcx_core/src/wallet/mock_wallet.rs
@@ -6,12 +6,12 @@ use super::{
         did_data::DidData, record::Record, search_filter::SearchFilter, BaseWallet, DidWallet,
         RecordWallet,
     },
+    record_tags::RecordTags,
     structs_io::UnpackMessageOutput,
 };
 use crate::{
     errors::error::{AriesVcxCoreError, AriesVcxCoreErrorKind, VcxCoreResult},
     utils::{self},
-    wallet::entry_tags::EntryTags,
 };
 
 #[derive(Debug)]
@@ -47,7 +47,7 @@ impl RecordWallet for MockWallet {
         &self,
         category: &str,
         name: &str,
-        new_tags: EntryTags,
+        new_tags: RecordTags,
     ) -> VcxCoreResult<()> {
         Ok(())
     }

--- a/aries/aries_vcx_core/src/wallet/mod.rs
+++ b/aries/aries_vcx_core/src/wallet/mod.rs
@@ -1,7 +1,7 @@
 pub mod agency_client_wallet;
 pub mod base_wallet;
-pub mod entry_tags;
 #[cfg(feature = "vdrtools_wallet")]
 pub mod indy;
 pub mod mock_wallet;
+pub mod record_tags;
 pub mod structs_io;

--- a/aries/aries_vcx_core/src/wallet/record_tags.rs
+++ b/aries/aries_vcx_core/src/wallet/record_tags.rs
@@ -2,14 +2,14 @@ use std::fmt;
 
 use serde::{de::Visitor, ser::SerializeMap, Deserialize, Serialize};
 
-pub(crate) type EntryTag = (String, String);
+pub(crate) type RecordTag = (String, String);
 
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct EntryTags {
-    inner: Vec<EntryTag>,
+pub struct RecordTags {
+    inner: Vec<RecordTag>,
 }
 
-impl Serialize for EntryTags {
+impl Serialize for RecordTags {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -22,10 +22,10 @@ impl Serialize for EntryTags {
     }
 }
 
-struct EntryTagsVisitor;
+struct RecordTagsVisitor;
 
-impl<'de> Visitor<'de> for EntryTagsVisitor {
-    type Value = EntryTags;
+impl<'de> Visitor<'de> for RecordTagsVisitor {
+    type Value = RecordTags;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "a map representing tags")
@@ -35,7 +35,7 @@ impl<'de> Visitor<'de> for EntryTagsVisitor {
     where
         A: serde::de::MapAccess<'de>,
     {
-        let mut tags = EntryTags::new(vec![]);
+        let mut tags = RecordTags::new(vec![]);
 
         while let Some(tag) = map.next_entry()? {
             tags.add(tag);
@@ -45,24 +45,24 @@ impl<'de> Visitor<'de> for EntryTagsVisitor {
     }
 }
 
-impl<'de> Deserialize<'de> for EntryTags {
+impl<'de> Deserialize<'de> for RecordTags {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_map(EntryTagsVisitor)
+        deserializer.deserialize_map(RecordTagsVisitor)
     }
 }
 
-impl EntryTags {
-    pub fn new(inner: Vec<EntryTag>) -> Self {
+impl RecordTags {
+    pub fn new(inner: Vec<RecordTag>) -> Self {
         let mut items = inner;
         items.sort();
 
         Self { inner: items }
     }
 
-    pub fn add(&mut self, tag: EntryTag) {
+    pub fn add(&mut self, tag: RecordTag) {
         self.inner.push(tag);
         self.inner.sort();
     }
@@ -71,23 +71,23 @@ impl EntryTags {
         self.inner.is_empty()
     }
 
-    pub fn into_inner(self) -> Vec<EntryTag> {
+    pub fn into_inner(self) -> Vec<RecordTag> {
         self.inner
     }
 
-    pub fn merge(&mut self, other: EntryTags) {
+    pub fn merge(&mut self, other: RecordTags) {
         self.inner.extend(other.into_inner());
         self.inner.sort();
     }
 
-    pub fn remove(&mut self, tag: EntryTag) {
+    pub fn remove(&mut self, tag: RecordTag) {
         self.inner.retain(|existing_tag| existing_tag.0 != tag.0);
         self.inner.sort();
     }
 }
 
-impl IntoIterator for EntryTags {
-    type Item = EntryTag;
+impl IntoIterator for RecordTags {
+    type Item = RecordTag;
 
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
@@ -96,8 +96,8 @@ impl IntoIterator for EntryTags {
     }
 }
 
-impl FromIterator<EntryTag> for EntryTags {
-    fn from_iter<T: IntoIterator<Item = EntryTag>>(iter: T) -> Self {
+impl FromIterator<RecordTag> for RecordTags {
+    fn from_iter<T: IntoIterator<Item = RecordTag>>(iter: T) -> Self {
         let mut tags = Self::default();
 
         for item in iter {
@@ -107,8 +107,8 @@ impl FromIterator<EntryTag> for EntryTags {
     }
 }
 
-impl From<Vec<EntryTag>> for EntryTags {
-    fn from(value: Vec<EntryTag>) -> Self {
+impl From<Vec<RecordTag>> for RecordTags {
+    fn from(value: Vec<RecordTag>) -> Self {
         value.into_iter().fold(Self::default(), |mut memo, item| {
             memo.add(item);
             memo
@@ -116,8 +116,8 @@ impl From<Vec<EntryTag>> for EntryTags {
     }
 }
 
-impl From<EntryTags> for Vec<EntryTag> {
-    fn from(value: EntryTags) -> Self {
+impl From<RecordTags> for Vec<RecordTag> {
+    fn from(value: RecordTags) -> Self {
         value.inner
     }
 }
@@ -126,11 +126,11 @@ impl From<EntryTags> for Vec<EntryTag> {
 mod tests {
     use serde_json::json;
 
-    use crate::wallet::entry_tags::EntryTags;
+    use crate::wallet::record_tags::RecordTags;
 
     #[test]
     fn test_entry_tags_serialize() {
-        let tags = EntryTags::new(vec![("~a".into(), "b".into()), ("c".into(), "d".into())]);
+        let tags = RecordTags::new(vec![("~a".into(), "b".into()), ("c".into(), "d".into())]);
 
         let res = serde_json::to_string(&tags).unwrap();
 
@@ -141,7 +141,7 @@ mod tests {
     fn test_entry_tags_deserialize() {
         let json = json!({"a":"b", "~c":"d"});
 
-        let tags = EntryTags::new(vec![("a".into(), "b".into()), ("~c".into(), "d".into())]);
+        let tags = RecordTags::new(vec![("a".into(), "b".into()), ("~c".into(), "d".into())]);
 
         let res = serde_json::from_str(&json.to_string()).unwrap();
 

--- a/aries/misc/legacy/libvcx_core/src/api_vcx/api_global/wallet.rs
+++ b/aries/misc/legacy/libvcx_core/src/api_vcx/api_global/wallet.rs
@@ -19,8 +19,8 @@ use aries_vcx::{
 };
 use aries_vcx_core::wallet::{
     base_wallet::{record::Record, DidWallet, RecordWallet},
-    entry_tags::EntryTags,
     indy::IndyWalletRecord,
+    record_tags::RecordTags,
 };
 use futures::FutureExt;
 use public_key::{Key, KeyType};
@@ -186,7 +186,7 @@ pub async fn wallet_add_wallet_record(
     option: Option<&str>,
 ) -> LibvcxResult<()> {
     let wallet = get_main_wallet()?;
-    let tags: Option<EntryTags> = option.map(serde_json::from_str).transpose()?;
+    let tags: Option<RecordTags> = option.map(serde_json::from_str).transpose()?;
 
     let record = if let Some(record_tags) = tags {
         Record::builder()
@@ -234,7 +234,7 @@ pub async fn wallet_add_wallet_record_tags(
     let record = wallet.get_record(xtype, id).await?;
 
     let tags = {
-        let mut tags: EntryTags = serde_json::from_str(tags_json)?;
+        let mut tags: RecordTags = serde_json::from_str(tags_json)?;
         tags.merge(record.tags().clone());
         tags
     };
@@ -248,7 +248,7 @@ pub async fn wallet_delete_wallet_record_tags(
     tags_json: &str,
 ) -> LibvcxResult<()> {
     let wallet = get_main_wallet()?;
-    let tags: EntryTags = serde_json::from_str(tags_json)?;
+    let tags: RecordTags = serde_json::from_str(tags_json)?;
 
     let record = wallet.get_record(xtype, id).await?;
 


### PR DESCRIPTION
Since the tags belong to `Record`, maybe they should be `RecordTags`. Also, https://github.com/hyperledger/aries-vcx/pull/1085 would not need to rename the imports from askar.