### PR TITLE
chore: adjust dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
- # For details on how this file works refer to:
- #   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# For details on how this file works refer to:
+#   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions
@@ -8,119 +8,47 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       all-actions:
-        patterns: [ "*" ]
+        patterns: ["*"]
 
   # Maintain dependencies for Cargo Packages
   - package-ecosystem: "cargo"
-    directory: "/aries/misc/anoncreds_types"
+    directories:
+      - "/"
+      - "/aries/misc/anoncreds_types"
+      - "/aries/agents/aries-vcx-agent"
+      - "/aries/agents/mediator"
+      - "/aries/agents/aath-backchannel"
+      - "/aries/aries_vcx"
+      - "/aries/aries_vcx_anoncreds"
+      - "/aries/aries_vcx_ledger"
+      - "/aries/aries_vcx_wallet"
+      - "/aries/messages"
+      - "/aries/messages_macros"
+      - "/did_core/did_doc"
+      - "/did_methods"
+      - "/did_parser_nom"
+      - "/did_resolver"
+      - "/did_resolver_registry"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-
-  # Maintain dependencies for Cargo Packages
-  - package-ecosystem: "cargo"
-    directory: "/aries/misc/legacy/libvdrtools/indy-api-types"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # Maintain dependencies for Cargo Packages
-  - package-ecosystem: "cargo"
-    directory: "/aries/misc/legacy/libvdrtools/indy-utils"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # Maintain dependencies for Cargo Packages
-  - package-ecosystem: "cargo"
-    directory: "/aries/misc/legacy/libvdrtools/indy-wallet"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # Maintain dependencies for Cargo Packages
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # Maintain dependencies for Gradle
-  - package-ecosystem: "gradle"
-    directory: "/aries/agents/mobile_demo/app"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major", "version-update:semver-patch"]
-
-  # Maintain dependencies for Gradle
-  - package-ecosystem: "gradle"
-    directory: "/aries/agents/mobile_demo"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Canada/Pacific"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major", "version-update:semver-patch"]
 
   # Maintain dependencies for docker
   - package-ecosystem: "docker"
-    directory: "/.github/ci"
+    directories:
+      - "/.github/ci"
+      - "/aries/agents/aath-backchannel"
+      - "/aries/agents/mediator"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
-
-  # Maintain dependencies for docker
-  - package-ecosystem: "docker"
-    directory: "/aries/agents/aath-backchannel"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Canada/Pacific"
-
-  # Maintain dependencies for docker
-  - package-ecosystem: "docker"
-    directory: "/aries/agents/mediator"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-      timezone: "Canada/Pacific"
-      


### PR DESCRIPTION
Adjust our dependabot PR config to remove the legacy crates and mobile directories (until they are solidified or not in a demo state), added missing cargo crates, and adjusted the frequency to 'monthly' so that it's not too frequent, but still provides value in keeping dependencies up to date (hopefully). 