### PR TITLE
refactor: improve didcore VerificationMethod in-memory representation

### DIFF
--- a/did_core/did_doc/Cargo.toml
+++ b/did_core/did_doc/Cargo.toml
@@ -10,7 +10,7 @@ did_parser_nom = { path = "../did_parser_nom" }
 public_key = { path = "../public_key" }
 hex = "0.4.3"
 multibase = "0.9.1"
-pem = "2.0.1"
+pem = { version = "2.0.1", features = ["serde"] }
 serde = { version = "1.0.159", default-features = false, features = ["derive"] }
 serde_json = "1.0.95"
 uniresid = { version = "0.1.4", default-features = false, features = ["serde"] }

--- a/did_core/did_doc/src/schema/legacy.rs
+++ b/did_core/did_doc/src/schema/legacy.rs
@@ -10,6 +10,8 @@ use crate::schema::{
     verification_method::{VerificationMethod, VerificationMethodType},
 };
 
+use super::verification_method::PublicKeyFormat;
+
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, display_as_json::Display)]
 #[serde(deny_unknown_fields)]
 pub struct LegacyDidDoc {
@@ -162,8 +164,9 @@ fn construct_new_did_document(
                 id,
                 did.clone(),
                 VerificationMethodType::Ed25519VerificationKey2018,
+                PublicKeyFormat::Multibase(multibase::Base::Base58Btc),
             )
-            .add_public_key_multibase(fingerprint.clone())
+            .add_public_key(fingerprint.clone().as_bytes().to_vec())
             .build(),
         );
     }

--- a/did_core/did_doc/src/schema/verification_method/mod.rs
+++ b/did_core/did_doc/src/schema/verification_method/mod.rs
@@ -3,16 +3,29 @@ pub mod public_key;
 mod verification_method_kind;
 mod verification_method_type;
 
+use crate::serde::ser::SerializeStruct;
 use ::public_key::Key;
 use did_parser_nom::{Did, DidUrl};
 use serde::{Deserialize, Serialize};
 pub use verification_method_kind::VerificationMethodKind;
 pub use verification_method_type::VerificationMethodType;
 
-pub use self::public_key::PublicKeyField;
-use crate::{error::DidDocumentBuilderError, schema::types::jsonwebkey::JsonWebKey};
+// pub use self::public_key::PublicKeyField;
+use crate::error::DidDocumentBuilderError;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum PublicKeyFormat {
+    Multibase(multibase::Base),
+    Jwk,
+    #[default]
+    Base58,
+    Base64,
+    Hex,
+    Pem,
+    Pgp,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct VerificationMethod {
     id: DidUrl,
@@ -20,7 +33,59 @@ pub struct VerificationMethod {
     #[serde(rename = "type")]
     verification_method_type: VerificationMethodType,
     #[serde(flatten)]
-    public_key: PublicKeyField,
+    public_key: Vec<u8>,
+    #[serde(skip)]
+    public_key_format: PublicKeyFormat,
+}
+
+impl Serialize for VerificationMethod {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("VerificationMethod", 4)?;
+        state.serialize_field("id", &self.id)?;
+        state.serialize_field("controller", &self.controller)?;
+        state.serialize_field("type", &self.verification_method_type)?;
+
+        use serde::ser::Error;
+        match self.public_key_format {
+            PublicKeyFormat::Multibase(base) => state.serialize_field(
+                "publicKeyMultibase",
+                &multibase::encode(base, &self.public_key),
+            )?,
+            PublicKeyFormat::Jwk => {
+                let res: String = serde_json::from_slice(&self.public_key)
+                    .map_err(|_| Error::custom("failed to serialize JWK key"))?;
+
+                state.serialize_field("publicKeyJwk", &res)?
+            }
+            PublicKeyFormat::Base58 => {
+                state.serialize_field(
+                    "publicKeyBase58",
+                    &bs58::encode(&self.public_key).into_vec(),
+                )?;
+            }
+            PublicKeyFormat::Base64 => {
+                use base64::engine::general_purpose::STANDARD as BASE64;
+                use base64::engine::Engine as _;
+
+                state.serialize_field("publicKeyBase64", &BASE64.encode(&self.public_key))?;
+            }
+            PublicKeyFormat::Hex => {
+                state.serialize_field("publicKeyHex", &hex::encode(&self.public_key))?
+            }
+            PublicKeyFormat::Pem => {
+                let res = pem::parse(&self.public_key)
+                    .map_err(|_| Error::custom("failed to serialize PEM key"))?;
+
+                state.serialize_field("publicKeyPem", &res)?;
+            }
+            PublicKeyFormat::Pgp => return Err(Error::custom("PGP key is not supported")),
+        }
+
+        state.end()
+    }
 }
 
 impl VerificationMethod {
@@ -28,8 +93,14 @@ impl VerificationMethod {
         id: DidUrl,
         controller: Did,
         verification_method_type: VerificationMethodType,
+        public_key_format: PublicKeyFormat,
     ) -> IncompleteVerificationMethodBuilder {
-        IncompleteVerificationMethodBuilder::new(id, controller, verification_method_type)
+        IncompleteVerificationMethodBuilder::new(
+            id,
+            controller,
+            verification_method_type,
+            public_key_format,
+        )
     }
 
     pub fn id(&self) -> &DidUrl {
@@ -44,13 +115,17 @@ impl VerificationMethod {
         &self.verification_method_type
     }
 
-    pub fn public_key_field(&self) -> &PublicKeyField {
+    pub fn public_key_format(&self) -> &PublicKeyFormat {
+        &self.public_key_format
+    }
+
+    pub fn public_key_field(&self) -> &[u8] {
         &self.public_key
     }
 
     pub fn public_key(&self) -> Result<Key, DidDocumentBuilderError> {
         Ok(Key::new(
-            self.public_key.key_decoded()?,
+            self.public_key.clone(),
             self.verification_method_type.try_into()?,
         )?)
     }
@@ -61,6 +136,7 @@ pub struct IncompleteVerificationMethodBuilder {
     id: DidUrl,
     controller: Did,
     verification_method_type: VerificationMethodType,
+    public_key_format: PublicKeyFormat,
 }
 
 #[derive(Debug, Clone)]
@@ -68,7 +144,8 @@ pub struct CompleteVerificationMethodBuilder {
     id: DidUrl,
     controller: Did,
     verification_method_type: VerificationMethodType,
-    public_key: Option<PublicKeyField>,
+    public_key_format: PublicKeyFormat,
+    public_key: Option<Vec<u8>>,
 }
 
 impl IncompleteVerificationMethodBuilder {
@@ -76,93 +153,93 @@ impl IncompleteVerificationMethodBuilder {
         id: DidUrl,
         controller: Did,
         verification_method_type: VerificationMethodType,
+        public_key_format: PublicKeyFormat,
     ) -> Self {
         Self {
             id,
             verification_method_type,
             controller,
+            public_key_format,
         }
     }
 
-    pub fn add_public_key_field(
-        self,
-        public_key: PublicKeyField,
-    ) -> CompleteVerificationMethodBuilder {
+    pub fn add_public_key(self, public_key: Vec<u8>) -> CompleteVerificationMethodBuilder {
         CompleteVerificationMethodBuilder {
             id: self.id,
             controller: self.controller,
             verification_method_type: self.verification_method_type,
             public_key: Some(public_key),
+            public_key_format: self.public_key_format,
         }
     }
 
-    pub fn add_public_key_multibase(
-        self,
-        public_key_multibase: String,
-    ) -> CompleteVerificationMethodBuilder {
-        CompleteVerificationMethodBuilder {
-            id: self.id,
-            controller: self.controller,
-            verification_method_type: self.verification_method_type,
-            public_key: Some(PublicKeyField::Multibase {
-                public_key_multibase,
-            }),
-        }
-    }
+    // pub fn add_public_key_multibase(
+    //     self,
+    //     public_key_multibase: String,
+    // ) -> CompleteVerificationMethodBuilder {
+    //     CompleteVerificationMethodBuilder {
+    //         id: self.id,
+    //         controller: self.controller,
+    //         verification_method_type: self.verification_method_type,
+    //         public_key: Some(PublicKeyField::Multibase {
+    //             public_key_multibase,
+    //         }),
+    //     }
+    // }
 
-    pub fn add_public_key_jwk(
-        self,
-        public_key_jwk: JsonWebKey,
-    ) -> CompleteVerificationMethodBuilder {
-        CompleteVerificationMethodBuilder {
-            id: self.id,
-            controller: self.controller,
-            verification_method_type: self.verification_method_type,
-            public_key: Some(PublicKeyField::Jwk { public_key_jwk }),
-        }
-    }
+    // pub fn add_public_key_jwk(
+    //     self,
+    //     public_key_jwk: JsonWebKey,
+    // ) -> CompleteVerificationMethodBuilder {
+    //     CompleteVerificationMethodBuilder {
+    //         id: self.id,
+    //         controller: self.controller,
+    //         verification_method_type: self.verification_method_type,
+    //         public_key: Some(PublicKeyField::Jwk { public_key_jwk }),
+    //     }
+    // }
 
-    pub fn add_public_key_base58(
-        self,
-        public_key_base58: String,
-    ) -> CompleteVerificationMethodBuilder {
-        CompleteVerificationMethodBuilder {
-            id: self.id,
-            controller: self.controller,
-            verification_method_type: self.verification_method_type,
-            public_key: Some(PublicKeyField::Base58 { public_key_base58 }),
-        }
-    }
+    // pub fn add_public_key_base58(
+    //     self,
+    //     public_key_base58: String,
+    // ) -> CompleteVerificationMethodBuilder {
+    //     CompleteVerificationMethodBuilder {
+    //         id: self.id,
+    //         controller: self.controller,
+    //         verification_method_type: self.verification_method_type,
+    //         public_key: Some(PublicKeyField::Base58 { public_key_base58 }),
+    //     }
+    // }
 
-    pub fn add_public_key_base64(
-        self,
-        public_key_base64: String,
-    ) -> CompleteVerificationMethodBuilder {
-        CompleteVerificationMethodBuilder {
-            id: self.id,
-            controller: self.controller,
-            verification_method_type: self.verification_method_type,
-            public_key: Some(PublicKeyField::Base64 { public_key_base64 }),
-        }
-    }
+    // pub fn add_public_key_base64(
+    //     self,
+    //     public_key_base64: String,
+    // ) -> CompleteVerificationMethodBuilder {
+    //     CompleteVerificationMethodBuilder {
+    //         id: self.id,
+    //         controller: self.controller,
+    //         verification_method_type: self.verification_method_type,
+    //         public_key: Some(PublicKeyField::Base64 { public_key_base64 }),
+    //     }
+    // }
 
-    pub fn add_public_key_hex(self, public_key_hex: String) -> CompleteVerificationMethodBuilder {
-        CompleteVerificationMethodBuilder {
-            id: self.id,
-            controller: self.controller,
-            verification_method_type: self.verification_method_type,
-            public_key: Some(PublicKeyField::Hex { public_key_hex }),
-        }
-    }
+    // pub fn add_public_key_hex(self, public_key_hex: String) -> CompleteVerificationMethodBuilder {
+    //     CompleteVerificationMethodBuilder {
+    //         id: self.id,
+    //         controller: self.controller,
+    //         verification_method_type: self.verification_method_type,
+    //         public_key: Some(PublicKeyField::Hex { public_key_hex }),
+    //     }
+    // }
 
-    pub fn add_public_key_pem(self, public_key_pem: String) -> CompleteVerificationMethodBuilder {
-        CompleteVerificationMethodBuilder {
-            id: self.id,
-            controller: self.controller,
-            verification_method_type: self.verification_method_type,
-            public_key: Some(PublicKeyField::Pem { public_key_pem }),
-        }
-    }
+    // pub fn add_public_key_pem(self, public_key_pem: String) -> CompleteVerificationMethodBuilder {
+    //     CompleteVerificationMethodBuilder {
+    //         id: self.id,
+    //         controller: self.controller,
+    //         verification_method_type: self.verification_method_type,
+    //         public_key: Some(PublicKeyField::Pem { public_key_pem }),
+    //     }
+    // }
 }
 
 impl CompleteVerificationMethodBuilder {
@@ -171,6 +248,7 @@ impl CompleteVerificationMethodBuilder {
             id: self.id,
             controller: self.controller,
             verification_method_type: self.verification_method_type,
+            public_key_format: self.public_key_format,
             public_key: self.public_key.unwrap(), /* SAFETY: The builder will always set the
                                                    * public key */
         }
@@ -193,6 +271,10 @@ mod tests {
 
     fn create_valid_multibase() -> String {
         "zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e".to_string()
+    }
+
+    fn create_valid_multibase_kind() -> multibase::Base {
+        multibase::Base::Base58Btc
     }
 
     fn create_valid_verification_key_type() -> VerificationMethodType {
@@ -227,10 +309,14 @@ mod tests {
         let id = create_valid_did_url();
         let controller = create_valid_did();
         let verification_method_type = create_valid_verification_key_type();
-        let verification_method =
-            VerificationMethod::builder(id.clone(), controller, verification_method_type)
-                .add_public_key_multibase(create_valid_multibase())
-                .build();
+        let verification_method = VerificationMethod::builder(
+            id.clone(),
+            controller,
+            verification_method_type,
+            PublicKeyFormat::Multibase(multibase::Base::Base58Btc),
+        )
+        .add_public_key(create_valid_multibase().as_bytes().to_vec())
+        .build();
         assert_eq!(verification_method.id(), &id);
     }
 
@@ -241,19 +327,21 @@ mod tests {
         let verification_method_type = create_valid_verification_key_type();
         let public_key_multibase = create_valid_multibase();
 
-        let vm =
-            VerificationMethod::builder(id.clone(), controller.clone(), verification_method_type)
-                .add_public_key_multibase(public_key_multibase)
-                .build();
+        let vm = VerificationMethod::builder(
+            id.clone(),
+            controller.clone(),
+            verification_method_type,
+            PublicKeyFormat::Multibase(multibase::Base::Base58Btc),
+        )
+        .add_public_key(public_key_multibase.as_bytes().to_vec())
+        .build();
 
         assert_eq!(vm.id(), &id);
         assert_eq!(vm.controller(), &controller);
         assert_eq!(vm.verification_method_type(), &verification_method_type);
-        match vm.public_key_field() {
-            PublicKeyField::Multibase {
-                public_key_multibase,
-            } => {
-                assert_eq!(public_key_multibase, public_key_multibase)
+        match vm.public_key_format() {
+            &PublicKeyFormat::Multibase(_) => {
+                assert_eq!(vm.public_key_field(), public_key_multibase.as_bytes())
             }
             _ => panic!("Expected public key to be multibase"),
         }
@@ -266,19 +354,21 @@ mod tests {
         let verification_method_type = create_valid_verification_key_type();
         let public_key_multibase = create_valid_multibase();
 
-        let vm =
-            VerificationMethod::builder(id.clone(), controller.clone(), verification_method_type)
-                .add_public_key_multibase(public_key_multibase)
-                .build();
+        let vm = VerificationMethod::builder(
+            id.clone(),
+            controller.clone(),
+            verification_method_type,
+            PublicKeyFormat::Multibase(multibase::Base::Base58Btc),
+        )
+        .add_public_key(public_key_multibase.into())
+        .build();
 
         assert_eq!(vm.id(), &id);
         assert_eq!(vm.controller(), &controller);
         assert_eq!(vm.verification_method_type(), &verification_method_type);
-        match vm.public_key_field() {
-            PublicKeyField::Multibase {
-                public_key_multibase,
-            } => {
-                assert_eq!(public_key_multibase, public_key_multibase)
+        match vm.public_key_format() {
+            &PublicKeyFormat::Multibase(_) => {
+                assert_eq!(vm.public_key_field(), public_key_multibase.as_bytes())
             }
             _ => panic!("Expected public key to be multibase"),
         }
@@ -311,17 +401,20 @@ mod tests {
         let verification_method_type = create_valid_verification_key_type();
         let public_key_multibase_expected = create_valid_multibase();
 
-        let vm = VerificationMethod::builder(id, controller, verification_method_type)
-            .add_public_key_multibase(public_key_multibase_expected.clone())
-            .build();
+        let vm = VerificationMethod::builder(
+            id,
+            controller,
+            verification_method_type,
+            PublicKeyFormat::Multibase(multibase::Base::Base58Btc),
+        )
+        .add_public_key(public_key_multibase_expected.clone().into())
+        .build();
 
-        match vm.public_key_field() {
-            PublicKeyField::Multibase {
-                public_key_multibase,
-            } => {
+        match vm.public_key_format() {
+            &PublicKeyFormat::Multibase(_) => {
                 assert_eq!(
-                    public_key_multibase.to_string(),
-                    public_key_multibase_expected
+                    vm.public_key_field(),
+                    public_key_multibase_expected.as_bytes()
                 )
             }
             _ => panic!("Expected public key to be multibase"),

--- a/did_core/did_doc/src/schema/verification_method/public_key.rs
+++ b/did_core/did_doc/src/schema/verification_method/public_key.rs
@@ -1,148 +1,148 @@
-use std::str::FromStr;
+// use std::str::FromStr;
 
-use base64::{engine::general_purpose, Engine};
-use serde::{Deserialize, Serialize};
+// use base64::{engine::general_purpose, Engine};
+// use serde::{Deserialize, Serialize};
 
-use crate::schema::{
-    types::{jsonwebkey::JsonWebKey, multibase::Multibase},
-    verification_method::error::KeyDecodingError,
-};
+// use crate::schema::{
+//     types::{jsonwebkey::JsonWebKey, multibase::Multibase},
+//     verification_method::error::KeyDecodingError,
+// };
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
-pub enum PublicKeyField {
-    #[serde(rename_all = "camelCase")]
-    Multibase { public_key_multibase: String },
-    #[serde(rename_all = "camelCase")]
-    Jwk { public_key_jwk: JsonWebKey },
-    #[serde(rename_all = "camelCase")]
-    Base58 { public_key_base58: String },
-    #[serde(rename_all = "camelCase")]
-    Base64 { public_key_base64: String },
-    #[serde(rename_all = "camelCase")]
-    Hex { public_key_hex: String },
-    #[serde(rename_all = "camelCase")]
-    Pem { public_key_pem: String },
-    #[serde(rename_all = "camelCase")]
-    Pgp { public_key_pgp: String },
-}
+// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+// #[serde(untagged)]
+// #[serde(deny_unknown_fields)]
+// pub enum PublicKeyField {
+//     #[serde(rename_all = "camelCase")]
+//     Multibase { public_key_multibase: String },
+//     #[serde(rename_all = "camelCase")]
+//     Jwk { public_key_jwk: JsonWebKey },
+//     #[serde(rename_all = "camelCase")]
+//     Base58 { public_key_base58: String },
+//     #[serde(rename_all = "camelCase")]
+//     Base64 { public_key_base64: String },
+//     #[serde(rename_all = "camelCase")]
+//     Hex { public_key_hex: String },
+//     #[serde(rename_all = "camelCase")]
+//     Pem { public_key_pem: String },
+//     #[serde(rename_all = "camelCase")]
+//     Pgp { public_key_pgp: String },
+// }
 
-impl PublicKeyField {
-    pub fn key_decoded(&self) -> Result<Vec<u8>, KeyDecodingError> {
-        match self {
-            PublicKeyField::Multibase {
-                public_key_multibase,
-            } => {
-                let multibase = Multibase::from_str(public_key_multibase)?;
-                Ok(multibase.as_ref().to_vec())
-            }
-            PublicKeyField::Jwk { public_key_jwk } => Ok(public_key_jwk.to_vec()?),
-            PublicKeyField::Base58 { public_key_base58 } => {
-                Ok(bs58::decode(public_key_base58).into_vec()?)
-            }
-            PublicKeyField::Base64 { public_key_base64 } => {
-                Ok(general_purpose::STANDARD_NO_PAD.decode(public_key_base64.as_bytes())?)
-            }
-            PublicKeyField::Hex { public_key_hex } => Ok(hex::decode(public_key_hex)?),
-            PublicKeyField::Pem { public_key_pem } => {
-                Ok(pem::parse(public_key_pem.as_bytes())?.contents().to_vec())
-            }
-            PublicKeyField::Pgp { public_key_pgp: _ } => Err(KeyDecodingError::new(
-                "PGP public key decoding not supported",
-            )),
-        }
-    }
+// impl PublicKeyField {
+//     pub fn key_decoded(&self) -> Result<Vec<u8>, KeyDecodingError> {
+//         match self {
+//             PublicKeyField::Multibase {
+//                 public_key_multibase,
+//             } => {
+//                 let multibase = Multibase::from_str(public_key_multibase)?;
+//                 Ok(multibase.as_ref().to_vec())
+//             }
+//             PublicKeyField::Jwk { public_key_jwk } => Ok(public_key_jwk.to_vec()?),
+//             PublicKeyField::Base58 { public_key_base58 } => {
+//                 Ok(bs58::decode(public_key_base58).into_vec()?)
+//             }
+//             PublicKeyField::Base64 { public_key_base64 } => {
+//                 Ok(general_purpose::STANDARD_NO_PAD.decode(public_key_base64.as_bytes())?)
+//             }
+//             PublicKeyField::Hex { public_key_hex } => Ok(hex::decode(public_key_hex)?),
+//             PublicKeyField::Pem { public_key_pem } => {
+//                 Ok(pem::parse(public_key_pem.as_bytes())?.contents().to_vec())
+//             }
+//             PublicKeyField::Pgp { public_key_pgp: _ } => Err(KeyDecodingError::new(
+//                 "PGP public key decoding not supported",
+//             )),
+//         }
+//     }
 
-    // TODO: Other formats
-    pub fn base58(&self) -> Result<String, KeyDecodingError> {
-        Ok(bs58::encode(self.key_decoded()?).into_string())
-    }
-}
+//     // TODO: Other formats
+//     pub fn base58(&self) -> Result<String, KeyDecodingError> {
+//         Ok(bs58::encode(self.key_decoded()?).into_string())
+//     }
+// }
 
-#[cfg(test)]
-mod tests {
-    use std::error::Error;
+// #[cfg(test)]
+// mod tests {
+//     use std::error::Error;
 
-    use super::*;
+//     use super::*;
 
-    static PUBLIC_KEY_MULTIBASE: &str = "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc";
-    static PUBLIC_KEY_BASE58: &str = "6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc";
-    static PUBLIC_KEY_BASE64: &str = "7AEEiIVxASfd1+8HamOWE5BCi6vqNfL13mzYUoQk1M4mKQ";
-    static PUBLIC_KEY_HEX: &str =
-        "ec01048885710127ddd7ef076a63961390428babea35f2f5de6cd8528424d4ce2629";
-    static PUBLIC_KEY_BYTES: [u8; 34] = [
-        236, 1, 4, 136, 133, 113, 1, 39, 221, 215, 239, 7, 106, 99, 150, 19, 144, 66, 139, 171,
-        234, 53, 242, 245, 222, 108, 216, 82, 132, 36, 212, 206, 38, 41,
-    ];
+//     static PUBLIC_KEY_MULTIBASE: &str = "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc";
+//     static PUBLIC_KEY_BASE58: &str = "6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc";
+//     static PUBLIC_KEY_BASE64: &str = "7AEEiIVxASfd1+8HamOWE5BCi6vqNfL13mzYUoQk1M4mKQ";
+//     static PUBLIC_KEY_HEX: &str =
+//         "ec01048885710127ddd7ef076a63961390428babea35f2f5de6cd8528424d4ce2629";
+//     static PUBLIC_KEY_BYTES: [u8; 34] = [
+//         236, 1, 4, 136, 133, 113, 1, 39, 221, 215, 239, 7, 106, 99, 150, 19, 144, 66, 139, 171,
+//         234, 53, 242, 245, 222, 108, 216, 82, 132, 36, 212, 206, 38, 41,
+//     ];
 
-    #[test]
-    fn test_multibase() {
-        let public_key_field = PublicKeyField::Multibase {
-            public_key_multibase: PUBLIC_KEY_MULTIBASE.to_string(),
-        };
-        assert_eq!(public_key_field.key_decoded().unwrap(), PUBLIC_KEY_BYTES);
-        assert_eq!(public_key_field.base58().unwrap(), PUBLIC_KEY_BASE58);
-    }
+//     #[test]
+//     fn test_multibase() {
+//         let public_key_field = PublicKeyField::Multibase {
+//             public_key_multibase: PUBLIC_KEY_MULTIBASE.to_string(),
+//         };
+//         assert_eq!(public_key_field.key_decoded().unwrap(), PUBLIC_KEY_BYTES);
+//         assert_eq!(public_key_field.base58().unwrap(), PUBLIC_KEY_BASE58);
+//     }
 
-    #[test]
-    fn test_base58() {
-        let public_key_field = PublicKeyField::Base58 {
-            public_key_base58: PUBLIC_KEY_BASE58.to_string(),
-        };
-        assert_eq!(
-            public_key_field.key_decoded().unwrap(),
-            PUBLIC_KEY_BYTES.to_vec()
-        );
-    }
+//     #[test]
+//     fn test_base58() {
+//         let public_key_field = PublicKeyField::Base58 {
+//             public_key_base58: PUBLIC_KEY_BASE58.to_string(),
+//         };
+//         assert_eq!(
+//             public_key_field.key_decoded().unwrap(),
+//             PUBLIC_KEY_BYTES.to_vec()
+//         );
+//     }
 
-    #[test]
-    fn test_base64() {
-        let public_key_field = PublicKeyField::Base64 {
-            public_key_base64: PUBLIC_KEY_BASE64.to_string(),
-        };
-        assert_eq!(
-            public_key_field.key_decoded().unwrap(),
-            PUBLIC_KEY_BYTES.to_vec()
-        );
-    }
+//     #[test]
+//     fn test_base64() {
+//         let public_key_field = PublicKeyField::Base64 {
+//             public_key_base64: PUBLIC_KEY_BASE64.to_string(),
+//         };
+//         assert_eq!(
+//             public_key_field.key_decoded().unwrap(),
+//             PUBLIC_KEY_BYTES.to_vec()
+//         );
+//     }
 
-    #[test]
-    fn test_hex() {
-        let public_key_field = PublicKeyField::Hex {
-            public_key_hex: PUBLIC_KEY_HEX.to_string(),
-        };
-        assert_eq!(
-            public_key_field.key_decoded().unwrap(),
-            PUBLIC_KEY_BYTES.to_vec()
-        );
-    }
+//     #[test]
+//     fn test_hex() {
+//         let public_key_field = PublicKeyField::Hex {
+//             public_key_hex: PUBLIC_KEY_HEX.to_string(),
+//         };
+//         assert_eq!(
+//             public_key_field.key_decoded().unwrap(),
+//             PUBLIC_KEY_BYTES.to_vec()
+//         );
+//     }
 
-    #[test]
-    fn test_b58_fails() {
-        let public_key_field = PublicKeyField::Base58 {
-            public_key_base58: "abcdefghijkl".to_string(),
-        };
-        let err = public_key_field.key_decoded().expect_err("Expected error");
-        println!("Error: {}", err);
-        assert!(err
-            .source()
-            .expect("Error was expected to has source set up.")
-            .is::<bs58::decode::Error>());
-        assert!(err.to_string().contains("Failed to decode base58"));
-    }
+//     #[test]
+//     fn test_b58_fails() {
+//         let public_key_field = PublicKeyField::Base58 {
+//             public_key_base58: "abcdefghijkl".to_string(),
+//         };
+//         let err = public_key_field.key_decoded().expect_err("Expected error");
+//         println!("Error: {}", err);
+//         assert!(err
+//             .source()
+//             .expect("Error was expected to has source set up.")
+//             .is::<bs58::decode::Error>());
+//         assert!(err.to_string().contains("Failed to decode base58"));
+//     }
 
-    #[test]
-    fn test_pem_fails() {
-        let public_key_field = PublicKeyField::Pem {
-            public_key_pem: "abcdefghijkl".to_string(),
-        };
-        let err = public_key_field.key_decoded().unwrap_err();
-        println!("Error: {}", err);
-        assert!(err
-            .source()
-            .expect("Error was expected to has source set up.")
-            .is::<pem::PemError>());
-        assert!(err.to_string().contains("Failed to decode PEM"));
-    }
-}
+//     #[test]
+//     fn test_pem_fails() {
+//         let public_key_field = PublicKeyField::Pem {
+//             public_key_pem: "abcdefghijkl".to_string(),
+//         };
+//         let err = public_key_field.key_decoded().unwrap_err();
+//         println!("Error: {}", err);
+//         assert!(err
+//             .source()
+//             .expect("Error was expected to has source set up.")
+//             .is::<pem::PemError>());
+//         assert!(err.to_string().contains("Failed to decode PEM"));
+//     }
+// }


### PR DESCRIPTION
I followed the approach outlined in https://github.com/hyperledger/aries-vcx/issues/1163#issue-2202258364
 * removed `PublicKeyField` in favour of bytes
 * introduced a new flag that determines the serialization format
 * implemented custom serialization

I do not think that this is really an improvement since it has its own downsides:
* we now have 2 separate attributes to determine the format of a single value
* `VerificationMethod` is now responsible for implementing how to serialize other type - key should know how to serialize itself
* while bytes can represent various key types, having just raw bytes us not that useful for working with the key. Usually, those bytes are used to construct a type that has methods for key operations


So I think we might go from:

```rust
#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
#[serde(untagged)]
#[serde(deny_unknown_fields)]
pub enum PublicKeyField {
    #[serde(rename_all = "camelCase")]
    Multibase { public_key_multibase: String },
    #[serde(rename_all = "camelCase")]
    Jwk { public_key_jwk: JsonWebKey },
    #[serde(rename_all = "camelCase")]
    Base58 { public_key_base58: String },
    #[serde(rename_all = "camelCase")]
    Base64 { public_key_base64: String },
    #[serde(rename_all = "camelCase")]
    Hex { public_key_hex: String },
    #[serde(rename_all = "camelCase")]
    Pem { public_key_pem: String },
    #[serde(rename_all = "camelCase")]
    Pgp { public_key_pgp: String },
}
```

to something like:

```rust
#[derive(Clone, Debug, PartialEq)]
pub enum PublicKeyField {
    Multibase(public_key::Key),
    Jwk (JsonWebKey),
    Base58(public_key::Key),
    Base64(public_key::Key),
    Hex(public_key::Key), 
    Pem(pem::Pem),
    Pgp(pgp::Pgp),
}

impl Serialize for PublicKeyField {...}
```

The key type is responsible for holding the key bytes and `PublicKeyField` knows how to de/serialize itself. Your thoughts?

