### PR TITLE
(refactor) small refactor to the new DIDExchange AnyXYZ wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4888,9 +4888,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -4917,9 +4917,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/complete.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/complete.rs
@@ -29,7 +29,7 @@ pub struct CompleteDecorators {
     pub timing: Option<Timing>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum AnyComplete {
     V1_0(Complete),

--- a/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/complete.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/complete.rs
@@ -2,14 +2,10 @@ use serde::{Deserialize, Serialize};
 use shared::misc::serde_ignored::SerdeIgnored as NoContent;
 use typed_builder::TypedBuilder;
 
+use super::DidExchangeV1MessageVariant;
 use crate::{
     decorators::{thread::Thread, timing::Timing},
-    msg_fields::protocols::did_exchange::{
-        v1_0::DidExchangeV1_0, v1_1::DidExchangeV1_1, DidExchange,
-    },
     msg_parts::MsgParts,
-    msg_types::protocols::did_exchange::DidExchangeTypeV1,
-    AriesMessage,
 };
 
 /// Alias type for the shared DIDExchange v1.X complete message type.
@@ -29,41 +25,4 @@ pub struct CompleteDecorators {
     pub timing: Option<Timing>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[serde(untagged)]
-pub enum AnyComplete {
-    V1_0(Complete),
-    V1_1(Complete),
-}
-
-impl AnyComplete {
-    pub fn get_version(&self) -> DidExchangeTypeV1 {
-        match self {
-            AnyComplete::V1_0(_) => DidExchangeTypeV1::new_v1_0(),
-            AnyComplete::V1_1(_) => DidExchangeTypeV1::new_v1_1(),
-        }
-    }
-}
-
-impl AnyComplete {
-    pub fn into_inner(self) -> Complete {
-        match self {
-            AnyComplete::V1_0(r) | AnyComplete::V1_1(r) => r,
-        }
-    }
-
-    pub fn inner(&self) -> &Complete {
-        match self {
-            AnyComplete::V1_0(r) | AnyComplete::V1_1(r) => r,
-        }
-    }
-}
-
-impl From<AnyComplete> for AriesMessage {
-    fn from(value: AnyComplete) -> Self {
-        match value {
-            AnyComplete::V1_0(inner) => DidExchange::V1_0(DidExchangeV1_0::Complete(inner)).into(),
-            AnyComplete::V1_1(inner) => DidExchange::V1_1(DidExchangeV1_1::Complete(inner)).into(),
-        }
-    }
-}
+pub type AnyComplete = DidExchangeV1MessageVariant<Complete, Complete>;

--- a/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/mod.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/mod.rs
@@ -1,7 +1,59 @@
 //! Common components for V1.X DIDExchange messages (v1.0 & v1.1).
 //! Necessary to prevent duplicated code, since most types between v1.0 & v1.1 are identical
 
+use serde::Serialize;
+
+use super::{v1_0::DidExchangeV1_0, v1_1::DidExchangeV1_1, DidExchange};
+use crate::{msg_types::protocols::did_exchange::DidExchangeTypeV1, AriesMessage};
+
 pub mod complete;
 pub mod problem_report;
 pub mod request;
 pub mod response;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum DidExchangeV1MessageVariant<V1_0, V1_1> {
+    V1_0(V1_0),
+    V1_1(V1_1),
+}
+
+impl<A, B> DidExchangeV1MessageVariant<A, B> {
+    pub fn get_version(&self) -> DidExchangeTypeV1 {
+        match self {
+            DidExchangeV1MessageVariant::V1_0(_) => DidExchangeTypeV1::new_v1_0(),
+            DidExchangeV1MessageVariant::V1_1(_) => DidExchangeTypeV1::new_v1_1(),
+        }
+    }
+}
+
+impl<T> DidExchangeV1MessageVariant<T, T> {
+    pub fn into_inner(self) -> T {
+        match self {
+            DidExchangeV1MessageVariant::V1_0(r) | DidExchangeV1MessageVariant::V1_1(r) => r,
+        }
+    }
+
+    pub fn inner(&self) -> &T {
+        match self {
+            DidExchangeV1MessageVariant::V1_0(r) | DidExchangeV1MessageVariant::V1_1(r) => r,
+        }
+    }
+}
+
+impl<A, B> From<DidExchangeV1MessageVariant<A, B>> for AriesMessage
+where
+    A: Into<DidExchangeV1_0>,
+    B: Into<DidExchangeV1_1>,
+{
+    fn from(value: DidExchangeV1MessageVariant<A, B>) -> Self {
+        match value {
+            DidExchangeV1MessageVariant::V1_0(a) => {
+                AriesMessage::DidExchange(DidExchange::V1_0(a.into()))
+            }
+            DidExchangeV1MessageVariant::V1_1(b) => {
+                AriesMessage::DidExchange(DidExchange::V1_1(b.into()))
+            }
+        }
+    }
+}

--- a/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/problem_report.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/problem_report.rs
@@ -59,7 +59,7 @@ impl ProblemReportDecorators {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum AnyProblemReport {
     V1_0(ProblemReport),

--- a/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/problem_report.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/problem_report.rs
@@ -1,14 +1,10 @@
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
+use super::DidExchangeV1MessageVariant;
 use crate::{
     decorators::{localization::MsgLocalization, thread::Thread, timing::Timing},
-    msg_fields::protocols::did_exchange::{
-        v1_0::DidExchangeV1_0, v1_1::DidExchangeV1_1, DidExchange,
-    },
     msg_parts::MsgParts,
-    msg_types::protocols::did_exchange::DidExchangeTypeV1,
-    AriesMessage,
 };
 
 /// Alias type for the shared DIDExchange v1.X problem report message type.
@@ -59,45 +55,4 @@ impl ProblemReportDecorators {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[serde(untagged)]
-pub enum AnyProblemReport {
-    V1_0(ProblemReport),
-    V1_1(ProblemReport),
-}
-
-impl AnyProblemReport {
-    pub fn get_version(&self) -> DidExchangeTypeV1 {
-        match self {
-            AnyProblemReport::V1_0(_) => DidExchangeTypeV1::new_v1_0(),
-            AnyProblemReport::V1_1(_) => DidExchangeTypeV1::new_v1_1(),
-        }
-    }
-}
-
-impl AnyProblemReport {
-    pub fn into_inner(self) -> ProblemReport {
-        match self {
-            AnyProblemReport::V1_0(r) | AnyProblemReport::V1_1(r) => r,
-        }
-    }
-
-    pub fn inner(&self) -> &ProblemReport {
-        match self {
-            AnyProblemReport::V1_0(r) | AnyProblemReport::V1_1(r) => r,
-        }
-    }
-}
-
-impl From<AnyProblemReport> for AriesMessage {
-    fn from(value: AnyProblemReport) -> Self {
-        match value {
-            AnyProblemReport::V1_0(inner) => {
-                DidExchange::V1_0(DidExchangeV1_0::ProblemReport(inner)).into()
-            }
-            AnyProblemReport::V1_1(inner) => {
-                DidExchange::V1_1(DidExchangeV1_1::ProblemReport(inner)).into()
-            }
-        }
-    }
-}
+pub type AnyProblemReport = DidExchangeV1MessageVariant<ProblemReport, ProblemReport>;

--- a/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/request.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/request.rs
@@ -2,18 +2,14 @@ use serde::{Deserialize, Serialize};
 use shared::maybe_known::MaybeKnown;
 use typed_builder::TypedBuilder;
 
+use super::DidExchangeV1MessageVariant;
 use crate::{
     decorators::{
         attachment::Attachment,
         thread::{Thread, ThreadGoalCode},
         timing::Timing,
     },
-    msg_fields::protocols::did_exchange::{
-        v1_0::DidExchangeV1_0, v1_1::DidExchangeV1_1, DidExchange,
-    },
     msg_parts::MsgParts,
-    msg_types::protocols::did_exchange::DidExchangeTypeV1,
-    AriesMessage,
 };
 
 /// Alias type for the shared DIDExchange v1.X request message type.
@@ -45,41 +41,4 @@ pub struct RequestDecorators {
     pub timing: Option<Timing>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[serde(untagged)]
-pub enum AnyRequest {
-    V1_0(Request),
-    V1_1(Request),
-}
-
-impl AnyRequest {
-    pub fn get_version(&self) -> DidExchangeTypeV1 {
-        match self {
-            AnyRequest::V1_0(_) => DidExchangeTypeV1::new_v1_0(),
-            AnyRequest::V1_1(_) => DidExchangeTypeV1::new_v1_1(),
-        }
-    }
-}
-
-impl AnyRequest {
-    pub fn into_inner(self) -> Request {
-        match self {
-            AnyRequest::V1_0(r) | AnyRequest::V1_1(r) => r,
-        }
-    }
-
-    pub fn inner(&self) -> &Request {
-        match self {
-            AnyRequest::V1_0(r) | AnyRequest::V1_1(r) => r,
-        }
-    }
-}
-
-impl From<AnyRequest> for AriesMessage {
-    fn from(value: AnyRequest) -> Self {
-        match value {
-            AnyRequest::V1_0(inner) => DidExchange::V1_0(DidExchangeV1_0::Request(inner)).into(),
-            AnyRequest::V1_1(inner) => DidExchange::V1_1(DidExchangeV1_1::Request(inner)).into(),
-        }
-    }
-}
+pub type AnyRequest = DidExchangeV1MessageVariant<Request, Request>;

--- a/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/request.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/request.rs
@@ -45,7 +45,7 @@ pub struct RequestDecorators {
     pub timing: Option<Timing>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum AnyRequest {
     V1_0(Request),

--- a/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/response.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/response.rs
@@ -15,7 +15,7 @@ use crate::{
     AriesMessage,
 };
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, derive_more::From)]
+#[derive(Debug, Clone, Serialize, PartialEq, derive_more::From)]
 #[serde(untagged)]
 pub enum AnyResponse {
     V1_0(ResponseV1_0),

--- a/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/response.rs
+++ b/aries/messages/src/msg_fields/protocols/did_exchange/v1_x/response.rs
@@ -1,35 +1,18 @@
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
+use super::DidExchangeV1MessageVariant;
 use crate::{
     decorators::{thread::Thread, timing::Timing},
     msg_fields::protocols::did_exchange::{
-        v1_0::{response::Response as ResponseV1_0, DidExchangeV1_0},
-        v1_1::{
-            response::{Response as ResponseV1_1, ResponseContent as ResponseV1_1Content},
-            DidExchangeV1_1,
-        },
-        DidExchange,
+        v1_0::response::Response as ResponseV1_0,
+        v1_1::response::{Response as ResponseV1_1, ResponseContent as ResponseV1_1Content},
     },
-    msg_types::protocols::did_exchange::DidExchangeTypeV1,
-    AriesMessage,
 };
 
-#[derive(Debug, Clone, Serialize, PartialEq, derive_more::From)]
-#[serde(untagged)]
-pub enum AnyResponse {
-    V1_0(ResponseV1_0),
-    V1_1(ResponseV1_1),
-}
+pub type AnyResponse = DidExchangeV1MessageVariant<ResponseV1_0, ResponseV1_1>;
 
 impl AnyResponse {
-    pub fn get_version(&self) -> DidExchangeTypeV1 {
-        match self {
-            AnyResponse::V1_0(_) => DidExchangeTypeV1::new_v1_0(),
-            AnyResponse::V1_1(_) => DidExchangeTypeV1::new_v1_1(),
-        }
-    }
-
     pub fn into_v1_1(self) -> ResponseV1_1 {
         match self {
             AnyResponse::V1_0(r) => r.into_v1_1(),
@@ -52,12 +35,15 @@ impl ResponseV1_0 {
     }
 }
 
-impl From<AnyResponse> for AriesMessage {
-    fn from(value: AnyResponse) -> Self {
-        match value {
-            AnyResponse::V1_0(inner) => DidExchange::V1_0(DidExchangeV1_0::Response(inner)).into(),
-            AnyResponse::V1_1(inner) => DidExchange::V1_1(DidExchangeV1_1::Response(inner)).into(),
-        }
+impl From<ResponseV1_0> for AnyResponse {
+    fn from(value: ResponseV1_0) -> Self {
+        Self::V1_0(value)
+    }
+}
+
+impl From<ResponseV1_1> for AnyResponse {
+    fn from(value: ResponseV1_1) -> Self {
+        Self::V1_1(value)
     }
 }
 


### PR DESCRIPTION
I started these changes mostly wanting to remove `Deserialize` trait from the `AnyXYZ` wrappers. As IMO trying to deserialize JSON back into AnyXYZ is dangerous; if both V1_0 & V1_1 variants are the same, then the serialized format is the same, so when deserializing `serde` cannot tell which variant it is, so it just picks the first one (misleading).

Also whilst i was here... i realised the Any wrappers were duplicating themselves alot, so i made a generic enum for it