### PR TITLE
`did:peer:4` integration, bugfix, improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "log",
  "messages",
  "num-bigint",
+ "pretty_assertions",
  "public_key",
  "rand 0.8.5",
  "regex",

--- a/aries/agents/aath-backchannel/src/setup.rs
+++ b/aries/agents/aath-backchannel/src/setup.rs
@@ -65,6 +65,7 @@ async fn download_genesis_file() -> std::result::Result<String, String> {
                 let mut f = std::fs::OpenOptions::new()
                     .write(true)
                     .create(true)
+                    .truncate(true)
                     .open(path.clone())
                     .expect("Unable to open file");
                 f.write_all(body.as_bytes()).expect("Unable to write data");

--- a/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
@@ -16,7 +16,7 @@ use aries_vcx::{
     protocols::did_exchange::{
         resolve_enc_key_from_invitation,
         state_machine::{
-            create_our_did_document,
+            create_peer_did_2,
             generic::{GenericDidExchange, ThinState},
         },
     },
@@ -24,7 +24,6 @@ use aries_vcx::{
     utils::encryption_envelope::EncryptionEnvelope,
 };
 use aries_vcx_core::wallet::base_wallet::BaseWallet;
-use did_peer::peer_did::{numalgos::numalgo2::Numalgo2, PeerDid};
 use did_resolver_registry::ResolverRegistry;
 use did_resolver_sov::did_resolver::did_doc::schema::did_doc::DidDocument;
 use url::Url;
@@ -66,17 +65,16 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
         invitation_id: Option<String>,
     ) -> AgentResult<(String, Option<String>)> {
         // todo: type the return type
-        let (our_did_document, _our_verkey) =
-            create_our_did_document(self.wallet.as_ref(), self.service_endpoint.clone(), vec![])
+        let (our_peer_did_2, _our_verkey) =
+            create_peer_did_2(self.wallet.as_ref(), self.service_endpoint.clone(), vec![])
                 .await?;
 
         let their_did: Did = their_did.parse()?;
-        let our_peer_did = PeerDid::<Numalgo2>::from_did_doc(our_did_document.clone())?;
         let (requester, request) = GenericDidExchange::construct_request(
             self.resolver_registry.clone(),
             invitation_id,
             &their_did,
-            &our_peer_did,
+            &our_peer_did_2,
         )
         .await?;
 
@@ -168,10 +166,9 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
             }
         };
 
-        let (our_did_document, _our_verkey) =
-            create_our_did_document(self.wallet.as_ref(), self.service_endpoint.clone(), vec![])
+        let (peer_did_2_invitee, _our_verkey) =
+            create_peer_did_2(self.wallet.as_ref(), self.service_endpoint.clone(), vec![])
                 .await?;
-        let peer_did_invitee = PeerDid::<Numalgo2>::from_did_doc(our_did_document.clone())?;
 
         let pthid = request
             .clone()
@@ -190,7 +187,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
             self.wallet.as_ref(),
             self.resolver_registry.clone(),
             request,
-            &peer_did_invitee,
+            &peer_did_2_invitee,
             invitation_key,
         )
         .await?;

--- a/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
@@ -65,7 +65,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
         invitation_id: Option<String>,
     ) -> AgentResult<(String, Option<String>)> {
         // todo: type the return type
-        let (our_peer_did_2, _our_verkey) =
+        let (our_peer_did, _our_verkey) =
             create_peer_did_4(self.wallet.as_ref(), self.service_endpoint.clone(), vec![]).await?;
 
         let their_did: Did = their_did.parse()?;
@@ -73,7 +73,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
             self.resolver_registry.clone(),
             invitation_id,
             &their_did,
-            &our_peer_did_2,
+            &our_peer_did,
         )
         .await?;
 
@@ -165,7 +165,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
             }
         };
 
-        let (peer_did_2_invitee, _our_verkey) =
+        let (peer_did_4_invitee, _our_verkey) =
             create_peer_did_4(self.wallet.as_ref(), self.service_endpoint.clone(), vec![]).await?;
 
         let pthid = request
@@ -185,7 +185,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
             self.wallet.as_ref(),
             self.resolver_registry.clone(),
             request,
-            &peer_did_2_invitee,
+            &peer_did_4_invitee,
             invitation_key,
         )
         .await?;

--- a/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
@@ -16,8 +16,8 @@ use aries_vcx::{
     protocols::did_exchange::{
         resolve_enc_key_from_invitation,
         state_machine::{
-            create_peer_did_2,
             generic::{GenericDidExchange, ThinState},
+            helpers::create_peer_did_4,
         },
     },
     transport::Transport,
@@ -66,8 +66,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
     ) -> AgentResult<(String, Option<String>)> {
         // todo: type the return type
         let (our_peer_did_2, _our_verkey) =
-            create_peer_did_2(self.wallet.as_ref(), self.service_endpoint.clone(), vec![])
-                .await?;
+            create_peer_did_4(self.wallet.as_ref(), self.service_endpoint.clone(), vec![]).await?;
 
         let their_did: Did = their_did.parse()?;
         let (requester, request) = GenericDidExchange::construct_request(
@@ -167,8 +166,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
         };
 
         let (peer_did_2_invitee, _our_verkey) =
-            create_peer_did_2(self.wallet.as_ref(), self.service_endpoint.clone(), vec![])
-                .await?;
+            create_peer_did_4(self.wallet.as_ref(), self.service_endpoint.clone(), vec![]).await?;
 
         let pthid = request
             .clone()
@@ -232,7 +230,9 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
 
         let (requester, _) = self.did_exchange.get(&thid)?;
 
-        let (requester, complete) = requester.handle_response(response).await?;
+        let (requester, complete) = requester
+            .handle_response(response, self.resolver_registry.clone())
+            .await?;
         let ddo_their = requester.their_did_doc();
         let ddo_our = requester.our_did_document();
         let service = ddo_their.get_service_of_type(&ServiceType::DIDCommV1)?;

--- a/aries/agents/aries-vcx-agent/src/handlers/out_of_band.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/out_of_band.rs
@@ -12,7 +12,7 @@ use aries_vcx::{
         },
         AriesMessage,
     },
-    protocols::did_exchange::state_machine::create_peer_did_2,
+    protocols::did_exchange::state_machine::helpers::create_peer_did_4,
 };
 use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use url::Url;
@@ -38,12 +38,11 @@ impl<T: BaseWallet> ServiceOutOfBand<T> {
     }
 
     pub async fn create_invitation(&self) -> AgentResult<AriesMessage> {
-        let (peer_did_2, _our_verkey) =
-            create_peer_did_2(self.wallet.as_ref(), self.service_endpoint.clone(), vec![])
-                .await?;
+        let (peer_did, _our_verkey) =
+            create_peer_did_4(self.wallet.as_ref(), self.service_endpoint.clone(), vec![]).await?;
 
         let sender = OutOfBandSender::create()
-            .append_service(&OobService::Did(peer_did_2.to_string()))
+            .append_service(&OobService::Did(peer_did.to_string()))
             .append_handshake_protocol(Protocol::DidExchangeType(DidExchangeType::V1(
                 DidExchangeTypeV1::new_v1_0(),
             )))?;

--- a/aries/agents/aries-vcx-agent/src/handlers/out_of_band.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/out_of_band.rs
@@ -12,10 +12,9 @@ use aries_vcx::{
         },
         AriesMessage,
     },
-    protocols::did_exchange::state_machine::create_our_did_document,
+    protocols::did_exchange::state_machine::create_peer_did_2,
 };
 use aries_vcx_core::wallet::base_wallet::BaseWallet;
-use did_peer::peer_did::{numalgos::numalgo2::Numalgo2, PeerDid};
 use url::Url;
 
 use crate::{
@@ -39,13 +38,12 @@ impl<T: BaseWallet> ServiceOutOfBand<T> {
     }
 
     pub async fn create_invitation(&self) -> AgentResult<AriesMessage> {
-        let (our_did_document, _our_verkey) =
-            create_our_did_document(self.wallet.as_ref(), self.service_endpoint.clone(), vec![])
+        let (peer_did_2, _our_verkey) =
+            create_peer_did_2(self.wallet.as_ref(), self.service_endpoint.clone(), vec![])
                 .await?;
-        let peer_did = PeerDid::<Numalgo2>::from_did_doc(our_did_document)?;
 
         let sender = OutOfBandSender::create()
-            .append_service(&OobService::Did(peer_did.to_string()))
+            .append_service(&OobService::Did(peer_did_2.to_string()))
             .append_handshake_protocol(Protocol::DidExchangeType(DidExchangeType::V1(
                 DidExchangeTypeV1::new_v1_0(),
             )))?;

--- a/aries/aries_vcx/Cargo.toml
+++ b/aries/aries_vcx/Cargo.toml
@@ -81,3 +81,4 @@ test_utils = { path = "../misc/test_utils" }
 wallet_migrator = { path = "../misc/wallet_migrator" }
 async-channel = "1.7.1"
 tokio = { version = "1.20", features = ["rt", "macros", "rt-multi-thread"] }
+pretty_assertions = "1.4.0"

--- a/aries/aries_vcx/src/protocols/did_exchange/state_machine/generic/mod.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/state_machine/generic/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use did_doc::schema::did_doc::DidDocument;
 use did_parser_nom::Did;
-use did_peer::peer_did::{numalgos::numalgo2::Numalgo2, PeerDid};
+use did_peer::peer_did::{numalgos::numalgo4::Numalgo4, PeerDid};
 use did_resolver_registry::ResolverRegistry;
 use messages::msg_fields::protocols::did_exchange::{
     complete::Complete, problem_report::ProblemReport, request::Request, response::Response,
@@ -87,7 +87,7 @@ impl GenericDidExchange {
         resolver_registry: Arc<ResolverRegistry>,
         invitation_id: Option<String>,
         their_did: &Did,
-        our_peer_did: &PeerDid<Numalgo2>,
+        our_peer_did: &PeerDid<Numalgo4>,
     ) -> Result<(Self, Request), AriesVcxError> {
         let TransitionResult { state, output } =
             DidExchangeRequester::<RequestSent>::construct_request(
@@ -107,7 +107,7 @@ impl GenericDidExchange {
         wallet: &impl BaseWallet,
         resolver_registry: Arc<ResolverRegistry>,
         request: Request,
-        our_peer_did: &PeerDid<Numalgo2>,
+        our_peer_did: &PeerDid<Numalgo4>,
         invitation_key: Option<Key>,
     ) -> Result<(Self, Response), AriesVcxError> {
         let TransitionResult { state, output } =
@@ -128,11 +128,15 @@ impl GenericDidExchange {
     pub async fn handle_response(
         self,
         response: Response,
+        resolver_registry: Arc<ResolverRegistry>,
     ) -> Result<(Self, Complete), (Self, AriesVcxError)> {
         match self {
             GenericDidExchange::Requester(requester_state) => match requester_state {
                 RequesterState::RequestSent(request_sent_state) => {
-                    match request_sent_state.receive_response(response).await {
+                    match request_sent_state
+                        .receive_response(response, resolver_registry)
+                        .await
+                    {
                         Ok(TransitionResult { state, output }) => Ok((
                             GenericDidExchange::Requester(RequesterState::Completed(state)),
                             output,

--- a/aries/aries_vcx/src/protocols/did_exchange/state_machine/helpers.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/state_machine/helpers.rs
@@ -88,9 +88,9 @@ pub async fn create_peer_did_4(
     )
     .try_into()?;
 
-    info!("Prepared service for peer:did:2 generation: {} ", service);
+    info!("Prepared service for peer:did:4 generation: {} ", service);
     let vm_ka = DidPeer4VerificationMethod::builder()
-        .id(DidUrl::from_fragment("#key1".to_string())?)
+        .id(DidUrl::from_fragment("key1".to_string())?)
         .verification_method_type(VerificationMethodType::Ed25519VerificationKey2020)
         .public_key(PublicKeyField::Base58 {
             public_key_base58: key_enc.base58(),

--- a/aries/aries_vcx/src/protocols/did_exchange/state_machine/helpers.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/state_machine/helpers.rs
@@ -7,11 +7,17 @@ use did_doc::schema::{
     did_doc::DidDocument,
     service::{service_key_kind::ServiceKeyKind, typed::didcommv1::ServiceDidCommV1, Service},
     types::uri::Uri,
-    verification_method::{PublicKeyField, VerificationMethod, VerificationMethodType},
+    verification_method::{PublicKeyField, VerificationMethodType},
 };
 use did_key::DidKey;
-use did_parser_nom::{Did, DidUrl};
-use did_peer::peer_did::{numalgos::numalgo2::Numalgo2, PeerDid};
+use did_parser_nom::DidUrl;
+use did_peer::peer_did::{
+    numalgos::numalgo4::{
+        construction_did_doc::{DidPeer4ConstructionDidDocument, DidPeer4VerificationMethod},
+        Numalgo4,
+    },
+    PeerDid,
+};
 use messages::{
     decorators::{
         attachment::{Attachment, AttachmentData, AttachmentType},
@@ -26,8 +32,6 @@ use public_key::{Key, KeyType};
 use serde_json::Value;
 use url::Url;
 use uuid::Uuid;
-use did_peer::peer_did::numalgos::numalgo4::encoded_document::{DidPeer4EncodedDocument, DidPeer4VerificationMethod};
-use did_peer::peer_did::numalgos::numalgo4::Numalgo4;
 
 use crate::{
     errors::error::{AriesVcxError, AriesVcxErrorKind},
@@ -37,7 +41,7 @@ use crate::{
     },
 };
 
-pub fn construct_response(
+pub(crate) fn construct_response(
     request_id: String,
     our_did_document: &DidDocument,
     signed_attach: Attachment,
@@ -57,46 +61,12 @@ pub fn construct_response(
         .build()
 }
 
-pub async fn generate_keypair(
+async fn generate_keypair(
     wallet: &impl BaseWallet,
     key_type: KeyType,
 ) -> Result<Key, AriesVcxError> {
     let pairwise_info = PairwiseInfo::create(wallet).await?;
     Ok(Key::from_base58(&pairwise_info.pw_vk, key_type)?)
-}
-
-pub async fn create_peer_did_2(
-    wallet: &impl BaseWallet,
-    service_endpoint: Url,
-    routing_keys: Vec<String>,
-) -> Result<(PeerDid<Numalgo2>, Key), AriesVcxError> {
-    let key_enc = generate_keypair(wallet, KeyType::Ed25519).await?;
-
-    let service: Service = ServiceDidCommV1::new(
-        Uri::new("#0")?,
-        service_endpoint,
-        0,
-        vec![],
-        routing_keys
-            .into_iter()
-            .map(ServiceKeyKind::Value)
-            .collect(),
-    )
-    .try_into()?;
-
-    info!("Prepared service for peer:did:2 generation: {} ", service);
-    let mut did_document = did_doc_from_keys(Default::default(), key_enc.clone(), service)?;
-    info!(
-        "Created did document for peer:did:2 generation: {} ",
-        did_document
-    );
-    let peer_did = PeerDid::<Numalgo2>::from_did_doc(did_document.clone())?;
-    did_document.set_id(peer_did.did().clone());
-
-    let requesters_peer_did = PeerDid::<Numalgo2>::from_did_doc(did_document)?;
-    info!("Created peer did: {requesters_peer_did}");
-
-    Ok((requesters_peer_did, key_enc))
 }
 
 pub async fn create_peer_did_4(
@@ -116,10 +86,9 @@ pub async fn create_peer_did_4(
             .map(ServiceKeyKind::Value)
             .collect(),
     )
-        .try_into()?;
+    .try_into()?;
 
     info!("Prepared service for peer:did:2 generation: {} ", service);
-    let vm_ka_id = DidUrl::from_fragment(key_enc.short_prefixless_fingerprint())?;
     let vm_ka = DidPeer4VerificationMethod::builder()
         .id(DidUrl::from_fragment("#key1".to_string())?)
         .verification_method_type(VerificationMethodType::Ed25519VerificationKey2020)
@@ -127,44 +96,21 @@ pub async fn create_peer_did_4(
             public_key_base58: key_enc.base58(),
         })
         .build();
-    DidPeer4EncodedDocument::builder()
-        .
-
+    let mut construction_did_doc = DidPeer4ConstructionDidDocument::new();
+    construction_did_doc.add_key_agreement(vm_ka);
+    construction_did_doc.add_service(service);
 
     info!(
-        "Created did document for peer:did:2 generation: {} ",
-        did_document
+        "Created did document for peer:did:4 generation: {} ",
+        construction_did_doc
     );
-    let peer_did = PeerDid::<Numalgo2>::from_did_doc(did_document.clone())?;
-    did_document.set_id(peer_did.did().clone());
+    let peer_did = PeerDid::<Numalgo4>::new(construction_did_doc)?;
+    info!("Created peer did: {peer_did}");
 
-    let requesters_peer_did = PeerDid::<Numalgo2>::from_did_doc(did_document)?;
-    info!("Created peer did: {requesters_peer_did}");
-
-    Ok((requesters_peer_did, key_enc))
+    Ok((peer_did, key_enc))
 }
 
-fn did_doc_from_keys(
-    did: Did,
-    key_enc: Key,
-    service: Service,
-) -> Result<DidDocument, AriesVcxError> {
-    let vm_ka_id = DidUrl::from_fragment(key_enc.short_prefixless_fingerprint())?;
-    let vm_ka = VerificationMethod::builder()
-        .id(vm_ka_id)
-        .controller(did.clone())
-        .verification_method_type(VerificationMethodType::Ed25519VerificationKey2020)
-        .public_key(PublicKeyField::Base58 {
-            public_key_base58: key_enc.base58(),
-        })
-        .build();
-    let mut did_doc = DidDocument::new(did);
-    did_doc.add_service(service);
-    did_doc.add_key_agreement(vm_ka);
-    Ok(did_doc)
-}
-
-pub fn ddo_to_attach(ddo: DidDocument) -> Result<Attachment, AriesVcxError> {
+pub(crate) fn ddo_to_attach(ddo: DidDocument) -> Result<Attachment, AriesVcxError> {
     // Interop note: acapy accepts unsigned when using peer dids?
     let content_b64 =
         base64::engine::Engine::encode(&URL_SAFE_NO_PAD, serde_json::to_string(&ddo)?);
@@ -179,7 +125,7 @@ pub fn ddo_to_attach(ddo: DidDocument) -> Result<Attachment, AriesVcxError> {
 
 // TODO: Obviously, extract attachment signing
 // TODO: JWS verification
-pub async fn jws_sign_attach(
+pub(crate) async fn jws_sign_attach(
     mut attach: Attachment,
     verkey: Key,
     wallet: &impl BaseWallet,
@@ -224,7 +170,7 @@ pub async fn jws_sign_attach(
     }
 }
 
-pub fn attachment_to_diddoc(attachment: Attachment) -> Result<DidDocument, AriesVcxError> {
+pub(crate) fn attachment_to_diddoc(attachment: Attachment) -> Result<DidDocument, AriesVcxError> {
     match attachment.data.content {
         AttachmentType::Json(value) => serde_json::from_value(value).map_err(Into::into),
         AttachmentType::Base64(ref value) => {
@@ -245,78 +191,12 @@ pub fn attachment_to_diddoc(attachment: Attachment) -> Result<DidDocument, Aries
     }
 }
 
-pub fn to_transition_error<S, T>(state: S) -> impl FnOnce(T) -> TransitionError<S>
+pub(crate) fn to_transition_error<S, T>(state: S) -> impl FnOnce(T) -> TransitionError<S>
 where
     T: Into<AriesVcxError>,
 {
     move |error| TransitionError {
         error: error.into(),
         state,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use did_doc::schema::{
-        service::typed::ServiceType, utils::OneOrList, verification_method::VerificationMethodKind,
-    };
-
-    use super::*;
-
-    #[tokio::test]
-    async fn test_did_doc_from_keys() {
-        let key_enc = Key::new(
-            "tyntrez7bCthPqvZUDGwhYB1bSe9HzpLdSeHFpuSwst".into(),
-            KeyType::Ed25519,
-        )
-        .unwrap();
-
-        let service_endpoint = Url::parse("http://example.com").unwrap();
-        let routing_keys = vec![
-            ServiceKeyKind::Value("routing_key1".into()),
-            ServiceKeyKind::Value("routing_key2".into()),
-        ];
-        let service: Service = ServiceDidCommV1::new(
-            Uri::new("#service-0").unwrap(),
-            service_endpoint.clone(),
-            0,
-            vec![],
-            routing_keys,
-        )
-        .try_into()
-        .unwrap();
-
-        let did = Did::default();
-
-        let result = did_doc_from_keys(did, key_enc.clone(), service);
-
-        assert!(result.is_ok());
-        let did_doc = result.unwrap();
-
-        assert_eq!(did_doc.service().len(), 1);
-        let ddo_service = did_doc.service().first().unwrap();
-        assert_eq!(&ddo_service.id().to_string(), "#service-0");
-        assert_eq!(
-            ddo_service.service_type(),
-            &OneOrList::One(ServiceType::DIDCommV1)
-        );
-        assert_eq!(ddo_service.service_endpoint(), &service_endpoint);
-        assert_eq!(
-            ddo_service.extra_field_routing_keys().unwrap(),
-            vec![
-                ServiceKeyKind::Value("routing_key1".into()),
-                ServiceKeyKind::Value("routing_key2".into())
-            ]
-        );
-
-        assert_eq!(did_doc.key_agreement().len(), 1);
-        match did_doc.key_agreement().first().unwrap() {
-            VerificationMethodKind::Resolved(key_agreement) => {
-                assert_eq!(key_agreement.public_key().unwrap(), key_enc);
-            }
-            VerificationMethodKind::Resolvable(_) => {
-                panic!("Key agreement was expected to have embedded key");
-            }
-        }
     }
 }

--- a/aries/aries_vcx/src/protocols/did_exchange/state_machine/helpers.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/state_machine/helpers.rs
@@ -26,7 +26,7 @@ use public_key::{Key, KeyType};
 use serde_json::Value;
 use url::Url;
 use uuid::Uuid;
-use did_peer::peer_did::numalgos::numalgo4::encoded_document::DidPeer4VerificationMethod;
+use did_peer::peer_did::numalgos::numalgo4::encoded_document::{DidPeer4EncodedDocument, DidPeer4VerificationMethod};
 use did_peer::peer_did::numalgos::numalgo4::Numalgo4;
 
 use crate::{
@@ -120,17 +120,15 @@ pub async fn create_peer_did_4(
 
     info!("Prepared service for peer:did:2 generation: {} ", service);
     let vm_ka_id = DidUrl::from_fragment(key_enc.short_prefixless_fingerprint())?;
-    let vm_ka = DidPeer4VerificationMethod {
-        id: Default::default(),
-        verification_method_type: VerificationMethodType::JsonWebKey2020,
-        public_key: (),
-    }
-        .add_public_key_base58(key_enc.base58())
+    let vm_ka = DidPeer4VerificationMethod::builder()
+        .id(DidUrl::from_fragment("#key1".to_string())?)
+        .verification_method_type(VerificationMethodType::Ed25519VerificationKey2020)
+        .public_key(PublicKeyField::Base58 {
+            public_key_base58: key_enc.base58(),
+        })
         .build();
-    Ok(DidDocument::builder(did)
-        .add_service(service)
-        .add_key_agreement(vm_ka)
-        .build())
+    DidPeer4EncodedDocument::builder()
+        .
 
 
     info!(

--- a/aries/aries_vcx/src/protocols/did_exchange/state_machine/mod.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/state_machine/mod.rs
@@ -1,4 +1,4 @@
-mod helpers;
+pub mod helpers;
 
 pub mod generic;
 pub mod requester;
@@ -8,7 +8,6 @@ use std::marker::PhantomData;
 
 use chrono::Utc;
 use did_doc::schema::did_doc::DidDocument;
-pub use helpers::{create_peer_did_2, generate_keypair};
 use messages::{
     decorators::{thread::Thread, timing::Timing},
     msg_fields::protocols::did_exchange::problem_report::{

--- a/aries/aries_vcx/src/protocols/did_exchange/state_machine/mod.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/state_machine/mod.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 
 use chrono::Utc;
 use did_doc::schema::did_doc::DidDocument;
-pub use helpers::{create_our_did_document, generate_keypair};
+pub use helpers::{create_peer_did_2, generate_keypair};
 use messages::{
     decorators::{thread::Thread, timing::Timing},
     msg_fields::protocols::did_exchange::problem_report::{

--- a/aries/aries_vcx/src/protocols/did_exchange/state_machine/responder/response_sent/mod.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/state_machine/responder/response_sent/mod.rs
@@ -2,11 +2,7 @@ use std::sync::Arc;
 
 use aries_vcx_core::wallet::base_wallet::BaseWallet;
 use did_doc::schema::did_doc::DidDocument;
-use did_peer::{
-    peer_did::{numalgos::numalgo2::Numalgo2, PeerDid},
-    resolver::options::PublicKeyEncoding,
-};
-use did_peer::peer_did::numalgos::numalgo4::Numalgo4;
+use did_peer::peer_did::{numalgos::numalgo4::Numalgo4, PeerDid};
 use did_resolver_registry::ResolverRegistry;
 use messages::msg_fields::protocols::did_exchange::{
     complete::Complete, request::Request, response::Response,

--- a/aries/aries_vcx/src/protocols/did_exchange/state_machine/responder/response_sent/mod.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/state_machine/responder/response_sent/mod.rs
@@ -6,6 +6,7 @@ use did_peer::{
     peer_did::{numalgos::numalgo2::Numalgo2, PeerDid},
     resolver::options::PublicKeyEncoding,
 };
+use did_peer::peer_did::numalgos::numalgo4::Numalgo4;
 use did_resolver_registry::ResolverRegistry;
 use messages::msg_fields::protocols::did_exchange::{
     complete::Complete, request::Request, response::Response,
@@ -22,7 +23,6 @@ use crate::{
         states::{completed::Completed, responder::response_sent::ResponseSent},
         transition::{transition_error::TransitionError, transition_result::TransitionResult},
     },
-    utils::didcomm_utils::resolve_didpeer2,
 };
 
 impl DidExchangeResponder<ResponseSent> {
@@ -30,7 +30,7 @@ impl DidExchangeResponder<ResponseSent> {
         wallet: &impl BaseWallet,
         resolver_registry: Arc<ResolverRegistry>,
         request: Request,
-        our_peer_did: &PeerDid<Numalgo2>,
+        our_peer_did: &PeerDid<Numalgo4>,
         invitation_key: Option<Key>,
     ) -> Result<TransitionResult<DidExchangeResponder<ResponseSent>, Response>, AriesVcxError> {
         info!(
@@ -39,22 +39,22 @@ impl DidExchangeResponder<ResponseSent> {
             request, our_peer_did, invitation_key
         );
         let their_ddo = resolve_ddo_from_request(&resolver_registry, &request).await?;
-        let our_did_document = resolve_didpeer2(our_peer_did, PublicKeyEncoding::Base58).await?;
+        let our_did_document = our_peer_did.resolve_did_doc()?;
         // TODO: Check amendment made to did-exchange protocol in terms of rotating keys.
         //       When keys are rotated, there's a new decorator which conveys that
         let ddo_attachment_unsigned = ddo_to_attach(our_did_document.clone())?;
         let ddo_attachment = match invitation_key {
             None => {
                 // TODO: not signing if invitation_key is not provided, that would be case for
-                // implicit invitations       However we should probably sign with
-                // the key the request used as recipient_vk to anoncrypt the request
+                //       implicit invitations. However we should probably sign with
+                //       the key the request used as recipient_vk to anoncrypt the request
                 //       So argument "invitation_key" should be required
                 ddo_attachment_unsigned
             }
             Some(invitation_key) => {
                 // TODO: this must happen only if we rotate DID; We currently do that always
                 //       can skip signing if we don't rotate did document (unique p2p invitations
-                // with peer DIDs)
+                //       with peer DIDs)
                 jws_sign_attach(ddo_attachment_unsigned, invitation_key, wallet).await?
             }
         };

--- a/aries/aries_vcx/src/utils/didcomm_utils.rs
+++ b/aries/aries_vcx/src/utils/didcomm_utils.rs
@@ -2,32 +2,9 @@ use did_doc::schema::{
     did_doc::DidDocument, service::service_key_kind::ServiceKeyKind, types::uri::Uri,
     verification_method::VerificationMethodType,
 };
-use did_peer::{
-    peer_did::{numalgos::numalgo2::Numalgo2, PeerDid},
-    resolver::{options::PublicKeyEncoding, PeerDidResolutionOptions, PeerDidResolver},
-};
-use did_resolver::{
-    error::GenericError,
-    traits::resolvable::{resolution_output::DidResolutionOutput, DidResolvable},
-};
 use public_key::Key;
 
 use crate::errors::error::{AriesVcxError, AriesVcxErrorKind, VcxResult};
-
-pub(crate) async fn resolve_didpeer2(
-    did_peer: &PeerDid<Numalgo2>,
-    encoding: PublicKeyEncoding,
-) -> Result<DidDocument, GenericError> {
-    let DidResolutionOutput { did_document, .. } = PeerDidResolver::new()
-        .resolve(
-            did_peer.did(),
-            &PeerDidResolutionOptions {
-                encoding: Some(encoding),
-            },
-        )
-        .await?;
-    Ok(did_document)
-}
 
 fn resolve_service_key_to_typed_key(
     key: &ServiceKeyKind,

--- a/aries/aries_vcx/tests/test_did_exchange.rs
+++ b/aries/aries_vcx/tests/test_did_exchange.rs
@@ -36,10 +36,12 @@ use url::Url;
 use crate::utils::test_agent::{
     create_test_agent, create_test_agent_endorser_2, create_test_agent_trustee,
 };
+use pretty_assertions::assert_eq;
 
 pub mod utils;
 
 fn assert_key_agreement(a: DidDocument, b: DidDocument) {
+    log::warn!("comparing did doc a: {}, b: {}", a, b);
     let a_key = resolve_base58_key_agreement(&a).unwrap();
     let b_key = resolve_base58_key_agreement(&b).unwrap();
     assert_eq!(a_key, b_key);

--- a/aries/aries_vcx/tests/test_did_exchange.rs
+++ b/aries/aries_vcx/tests/test_did_exchange.rs
@@ -30,13 +30,13 @@ use log::info;
 use messages::msg_fields::protocols::out_of_band::invitation::{
     Invitation, InvitationContent, OobService,
 };
+use pretty_assertions::assert_eq;
 use test_utils::devsetup::{dev_build_profile_vdr_ledger, SetupPoolDirectory};
 use url::Url;
 
 use crate::utils::test_agent::{
     create_test_agent, create_test_agent_endorser_2, create_test_agent_trustee,
 };
-use pretty_assertions::assert_eq;
 
 pub mod utils;
 

--- a/aries/misc/legacy/libvdrtools/indy-api-types/src/errors.rs
+++ b/aries/misc/legacy/libvdrtools/indy-api-types/src/errors.rs
@@ -587,7 +587,7 @@ where
 }
 
 thread_local! {
-    pub static CURRENT_ERROR_C_JSON: RefCell<Option<CString>> = RefCell::new(None);
+    pub static CURRENT_ERROR_C_JSON: RefCell<Option<CString>> = const { RefCell::new(None) };
 }
 
 pub fn set_current_error(err: &IndyError) {

--- a/did_core/did_doc/src/schema/did_doc.rs
+++ b/did_core/did_doc/src/schema/did_doc.rs
@@ -77,6 +77,10 @@ impl DidDocument {
         self.verification_method.as_ref()
     }
 
+    pub fn verification_method_by_id(&self, id: &str) -> &VerificationMethod {
+        
+    }
+
     pub fn authentication(&self) -> &[VerificationMethodKind] {
         self.authentication.as_ref()
     }
@@ -131,7 +135,12 @@ impl DidDocument {
         self.verification_method.push(method);
     }
 
-    pub fn add_authentication(&mut self, method: VerificationMethod) {
+    // authentication
+    pub fn add_authentication(&mut self, method: VerificationMethodKind) {
+        self.authentication.push(method);
+    }
+
+    pub fn add_authentication_object(&mut self, method: VerificationMethod) {
         self.authentication
             .push(VerificationMethodKind::Resolved(method));
     }
@@ -141,44 +150,56 @@ impl DidDocument {
             .push(VerificationMethodKind::Resolvable(reference));
     }
 
-    pub fn add_assertion_method(&mut self, method: VerificationMethod) {
-        self.assertion_method
-            .push(VerificationMethodKind::Resolved(method));
+    // assertion
+    pub fn add_assertion_method(&mut self, method: VerificationMethodKind) {
+        self.assertion_method.push(method);
+    }
+
+    pub fn add_assertion_method_object(&mut self, method: VerificationMethod) {
+        self.assertion_method.push(VerificationMethodKind::Resolved(method));
     }
 
     pub fn add_assertion_method_ref(&mut self, reference: DidUrl) {
-        self.assertion_method
-            .push(VerificationMethodKind::Resolvable(reference));
+        self.assertion_method.push(VerificationMethodKind::Resolvable(reference));
     }
 
-    pub fn add_key_agreement(&mut self, method: VerificationMethod) {
-        self.key_agreement
-            .push(VerificationMethodKind::Resolved(method));
+    // key agreement
+    pub fn add_key_agreement(&mut self, method: VerificationMethodKind) {
+        self.key_agreement.push(method);
     }
 
-    pub fn add_key_agreement_ref(&mut self, refernece: DidUrl) {
-        self.key_agreement
-            .push(VerificationMethodKind::Resolvable(refernece));
+    pub fn add_key_agreement_object(&mut self, method: VerificationMethod) {
+        self.key_agreement.push(VerificationMethodKind::Resolved(method));
     }
 
-    pub fn add_capability_invocation(&mut self, method: VerificationMethod) {
-        self.capability_invocation
-            .push(VerificationMethodKind::Resolved(method));
+    pub fn add_key_agreement_ref(&mut self, reference: DidUrl) {
+        self.key_agreement.push(VerificationMethodKind::Resolvable(reference));
+    }
+
+    // capability invocation
+    pub fn add_capability_invocation(&mut self, method: VerificationMethodKind) {
+        self.capability_invocation.push(method);
+    }
+
+    pub fn add_capability_invocation_object(&mut self, method: VerificationMethod) {
+        self.capability_invocation.push(VerificationMethodKind::Resolved(method));
     }
 
     pub fn add_capability_invocation_ref(&mut self, reference: DidUrl) {
-        self.capability_invocation
-            .push(VerificationMethodKind::Resolvable(reference));
+        self.capability_invocation.push(VerificationMethodKind::Resolvable(reference));
     }
 
-    pub fn add_capability_delegation(&mut self, method: VerificationMethod) {
-        self.capability_delegation
-            .push(VerificationMethodKind::Resolved(method));
+    // capability delegation
+    pub fn add_capability_delegation(&mut self, method: VerificationMethodKind) {
+        self.capability_delegation.push(method);
+    }
+
+    pub fn add_capability_delegation_object(&mut self, method: VerificationMethod) {
+        self.capability_delegation.push(VerificationMethodKind::Resolved(method));
     }
 
     pub fn add_capability_delegation_ref(&mut self, reference: DidUrl) {
-        self.capability_delegation
-            .push(VerificationMethodKind::Resolvable(reference));
+        self.capability_delegation.push(VerificationMethodKind::Resolvable(reference));
     }
 
     pub fn set_service(&mut self, services: Vec<Service>) {
@@ -243,19 +264,19 @@ mod tests {
         did_doc.set_controller(OneOrList::One(controller.clone()));
         did_doc.add_verification_method(verification_method.clone());
 
-        did_doc.add_authentication(verification_method.clone());
+        did_doc.add_authentication_object(verification_method.clone());
         did_doc.add_authentication_ref(authentication_reference.clone());
 
-        did_doc.add_assertion_method(assertion_method.clone());
+        did_doc.add_assertion_method_object(assertion_method.clone());
         did_doc.add_assertion_method_ref(authentication_reference.clone());
 
-        did_doc.add_key_agreement(verification_method.clone());
+        did_doc.add_key_agreement_object(verification_method.clone());
         did_doc.add_key_agreement_ref(authentication_reference.clone());
 
-        did_doc.add_capability_invocation(verification_method.clone());
+        did_doc.add_capability_invocation_object(verification_method.clone());
         did_doc.add_capability_invocation_ref(authentication_reference.clone());
 
-        did_doc.add_capability_delegation(verification_method.clone());
+        did_doc.add_capability_delegation_object(verification_method.clone());
         did_doc.add_capability_delegation_ref(authentication_reference.clone());
 
         did_doc.set_service(vec![service.clone()])

--- a/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo2/encoding.rs
+++ b/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo2/encoding.rs
@@ -181,7 +181,7 @@ mod tests {
         );
 
         let mut did_document = DidDocument::new(Did::parse(did_full.clone()).unwrap());
-        did_document.add_key_agreement(vm_0);
+        did_document.add_key_agreement_object(vm_0);
         did_document.add_verification_method(vm_1);
 
         let did = append_encoded_key_segments(did.to_string(), &did_document).unwrap();
@@ -241,7 +241,7 @@ mod tests {
         );
 
         let mut did_document = DidDocument::new(did_full.parse().unwrap());
-        did_document.add_key_agreement(vm);
+        did_document.add_key_agreement_object(vm);
 
         let result = append_encoded_key_segments(did.to_string(), &did_document);
         assert!(result.is_err());
@@ -275,8 +275,8 @@ mod tests {
         );
 
         let mut did_document = DidDocument::new(did_full.parse().unwrap());
-        did_document.add_assertion_method(vm_0);
-        did_document.add_key_agreement(vm_1);
+        did_document.add_assertion_method_object(vm_0);
+        did_document.add_key_agreement_object(vm_1);
         did_document.add_verification_method(vm_2);
 
         let did = append_encoded_key_segments(did.to_string(), &did_document).unwrap();

--- a/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo2/helpers.rs
+++ b/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo2/helpers.rs
@@ -93,16 +93,16 @@ fn add_key_from_element(
     for vm in vms.into_iter() {
         match purpose {
             ElementPurpose::Assertion => {
-                did_doc.add_assertion_method(vm);
+                did_doc.add_assertion_method_object(vm);
             }
             ElementPurpose::Encryption => {
-                did_doc.add_key_agreement(vm);
+                did_doc.add_key_agreement_object(vm);
             }
             ElementPurpose::Verification => {
                 did_doc.add_verification_method(vm);
             }
-            ElementPurpose::CapabilityInvocation => did_doc.add_capability_invocation(vm),
-            ElementPurpose::CapabilityDelegation => did_doc.add_capability_delegation(vm),
+            ElementPurpose::CapabilityInvocation => did_doc.add_capability_invocation_object(vm),
+            ElementPurpose::CapabilityDelegation => did_doc.add_capability_delegation_object(vm),
             _ => return Err(DidPeerError::UnsupportedPurpose(purpose.into())),
         }
     }

--- a/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
+++ b/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
@@ -92,7 +92,7 @@ impl DidPeer4ConstructionDidDocument {
         }
         let did_short_form = did_peer_4.short_form().to_string();
         let did_as_uri = Uri::new(&did_short_form)
-            .expect(&format!("DID or URI implementation is buggy, because DID {} failed to be parsed as URI, but per spec: The generic DID scheme is a URI scheme conformant with [RFC3986].", did_short_form));
+            .unwrap_or_else(|_| panic!("DID or URI implementation is buggy, because DID {} failed to be parsed as URI, but per spec: The generic DID scheme is a URI scheme conformant with [RFC3986].", did_short_form));
         did_doc.add_also_known_as(did_as_uri);
         did_doc
     }

--- a/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
+++ b/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
@@ -90,6 +90,10 @@ impl DidPeer4ConstructionDidDocument {
         for vm in &self.capability_invocation {
             did_doc.add_capability_invocation(vm.contextualize(did_peer_4))
         }
+        let did_short_form = did_peer_4.short_form().to_string();
+        let did_as_uri = Uri::new(&did_short_form)
+            .expect(&format!("DID or URI implementation is buggy, because DID {} failed to be parsed as URI, but per spec: The generic DID scheme is a URI scheme conformant with [RFC3986].", did_short_form));
+        did_doc.add_also_known_as(did_as_uri);
         did_doc
     }
 
@@ -226,7 +230,7 @@ impl DidPeer4VerificationMethod {
     pub(crate) fn contextualize(&self, did_peer_4: &PeerDid<Numalgo4>) -> VerificationMethod {
         VerificationMethod::builder()
             .id(self.id.clone())
-            .controller(did_peer_4.did().clone())
+            .controller(did_peer_4.short_form().clone())
             .verification_method_type(self.verification_method_type)
             .public_key(self.public_key.clone())
             .build()

--- a/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
+++ b/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
@@ -90,11 +90,14 @@ impl DidPeer4ConstructionDidDocument {
         for vm in &self.capability_invocation {
             did_doc.add_capability_invocation(vm.contextualize(did_peer_4))
         }
+        // ** safety note (panic) **
+        // Formally every DID is URI. Assuming the parsers for both DID and URI correctly
+        // implement   respective specs, this will never panic.
         let did_short_form = did_peer_4.short_form().to_string();
         let did_as_uri = Uri::new(&did_short_form).unwrap_or_else(|_| {
             panic!(
-                "DID or URI implementation is buggy, because DID {} failed to be parsed as URI, \
-                 but per spec: The generic DID scheme is a URI scheme conformant with [RFC3986].",
+                "DID or URI implementation is buggy, because DID {} failed to be parsed as URI. \
+                 This counters W3C DID-CORE spec which states that \"DIDs are URIs\" [RFC3986].",
                 did_short_form
             )
         });

--- a/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
+++ b/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
@@ -91,8 +91,13 @@ impl DidPeer4ConstructionDidDocument {
             did_doc.add_capability_invocation(vm.contextualize(did_peer_4))
         }
         let did_short_form = did_peer_4.short_form().to_string();
-        let did_as_uri = Uri::new(&did_short_form)
-            .unwrap_or_else(|_| panic!("DID or URI implementation is buggy, because DID {} failed to be parsed as URI, but per spec: The generic DID scheme is a URI scheme conformant with [RFC3986].", did_short_form));
+        let did_as_uri = Uri::new(&did_short_form).unwrap_or_else(|_| {
+            panic!(
+                "DID or URI implementation is buggy, because DID {} failed to be parsed as URI, \
+                 but per spec: The generic DID scheme is a URI scheme conformant with [RFC3986].",
+                did_short_form
+            )
+        });
         did_doc.add_also_known_as(did_as_uri);
         did_doc
     }

--- a/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
+++ b/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/construction_did_doc.rs
@@ -75,6 +75,21 @@ impl DidPeer4ConstructionDidDocument {
         for vm in &self.verification_method {
             did_doc.add_verification_method(vm.contextualize(did_peer_4));
         }
+        for vm in &self.key_agreement {
+            did_doc.add_key_agreement(vm.contextualize(did_peer_4))
+        }
+        for vm in &self.authentication {
+            did_doc.add_authentication(vm.contextualize(did_peer_4))
+        }
+        for vm in &self.assertion_method {
+            did_doc.add_assertion_method(vm.contextualize(did_peer_4))
+        }
+        for vm in &self.capability_delegation {
+            did_doc.add_capability_delegation(vm.contextualize(did_peer_4))
+        }
+        for vm in &self.capability_invocation {
+            did_doc.add_capability_invocation(vm.contextualize(did_peer_4))
+        }
         did_doc
     }
 

--- a/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/mod.rs
+++ b/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo4/mod.rs
@@ -59,9 +59,9 @@ impl PeerDid<Numalgo4> {
             DidPeerError::GeneralError(format!("Failed to parse short form of PeerDid: {}", e))
         });
         // Safety note:
-        // - This should never throw, because we are working with <self> DID which has already be parsed
-        //   and its ID portion is ought to be valid DID ID.
-        //   If we then append this valid ID to the "did:peer:" prefix, the resulting DID should be valid as well.
+        // - This should never throw, because we are working with <self> DID which has already be
+        //   parsed and its ID portion is ought to be valid DID ID. If we then append this valid ID
+        //   to the "did:peer:" prefix, the resulting DID should be valid as well.
         parse_result.expect("Failed to parse short form of PeerDid")
     }
 
@@ -162,7 +162,10 @@ mod tests {
         assert_eq!(did.to_string(), did_expected);
 
         let resolved_did_doc = did.resolve_did_doc().unwrap();
-        println!("resolved document: {}", serde_json::to_string_pretty(&resolved_did_doc).unwrap());
+        println!(
+            "resolved document: {}",
+            serde_json::to_string_pretty(&resolved_did_doc).unwrap()
+        );
         assert_eq!(resolved_did_doc.id().to_string(), did.did().to_string());
         assert!(resolved_did_doc
             .verification_method_by_id("shared-key-1")


### PR DESCRIPTION
- Use `did:peer:4` in didexchange (produce `did:peer:4` in outgoing messages for both requester and responder)
  - Still supports counterparty using ptentially `did:peer:2` (well, or any other DID method we support)

Additional updates:
- New get APIs for `DidDocument`: 
  - `assertion_method_by_key(&self, id: &str)`
  - `verification_method_by_id(&self, id: &str)`
  - `key_agreement_by_id(&self, id: &str)`
  - `capability_invocation_by_id(&self, id: &str)`
  - `capability_delegation_by_id(&self, id: &str)`
- New update APIs for `DidDocument`, generally following pattern:
  - `add_authentication(&mut self, method: VerificationMethodKind)`
  - `add_authentication_object(&mut self, method: VerificationMethod)`
  - `add_authentication_ref(&mut self, reference: DidUrl)`

Fixes
- Fix bug on `contextualize_to_did_doc` which causes `did:peer:4` to not fully decode

Error handling changes
- `PeerDid<Numalgo4>::short_form(&self)` does not return `Result`, but instead uses `expect()` which should never happens (see safety note in the code). 
- `DidPeer4ConstructionDidDocument::contextualize_to_did_doc(&self, did_peer_4: &PeerDid<Numalgo4>)` is now also using `panic` upon conversion of DID type to URI type. Every DID is URI and therefore this should never panic. If panic occurs, it strictly indicates either:
  - buggy DID parsing (something that is not actually DID was parsed as a DID)
  - buggy URI parsing (something that is URI fails to be parsed as URI)