### PR TITLE
fix: generate dids from indy seed secret bytes

### DIFF
--- a/aries/aries_vcx_wallet/src/wallet/askar/mod.rs
+++ b/aries/aries_vcx_wallet/src/wallet/askar/mod.rs
@@ -6,10 +6,7 @@ use aries_askar::{
 use async_trait::async_trait;
 use public_key::Key;
 
-use self::{
-    askar_utils::local_key_to_bs58_public_key, askar_wallet_config::AskarWalletConfig,
-    rng_method::RngMethod,
-};
+use self::askar_wallet_config::AskarWalletConfig;
 use super::{
     base_wallet::{
         did_value::DidValue, key_value::KeyValue, record_category::RecordCategory, BaseWallet,
@@ -142,16 +139,13 @@ impl AskarWallet {
     async fn insert_key(
         &self,
         session: &mut Session,
-        alg: KeyAlg,
-        seed: &[u8],
-        rng_method: RngMethod,
-    ) -> VcxWalletResult<(String, LocalKey)> {
-        let key = LocalKey::from_seed(alg, seed, rng_method.into())?;
-        let key_name = local_key_to_bs58_public_key(&key)?.into_inner();
+        key_name: &str,
+        local_key: &LocalKey,
+    ) -> VcxWalletResult<()> {
         session
-            .insert_key(&key_name, &key, None, None, None)
+            .insert_key(&key_name, &local_key, None, None, None)
             .await?;
-        Ok((key_name, key))
+        Ok(())
     }
 
     async fn find_did(

--- a/aries/misc/test_utils/src/devsetup.rs
+++ b/aries/misc/test_utils/src/devsetup.rs
@@ -202,7 +202,7 @@ pub async fn dev_build_featured_wallet(key_seed: &str) -> (String, impl BaseWall
     {
         use crate::{constants::INSTITUTION_DID, mock_wallet::MockWallet};
 
-        return (INSTITUTION_DID.to_owned(), MockWallet);
+        (INSTITUTION_DID.to_owned(), MockWallet)
     }
 }
 


### PR DESCRIPTION
Fixes the Askar implementation of the did_wallet trait function `create_and_store_my_did()` to match other framework implementations, such as ACA-Py, by deterministically generating a DID from a 'seed' (which in Indy is just the secret key). So this function changes the generation to use Askar's `from_secret_bytes` instead of `from_seed`. 
See [here](https://discord.com/channels/905194001349627914/1172582681805070420/1249759738531680287) for some discussion on the topic.

This required adjusting the underlying `insert_key()` method to only insert a `LocalKey` and leave the generation up to the call function (which seems like a better idea anyways IMO).