### PR TITLE
feat(actions): add input in publish image action and default it to ghcr.io

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -92,3 +92,4 @@ runs:
       with:
         docker-img: ${{ inputs.docker-img }}
         publish-version: ${{ inputs.branch-name }}
+        url-docker-registry: ${{ env.URL_DOCKER_REGISTRY }}

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -28,6 +28,10 @@ inputs:
   skip-build-optimization:
     description: "If set to true, will not try to load image from cache"
     default: false
+  url-docker-registry:
+    description: 'URL of the Docker registry to push the image to'
+    required: false
+    default: 'ghcr.io'
 
 runs:
   using: "composite"
@@ -92,4 +96,4 @@ runs:
       with:
         docker-img: ${{ inputs.docker-img }}
         publish-version: ${{ inputs.branch-name }}
-        url-docker-registry: ${{ env.URL_DOCKER_REGISTRY }}
+        url-docker-registry: ${{ inputs.url-docker-registry }}

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -1,5 +1,5 @@
 name: 'publish-image'
-description: "Given image specified by <docker-img>, retag it to <publish-version> and push to $URL_DOCKER_REGISTRY"
+description: "Given image specified by <docker-img>, retag it to <publish-version> and push to <url-docker-registry>"
 
 inputs:
   docker-img:

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -8,6 +8,10 @@ inputs:
   publish-version:
     description: 'The image will be published as <docker-tag>:<publish-version>'
     required: true
+  url-docker-registry:
+    description: 'URL of the Docker registry to push the image to'
+    required: false
+    default: 'ghcr.io'
 
 runs:
   using: "composite"
@@ -28,7 +32,7 @@ runs:
         IFS=$':' read -a arr <<< ${{ inputs.docker-img }}
         DOCKER_IMG_TAGLESS=${arr[0]}
         GITHUB_REPOSITORY_LOWERCASE=`echo $GITHUB_REPOSITORY | awk '{print tolower($0)}'`
-        REMOTE_DOCKER_IMG_CACHED="${URL_DOCKER_REGISTRY}/${GITHUB_REPOSITORY_LOWERCASE}/${DOCKER_IMG_TAGLESS}:${{ inputs.publish-version }}"
+        REMOTE_DOCKER_IMG_CACHED="${{ inputs.url-docker-registry }}/${GITHUB_REPOSITORY_LOWERCASE}/${DOCKER_IMG_TAGLESS}:${{ inputs.publish-version }}"
         echo "Publishing image $REMOTE_DOCKER_IMG_CACHED"
         docker tag ${{ inputs.docker-img }} "$REMOTE_DOCKER_IMG_CACHED"
         docker push "$REMOTE_DOCKER_IMG_CACHED" || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,6 +219,7 @@ jobs:
         with:
           docker-img: ${{ env.DOCKER_IMG_CACHED }}
           publish-version: ${{ env.PUBLISH_VERSION }}
+          url-docker-registry: ${{ env.URL_DOCKER_REGISTRY }}
 
 #  ##########################################################################################
 #  ###############################    CODECOV    ###########################################

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,6 +190,7 @@ jobs:
           branch-name: ${{ env.BRANCH_NAME }}
           branch-main: ${{ env.MAIN_BRANCH }}
           docker-repo-local-name: ${{ env.DOCKER_REPO_LOCAL_VDRPROXY }}
+          url-docker-registry: ${{ env.URL_DOCKER_REGISTRY }}
 
   ##########################################################################################
   ##############################   DOCKER PUBLISH   ########################################


### PR DESCRIPTION
- Adds `url-docker-registry` input in publish image github action with default value to `ghcr.io`
- Pass parameter where publish image action is called

Closes #1140 

