### PR TITLE
chore: minor readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Do you have a question ❓Are you considering using our components? 🚀 We'll b
 
 There's 2 best way to reach us:
 - Leave us message on `aries-vcx` [discord](https://discord.com/channels/905194001349627914/955480822675308604) channel.
-- Join our Zoom community calls. Biweekly Thursdays @ 09:00 am UTC via Zoom, find more details on [wiki](https://wiki.hyperledger.org/display/ARIES/Community+calls)
+- Join our Zoom community calls. Biweekly Tuesdays @ 11:00 pm UTC via Zoom, find more details on [wiki](https://wiki.hyperledger.org/display/ARIES/Community+calls)
 
 ## Versioning & releases
   - Crates are not yet published on crates.io. You can consume crates as github-type Cargo dependency.

--- a/aries/README.md
+++ b/aries/README.md
@@ -5,7 +5,7 @@
 - [`aries_vcx`](aries_vcx) - Library implementing DIDComm protocols, with focus on verifiable credential issuance and verification.
 - [`messages`](messages) - Library for building and parsing Aries messages.
 - [`aries_vcx_core`](aries_vcx_core) - Interfaces for interaction with ledgers, wallets and credentials.
-- [`aries-vcx-agent`](agents/rust/aries-vcx-agent) - simple aries agent framework built on top of `aries_vcx` library.
+- [`aries-vcx-agent`](agents/rust/aries-vcx-agent) - simple aries agent framework built on top of `aries_vcx` library. Not intended for production use. A new Aries VCX Framework is in development to provide simple, easy to use, and production ready functions for use.
 - [`mediator`](agents/rust/mediator) - Aries message mediator service
 
 ## Aries mobile 📱 components

--- a/aries/agents/README.md
+++ b/aries/agents/README.md
@@ -2,6 +2,6 @@
 
 This directory contains some of Rust agents built on top of the `aries_vcx` crate:
 
-- [`aries-vcx-agent`](./aries-vcx-agent) - aries agent library used to build our cross-framework testing [backchannel](https://github.com/hyperledger/aries-agent-test-harness/tree/main/aries-backchannels/aries-vcx)
+- [`aries-vcx-agent`](./aries-vcx-agent) - aries agent library used to build our cross-framework testing [backchannel](https://github.com/hyperledger/aries-agent-test-harness/tree/main/aries-backchannels/aries-vcx). Not intended for production use. A new Aries VCX Framework is in development to provide simple, easy to use, and production ready functions for use.
 - [`mediator`](./mediator) - didcomm mediator service
 - [`mobile-demo`](./mobile_demo) - android mobile app demo created using UniFFI bindings for aries-vcx library


### PR DESCRIPTION
Updates Aries VCX Community Call timing
Adds note about aries-vcx-agent is not production ready and that a new framework is in development that will fill end developer's needs (as discussed on [5-15-24 community call](https://wiki.hyperledger.org/display/ARIES/2024-5-15+Aries-vcx+community+call))