### PR TITLE
[FIX] Loosen "version" restriction on PresentationRequestPayload

### DIFF
--- a/aries/agents/aath-backchannel/src/controllers/presentation.rs
+++ b/aries/agents/aath-backchannel/src/controllers/presentation.rs
@@ -106,7 +106,7 @@ impl HarnessAgent {
         let id = self
             .aries_agent
             .verifier()
-            .send_proof_request(&presentation_request.connection_id, request.into(), None)
+            .send_proof_request(&presentation_request.connection_id, request.into_v1(), None)
             .await?;
         let state = self.aries_agent.verifier().get_state(&id)?;
         Ok(json!({ "state": to_backchannel_state_verifier(state), "thread_id": id }).to_string())

--- a/aries/aries_vcx/tests/test_verifier.rs
+++ b/aries/aries_vcx/tests/test_verifier.rs
@@ -361,7 +361,7 @@ async fn test_pool_proof_self_attested_proof_validation() -> Result<(), Box<dyn 
     let prover_proof_json = anoncreds
         .prover_create_proof(
             &setup.wallet,
-            proof_req_json.into(),
+            proof_req_json.into_v1(),
             RequestedCredentials {
                 self_attested_attributes: vec![
                     (
@@ -451,7 +451,7 @@ async fn test_pool_proof_restrictions() -> Result<(), Box<dyn Error>> {
     let prover_proof_json = anoncreds
         .prover_create_proof(
             &setup.wallet,
-            proof_req_json.into(),
+            proof_req_json.into_v1(),
             RequestedCredentials {
                 self_attested_attributes: vec![(
                     "attribute_2".to_string(),
@@ -563,7 +563,7 @@ async fn test_pool_proof_validate_attribute() -> Result<(), Box<dyn Error>> {
     let prover_proof_json = anoncreds
         .prover_create_proof(
             &setup.wallet,
-            proof_req_json.into(),
+            proof_req_json.into_v1(),
             RequestedCredentials {
                 self_attested_attributes: vec![(
                     "attribute_2".to_string(),

--- a/aries/aries_vcx/tests/utils/scenarios/proof_presentation.rs
+++ b/aries/aries_vcx/tests/utils/scenarios/proof_presentation.rs
@@ -115,7 +115,7 @@ pub async fn accept_proof_proposal(
         .nonce(Nonce::new().unwrap())
         .build();
     verifier
-        .set_presentation_request(presentation_request.into(), None)
+        .set_presentation_request(presentation_request.into_v1(), None)
         .unwrap();
     verifier.mark_presentation_request_sent().unwrap()
 }
@@ -159,7 +159,7 @@ pub async fn create_proof_request_data(
         .requested_predicates(requested_preds)
         .non_revoked(Some(revocation_interval))
         .build()
-        .into()
+        .into_v1()
 }
 
 pub async fn create_prover_from_request(presentation_request: RequestPresentationV1) -> Prover {

--- a/aries/misc/anoncreds_types/src/data_types/messages/pres_request.rs
+++ b/aries/misc/anoncreds_types/src/data_types/messages/pres_request.rs
@@ -21,8 +21,8 @@ use crate::{
 pub struct PresentationRequestPayload {
     pub nonce: Nonce,
     pub name: String,
-    #[builder(default)]
-    pub version: PresentationRequestVersion,
+    #[builder(default = String::from("1.0"))]
+    pub version: String,
     #[serde(default)]
     #[builder(default)]
     pub requested_attributes: HashMap<String, AttributeInfo>,
@@ -34,12 +34,13 @@ pub struct PresentationRequestPayload {
     pub non_revoked: Option<NonRevokedInterval>,
 }
 
-impl From<PresentationRequestPayload> for PresentationRequest {
-    fn from(value: PresentationRequestPayload) -> Self {
-        match value.version {
-            PresentationRequestVersion::V1 => Self::PresentationRequestV1(value),
-            PresentationRequestVersion::V2 => Self::PresentationRequestV2(value),
-        }
+impl PresentationRequestPayload {
+    pub fn into_v1(self) -> PresentationRequest {
+        PresentationRequest::PresentationRequestV1(self)
+    }
+
+    pub fn into_v2(self) -> PresentationRequest {
+        PresentationRequest::PresentationRequestV2(self)
     }
 }
 

--- a/aries/misc/anoncreds_types/src/data_types/messages/pres_request.rs
+++ b/aries/misc/anoncreds_types/src/data_types/messages/pres_request.rs
@@ -38,7 +38,6 @@ impl PresentationRequestPayload {
     pub fn into_v1(self) -> PresentationRequest {
         PresentationRequest::PresentationRequestV1(self)
     }
-
     pub fn into_v2(self) -> PresentationRequest {
         PresentationRequest::PresentationRequestV2(self)
     }


### PR DESCRIPTION
Currently our `anoncreds_types` crate (which mostly mirrors [anoncreds-rs](https://github.com/hyperledger/anoncreds-rs/blob/main/src/data_types/pres_request.rs#L18)), has an additional restriction on the presentation request payload: it requires that the inner "version" field is either "1.0" or "2.0".

However, the real anoncreds-rs types do not require this. They allow any string: https://github.com/hyperledger/anoncreds-rs/blob/main/src/data_types/pres_request.rs#L18.

The anoncreds spec also seems to imply that the version field is whatever the verifier wants it to be: https://hyperledger.github.io/anoncreds-spec/#create-presentation-request .

I think perhaps we were confusing this field `version` with the other field `ver`. which does seem to be required as "1.0" or "2.0": we have correctly implemented that though.

I've kept a default of "1.0" in the builder for backwards compatibility