### PR TITLE
Use Did type in message crate

### DIFF
--- a/aries/messages/src/msg_fields/protocols/connection/invitation/public.rs
+++ b/aries/messages/src/msg_fields/protocols/connection/invitation/public.rs
@@ -1,3 +1,4 @@
+use did_parser_nom::Did;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
@@ -7,7 +8,7 @@ use super::InvitationContent;
 #[builder(build_method(into = InvitationContent))]
 pub struct PublicInvitationContent {
     pub label: String,
-    pub did: String,
+    pub did: Did,
 }
 
 #[cfg(test)]

--- a/aries/messages/src/msg_fields/protocols/connection/mod.rs
+++ b/aries/messages/src/msg_fields/protocols/connection/mod.rs
@@ -6,6 +6,7 @@ pub mod request;
 pub mod response;
 
 use derive_more::From;
+use did_parser_nom::Did;
 use diddoc_legacy::aries::diddoc::AriesDidDoc;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -76,13 +77,13 @@ impl DelayedSerde for Connection {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ConnectionData {
     #[serde(rename = "DID")]
-    pub did: String,
+    pub did: Did,
     #[serde(rename = "DIDDoc")]
     pub did_doc: AriesDidDoc,
 }
 
 impl ConnectionData {
-    pub fn new(did: String, did_doc: AriesDidDoc) -> Self {
+    pub fn new(did: Did, did_doc: AriesDidDoc) -> Self {
         Self { did, did_doc }
     }
 }

--- a/aries/messages/src/msg_fields/protocols/did_exchange/request.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/request.rs
@@ -1,3 +1,4 @@
+use did_parser_nom::Did;
 use serde::{Deserialize, Serialize};
 use shared::maybe_known::MaybeKnown;
 use typed_builder::TypedBuilder;
@@ -18,7 +19,7 @@ pub struct RequestContent {
     pub label: String,
     pub goal_code: Option<MaybeKnown<ThreadGoalCode>>,
     pub goal: Option<String>,
-    pub did: String, // TODO: Use Did
+    pub did: Did,
     #[serde(rename = "did_doc~attach")]
     pub did_doc: Option<Attachment>,
 }

--- a/aries/messages/src/msg_fields/protocols/did_exchange/response.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/response.rs
@@ -1,3 +1,4 @@
+use did_parser_nom::Did;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
@@ -10,7 +11,7 @@ pub type Response = MsgParts<ResponseContent, ResponseDecorators>;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, TypedBuilder)]
 pub struct ResponseContent {
-    pub did: String, // TODO: Use Did
+    pub did: Did,
     #[serde(rename = "did_doc~attach")]
     pub did_doc: Option<Attachment>,
 }


### PR DESCRIPTION
Resolves #1165

Use [did_parser_nom](https://github.com/hyperledger/aries-vcx/tree/main/did_core/did_parser_nom)'s Did type in ```message``` crates instead of string so as to parse & verify DIDs upon message deserialization