### PR TITLE
Handle trust pings in the AATH backchannel

### DIFF
--- a/aries/agents/aries-vcx-agent/src/handlers/connection.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/connection.rs
@@ -6,11 +6,16 @@ use aries_vcx::{
         msg_fields::protocols::{
             connection::{request::Request, response::Response},
             notification::ack::Ack,
+            trust_ping::ping::Ping,
         },
         AriesMessage,
     },
-    protocols::connection::{
-        pairwise_info::PairwiseInfo, Connection, GenericConnection, State, ThinState,
+    protocols::{
+        connection::{
+            inviter::states::completed::Completed, pairwise_info::PairwiseInfo, Connection,
+            GenericConnection, State, ThinState,
+        },
+        trustping::build_ping_response,
     },
 };
 use aries_vcx_ledger::ledger::indy_vdr_ledger::DefaultIndyLedgerRead;
@@ -179,6 +184,42 @@ impl<T: BaseWallet> ServiceConnections<T> {
         Ok(())
     }
 
+    /// Process a trust ping and send a pong. Also bump the connection state (ack) if needed.
+    pub async fn process_trust_ping(&self, ping: Ping, connection_id: &str) -> AgentResult<()> {
+        let generic_inviter = self.connections.get(&connection_id)?;
+
+        let inviter: Connection<_, Completed> = match generic_inviter.state() {
+            ThinState::Inviter(State::Requested) => {
+                // bump state. requested -> complete
+                let inviter: Connection<_, _> = generic_inviter.try_into()?;
+                inviter.acknowledge_connection(&ping.clone().into())?
+            }
+            ThinState::Inviter(State::Completed) => generic_inviter.try_into()?,
+            s => {
+                return Err(AgentError::from_msg(
+                    AgentErrorKind::GenericAriesVcxError,
+                    &format!(
+                        "Connection with handle {} cannot process a trust ping; State: {:?}",
+                        connection_id, s
+                    ),
+                ))
+            }
+        };
+
+        // send pong if desired
+        if ping.content.response_requested {
+            let response = build_ping_response(&ping);
+            inviter
+                .send_message(self.wallet.as_ref(), &response.into(), &VcxHttpClient)
+                .await?;
+        }
+
+        // update state
+        self.connections.insert(&connection_id, inviter.into())?;
+
+        Ok(())
+    }
+
     pub fn get_state(&self, thread_id: &str) -> AgentResult<ThinState> {
         Ok(self.connections.get(thread_id)?.state())
     }
@@ -187,16 +228,29 @@ impl<T: BaseWallet> ServiceConnections<T> {
         self.connections.get(thread_id)
     }
 
-    pub fn get_by_their_vk(&self, their_vk: &str) -> AgentResult<Vec<String>> {
-        let their_vk = their_vk.to_string();
+    pub fn get_by_sender_vk(&self, sender_vk: String) -> AgentResult<String> {
         let f = |(id, m): (&String, &Mutex<GenericConnection>)| -> Option<String> {
             let connection = m.lock().unwrap();
             match connection.remote_vk() {
-                Ok(remote_vk) if remote_vk == their_vk => Some(id.to_string()),
+                Ok(remote_vk) if remote_vk == sender_vk => Some(id.to_string()),
                 _ => None,
             }
         };
-        self.connections.find_by(f)
+        let conns = self.connections.find_by(f)?;
+
+        if conns.len() > 1 {
+            return Err(AgentError::from_msg(
+                AgentErrorKind::InvalidState,
+                &format!(
+                    "Found multiple connections by sender's verkey {}",
+                    sender_vk
+                ),
+            ));
+        }
+        conns.into_iter().next().ok_or(AgentError::from_msg(
+            AgentErrorKind::InvalidState,
+            &format!("Found no connections by sender's verkey {}", sender_vk),
+        ))
     }
 
     pub fn exists_by_id(&self, thread_id: &str) -> bool {

--- a/aries/aries_vcx/src/protocols/connection/inviter/mod.rs
+++ b/aries/aries_vcx/src/protocols/connection/inviter/mod.rs
@@ -24,7 +24,6 @@ use crate::{
     common::signing::sign_connection_response,
     errors::error::VcxResult,
     handlers::util::{verify_thread_id, AnyInvitation},
-    protocols::connection::trait_bounds::ThreadId,
 };
 
 pub type InviterConnection<S> = Connection<Inviter, S>;
@@ -235,16 +234,10 @@ impl InviterConnection<Requested> {
 
     /// Acknowledges an invitee's connection by processing their first message
     /// and transitions to [`InviterConnection<Completed>`].
-    ///
-    /// # Errors
-    ///
-    /// Will error out if the message's thread ID does not match
-    /// the ID of the thread context used in this connection.
     pub fn acknowledge_connection(
         self,
-        msg: &AriesMessage,
+        _msg: &AriesMessage,
     ) -> VcxResult<InviterConnection<Completed>> {
-        verify_thread_id(self.state.thread_id(), msg)?;
         let state = Completed::new(
             self.state.did_doc,
             self.state.signed_response.decorators.thread.thid,


### PR DESCRIPTION
Close #1253 

This adds handling for TrustPing, which solves the issue of connections not entering complete state when VCX is the connection inviter.

# Results of ariesvcx-acapy manual runset of RFC0160
` behave -D Acme=http://0.0.0.0:9020 -D Bob=http://0.0.0.0:9030 -t @RFC0160 -t ~@wip -t ~@RFC0434 -t ~@RFC0453 -t ~@RFC0211 -t ~@DIDExchangeConnection -t ~@Transport_Ws`
## Before
all failures.

## After
(failures are due to running this with only 2 agents)
```
Failing scenarios:
  features/0160-connection.feature:52  Inviter Sends invitation for one agent second agent tries after connection
  features/0160-connection.feature:69  Inviter Sends invitation for one agent second agent tries during first share phase

0 features passed, 2 failed, 13 skipped
4 scenarios passed, 2 failed, 154 skipped
28 steps passed, 2 failed, 1353 skipped, 0 undefined
```