### PR TITLE
ci, fix: update path that mediator ci workkflow looks for

### DIFF
--- a/.github/workflows/mediator.pr.yml
+++ b/.github/workflows/mediator.pr.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - "**"
     paths:
-      - 'aries/agents/rust/mediator/**'
+      - 'aries/agents/mediator/**'
 
 env:
   DOCKER_BUILDKIT: 1


### PR DESCRIPTION
On reviewing the latest mediator related pr, I noticed the mediator CI workflow wasn't running. This should fix that. 