### PR TITLE
[Update] Update to anoncreds-rs 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,13 +315,13 @@ dependencies = [
 
 [[package]]
 name = "anoncreds"
-version = "0.2.0-dev.7"
-source = "git+https://github.com/mirgee/anoncreds-rs.git?rev=a85d739#a85d739c10a90834dbd912508cbceba77b114b64"
+version = "0.2.0"
+source = "git+https://github.com/hyperledger/anoncreds-rs.git?tag=v0.2.0#394a1ce469ef4d6cacf404d882266d798e3e171c"
 dependencies = [
- "anoncreds-clsignatures 0.3.1",
+ "anoncreds-clsignatures 0.3.2",
  "base64",
  "bitvec",
- "bs58 0.4.0",
+ "bs58 0.5.0",
  "chrono",
  "env_logger 0.9.3",
  "ffi-support",
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "anoncreds-clsignatures"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b4e286c791bc96ee61e7e5a41951e7dfdf2fd6732d21cb703f9954a2e069de"
+checksum = "1bacd4cc4bf6b711dbb5dfc5b79e69b3d845b9569f26252f587e2c5bb0759ef5"
 dependencies = [
  "amcl",
  "glass_pumpkin",
@@ -379,7 +379,7 @@ dependencies = [
 name = "anoncreds_types"
 version = "0.1.0"
 dependencies = [
- "anoncreds-clsignatures 0.3.1",
+ "anoncreds-clsignatures 0.3.2",
  "bitvec",
  "log",
  "once_cell",

--- a/aries/aries_vcx_anoncreds/Cargo.toml
+++ b/aries/aries_vcx_anoncreds/Cargo.toml
@@ -18,7 +18,7 @@ askar_wallet = ["aries_vcx_wallet/askar_wallet"]
 [dependencies]
 indy-credx = { git = "https://github.com/hyperledger/indy-shared-rs", tag = "v1.1.0", optional = true }
 aries_vcx_wallet = { path = "../aries_vcx_wallet" }
-anoncreds = { git = "https://github.com/mirgee/anoncreds-rs.git", rev = "a85d739", optional = true }
+anoncreds = { git = "https://github.com/hyperledger/anoncreds-rs.git", tag = "v0.2.0", optional = true }
 anoncreds_types = { path = "../misc/anoncreds_types" }
 did_parser_nom = { path = "../../did_core/did_parser_nom" }
 async-trait = "0.1.68"

--- a/aries/aries_vcx_anoncreds/src/anoncreds/anoncreds/mod.rs
+++ b/aries/aries_vcx_anoncreds/src/anoncreds/anoncreds/mod.rs
@@ -989,7 +989,6 @@ impl BaseAnonCreds for Anoncreds {
             Some(registry),
             Some(timestamp),
         )?;
-
         let rev_state = anoncreds::prover::create_or_update_revocation_state(
             tails_path,
             &revoc_reg_def,

--- a/aries/aries_vcx_anoncreds/src/anoncreds/anoncreds/mod.rs
+++ b/aries/aries_vcx_anoncreds/src/anoncreds/anoncreds/mod.rs
@@ -31,7 +31,6 @@ use anoncreds::{
         Presentation as AnoncredsPresentation, PresentationRequest as AnoncredsPresentationRequest,
         RegistryType, RevocationRegistry as AnoncredsRevocationRegistry,
         RevocationRegistryDefinition as AnoncredsRevocationRegistryDefinition,
-        RevocationStatusList,
     },
 };
 use anoncreds_types::data_types::{
@@ -40,11 +39,7 @@ use anoncreds_types::data_types::{
         schema_id::SchemaId,
     },
     ledger::{
-        cred_def::{CredentialDefinition, SignatureType},
-        rev_reg::RevocationRegistry,
-        rev_reg_def::RevocationRegistryDefinition,
-        rev_reg_delta::{RevocationRegistryDelta, RevocationRegistryDeltaValue},
-        schema::{AttributeNames, Schema},
+        cred_def::{CredentialDefinition, SignatureType}, rev_reg::RevocationRegistry, rev_reg_def::RevocationRegistryDefinition, rev_reg_delta::{RevocationRegistryDelta, RevocationRegistryDeltaValue}, rev_status_list::RevocationStatusList, schema::{AttributeNames, Schema}
     },
     messages::{
         cred_definition_config::CredentialDefinitionConfig,
@@ -104,7 +99,7 @@ fn from_revocation_registry_delta_to_revocation_status_list(
 
     RevocationStatusList::new(
         Some(&rev_reg_def_id.to_string()),
-        rev_reg_def.issuer_id.clone(),
+        rev_reg_def.issuer_id.clone().convert(())?,
         revocation_list,
         Some(accum),
         timestamp,
@@ -982,19 +977,9 @@ impl BaseAnonCreds for Anoncreds {
         });
         let registry = CryptoRevocationRegistry { accum };
 
-        // let rev_status_list = create_revocation_status_list(
-        //     &cred_def,
-        //     RevocationRegistryDefinitionId::new_unchecked(issuer_id),
-        //     &revoc_reg_def,
-        //     rev_reg_priv, // No way to construct this from revocation registry currently
-        //     true,
-        //     Some(timestamp),
-        // );
-
-        // TODO: Made public, should find a better way
         let rev_status_list = RevocationStatusList::new(
             Some(&rev_reg_def_id),
-            issuer_id,
+            issuer_id.convert(())?,
             revocation_list,
             Some(registry),
             Some(timestamp),
@@ -1003,7 +988,7 @@ impl BaseAnonCreds for Anoncreds {
         let rev_state = anoncreds::prover::create_or_update_revocation_state(
             tails_path,
             &revoc_reg_def,
-            &rev_status_list,
+            &rev_status_list.convert(())?,
             cred_rev_id,
             None,
             None,
@@ -1201,7 +1186,7 @@ impl BaseAnonCreds for Anoncreds {
             &cred_def,
             &rev_reg_def.convert(())?,
             &rev_reg_def_priv,
-            &rev_status_list,
+            &rev_status_list.convert(())?,
             None,
             Some(vec![cred_rev_id].into_iter().collect()),
             None,
@@ -1209,7 +1194,7 @@ impl BaseAnonCreds for Anoncreds {
 
         let updated_revocation_registry_delta =
             from_revocation_status_list_to_revocation_registry_delta(
-                &updated_rev_status_list,
+                &updated_rev_status_list.convert(())?,
                 Some(prev_accum),
             )?;
         let updated_revocation_registry_delta_str =

--- a/aries/aries_vcx_anoncreds/src/anoncreds/anoncreds/mod.rs
+++ b/aries/aries_vcx_anoncreds/src/anoncreds/anoncreds/mod.rs
@@ -39,7 +39,12 @@ use anoncreds_types::data_types::{
         schema_id::SchemaId,
     },
     ledger::{
-        cred_def::{CredentialDefinition, SignatureType}, rev_reg::RevocationRegistry, rev_reg_def::RevocationRegistryDefinition, rev_reg_delta::{RevocationRegistryDelta, RevocationRegistryDeltaValue}, rev_status_list::RevocationStatusList, schema::{AttributeNames, Schema}
+        cred_def::{CredentialDefinition, SignatureType},
+        rev_reg::RevocationRegistry,
+        rev_reg_def::RevocationRegistryDefinition,
+        rev_reg_delta::{RevocationRegistryDelta, RevocationRegistryDeltaValue},
+        rev_status_list::RevocationStatusList,
+        schema::{AttributeNames, Schema},
     },
     messages::{
         cred_definition_config::CredentialDefinitionConfig,

--- a/aries/aries_vcx_anoncreds/src/anoncreds/anoncreds/type_conversion.rs
+++ b/aries/aries_vcx_anoncreds/src/anoncreds/anoncreds/type_conversion.rs
@@ -49,6 +49,7 @@ use anoncreds_types::data_types::{
             RevocationRegistryDefinition as OurRevocationRegistryDefinition,
             RevocationRegistryDefinitionValue as OurRevocationRegistryDefinitionValue,
         },
+        rev_status_list::RevocationStatusList as OurRevocationStatusList,
         schema::{AttributeNames as OurAttributeNames, Schema as OurSchema},
     },
     messages::{
@@ -503,15 +504,15 @@ impl Convert for HashMap<OurRevocationRegistryDefinitionId, HashMap<u64, OurRevo
                 let OurRevocationRegistry { value } = entry;
                 let registry = CryptoRevocationRegistry { accum: value.accum };
 
-                let rev_status_list = AnoncredsRevocationStatusList::new(
+                let rev_status_list = OurRevocationStatusList::new(
                     Some(&rev_reg_def_id.to_string()),
-                    issuer_id,
+                    issuer_id.convert(())?,
                     Default::default(),
                     Some(registry),
                     Some(timestamp),
                 )?;
 
-                lists.push(rev_status_list);
+                lists.push(rev_status_list.convert(())?);
             }
         }
         Ok(lists)
@@ -574,6 +575,30 @@ impl Convert for OurCredentialRevocationState {
     type Error = Box<dyn std::error::Error>;
 
     fn convert(self, _args: Self::Args) -> Result<Self::Target, Self::Error> {
+        serde_convert(self)
+    }
+}
+
+impl Convert for AnoncredsRevocationStatusList {
+    type Args = ();
+
+    type Target = OurRevocationStatusList;
+
+    type Error = Box<dyn std::error::Error>;
+
+    fn convert(self, _: Self::Args) -> Result<Self::Target, Self::Error> {
+        serde_convert(self)
+    }
+}
+
+impl Convert for OurRevocationStatusList {
+    type Args = ();
+
+    type Target = AnoncredsRevocationStatusList;
+
+    type Error = Box<dyn std::error::Error>;
+
+    fn convert(self, _: Self::Args) -> Result<Self::Target, Self::Error> {
         serde_convert(self)
     }
 }

--- a/aries/misc/anoncreds_types/Cargo.toml
+++ b/aries/misc/anoncreds_types/Cargo.toml
@@ -13,7 +13,7 @@ ledger = []
 default = ["messages", "ledger"]
 
 [dependencies]
-anoncreds-clsignatures = "0.3.1"
+anoncreds-clsignatures = "0.3.2"
 bitvec = "1.0.1"
 log = "0.4.20"
 once_cell = "1.19.0"


### PR DESCRIPTION
In order to migrate off of mirgee's fork and onto 0.2.0, we lose the following patches made on 0.2.0: https://github.com/hyperledger/anoncreds-rs/compare/v0.2.0...mirgee:anoncreds-rs:refactor/public-api-changes.

However we can get around those public APIs being missing by using into our `Convert` layer: we can switch between the anoncreds-rs definition of RevocationStatusList, and our own anoncreds_types definition of RevocationStatusList. These definitions are exactly the same, and JSON de/serialize the exact same way, however our version has the public APIs we need. So we can switch between theirs and ours when we need to. 

Note that it is not perfectly efficient, as we are converting to JSON Value as an intermediate type (as we do for some other anoncreds types too), but this could potentially be cleaned up if we fully move to using the real types from anoncreds-rs crate.