### PR TITLE
[FIX] #1245 DIDExchange request handling should require invitation key rotation

### DIFF
--- a/aries/agents/aath-backchannel/src/controllers/did_exchange.rs
+++ b/aries/agents/aath-backchannel/src/controllers/did_exchange.rs
@@ -202,7 +202,7 @@ impl HarnessAgent {
         let (thid, pthid, my_did, their_did) = self
             .aries_agent
             .did_exchange()
-            .handle_msg_request(request, &inviter_key, opt_invitation)
+            .handle_msg_request(request, &inviter_key.clone(), opt_invitation)
             .await?;
 
         if let Some(pthid) = pthid {

--- a/aries/agents/aath-backchannel/src/controllers/did_exchange.rs
+++ b/aries/agents/aath-backchannel/src/controllers/did_exchange.rs
@@ -128,13 +128,6 @@ impl HarnessAgent {
         };
 
         let thid = request.decorators.thread.clone().unwrap().thid;
-
-        let inviter_did = request.content.did.clone();
-        self.inviter_keys
-            .write()
-            .unwrap()
-            .insert(thid.clone(), inviter_did);
-
         Ok(json!({ "connection_id": thid }).to_string())
     }
 
@@ -202,7 +195,7 @@ impl HarnessAgent {
         let (thid, pthid, my_did, their_did) = self
             .aries_agent
             .did_exchange()
-            .handle_msg_request(request, &inviter_key.clone(), opt_invitation)
+            .handle_msg_request(request, inviter_key, opt_invitation)
             .await?;
 
         if let Some(pthid) = pthid {

--- a/aries/agents/aath-backchannel/src/controllers/did_exchange.rs
+++ b/aries/agents/aath-backchannel/src/controllers/did_exchange.rs
@@ -128,6 +128,13 @@ impl HarnessAgent {
         };
 
         let thid = request.decorators.thread.clone().unwrap().thid;
+
+        let inviter_did = request.content.did.clone();
+        self.inviter_keys
+            .write()
+            .unwrap()
+            .insert(thid.clone(), inviter_did);
+
         Ok(json!({ "connection_id": thid }).to_string())
     }
 
@@ -178,6 +185,13 @@ impl HarnessAgent {
 
         let request_thread = &request.inner().decorators.thread;
 
+        let inviter_key = request_thread
+            .as_ref()
+            .and_then(|th| self.inviter_keys.read().unwrap().get(&th.thid).cloned())
+            .ok_or_else(|| {
+                HarnessError::from_msg(HarnessErrorType::InvalidState, "Inviter key not found")
+            })?;
+
         let opt_invitation = match request_thread.as_ref().and_then(|th| th.pthid.as_ref()) {
             Some(pthid) => {
                 let invitation = self.aries_agent.out_of_band().get_invitation(pthid)?;
@@ -188,7 +202,7 @@ impl HarnessAgent {
         let (thid, pthid, my_did, their_did) = self
             .aries_agent
             .did_exchange()
-            .handle_msg_request(request, opt_invitation)
+            .handle_msg_request(request, &inviter_key, opt_invitation)
             .await?;
 
         if let Some(pthid) = pthid {

--- a/aries/agents/aath-backchannel/src/controllers/didcomm.rs
+++ b/aries/agents/aath-backchannel/src/controllers/didcomm.rs
@@ -1,9 +1,5 @@
 use std::sync::RwLock;
 
-use crate::{
-    error::{HarnessError, HarnessErrorType, HarnessResult},
-    HarnessAgent,
-};
 use actix_web::{web, HttpResponse, Responder};
 use aries_vcx_agent::aries_vcx::{
     messages::{
@@ -21,6 +17,11 @@ use aries_vcx_agent::aries_vcx::{
         AriesMessage,
     },
     utils::encryption_envelope::EncryptionEnvelope,
+};
+
+use crate::{
+    error::{HarnessError, HarnessErrorType, HarnessResult},
+    HarnessAgent,
 };
 
 impl HarnessAgent {

--- a/aries/agents/aath-backchannel/src/controllers/issuance.rs
+++ b/aries/agents/aath-backchannel/src/controllers/issuance.rs
@@ -95,7 +95,6 @@ async fn download_tails_file(
     let url = match tails_base_url.to_string().matches('/').count() {
         0 => format!("{}/{}", tails_base_url, rev_reg_id),
         1.. => tails_base_url.to_string(),
-        _ => todo!(),
     };
     let client = reqwest::Client::new();
     let tails_folder_path = std::env::current_dir()

--- a/aries/agents/aath-backchannel/src/controllers/issuance.rs
+++ b/aries/agents/aath-backchannel/src/controllers/issuance.rs
@@ -95,6 +95,7 @@ async fn download_tails_file(
     let url = match tails_base_url.to_string().matches('/').count() {
         0 => format!("{}/{}", tails_base_url, rev_reg_id),
         1.. => tails_base_url.to_string(),
+        _ => todo!(),
     };
     let client = reqwest::Client::new();
     let tails_folder_path = std::env::current_dir()

--- a/aries/agents/aath-backchannel/src/main.rs
+++ b/aries/agents/aath-backchannel/src/main.rs
@@ -75,6 +75,7 @@ pub struct HarnessAgent {
     // todo: extra didx specific AATH service
     didx_msg_buffer: RwLock<Vec<AriesMessage>>,
     didx_pthid_to_thid: Mutex<HashMap<String, String>>,
+    inviter_keys: RwLock<HashMap<String, String>>,
 }
 
 #[macro_export]
@@ -121,6 +122,7 @@ async fn main() -> std::io::Result<()> {
                 status: Status::Active,
                 didx_msg_buffer: Default::default(),
                 didx_pthid_to_thid: Mutex::new(Default::default()),
+                inviter_keys: RwLock::new(HashMap::new()),
             })))
             .app_data(web::Data::new(RwLock::new(Vec::<AriesMessage>::new())))
             .service(

--- a/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
@@ -15,7 +15,7 @@ use aries_vcx::{
         AriesMessage,
     },
     protocols::did_exchange::{
-        resolve_enc_key_from_did_doc, resolve_enc_key_from_invitation,
+        resolve_enc_key_from_did, resolve_enc_key_from_did_doc, resolve_enc_key_from_invitation,
         state_machine::{
             generic::{GenericDidExchange, ThinState},
             helpers::create_peer_did_4,
@@ -125,6 +125,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
     pub async fn handle_msg_request(
         &self,
         request: AnyRequest,
+        request_did: &String,
         invitation: Option<OobInvitation>,
     ) -> AgentResult<(String, Option<String>, String, String)> {
         // todo: type the return type
@@ -144,14 +145,9 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
 
         // Todo: "invitation_key" should not be None; see the todo inside this scope
         let invitation_key = match invitation {
-            None => {
-                // TODO: Case for "implicit invitations", where request is sent on basis of
-                // knowledge of public DID       However in that cases we should
-                // probably use the Recipient Verkey which was used to anoncrypt the Request msg
-                None
-            }
+            None => resolve_enc_key_from_did(&request_did, &self.resolver_registry).await?,
             Some(invitation) => {
-                Some(resolve_enc_key_from_invitation(&invitation, &self.resolver_registry).await?)
+                resolve_enc_key_from_invitation(&invitation, &self.resolver_registry).await?
             }
         };
 

--- a/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
@@ -125,7 +125,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
     pub async fn handle_msg_request(
         &self,
         request: AnyRequest,
-        request_did: &String,
+        request_did: &str,
         invitation: Option<OobInvitation>,
     ) -> AgentResult<(String, Option<String>, String, String)> {
         // todo: type the return type

--- a/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
@@ -145,7 +145,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
 
         // Todo: "invitation_key" should not be None; see the todo inside this scope
         let invitation_key = match invitation {
-            None => resolve_enc_key_from_did(&request_did, &self.resolver_registry).await?,
+            None => resolve_enc_key_from_did(request_did, &self.resolver_registry).await?,
             Some(invitation) => {
                 resolve_enc_key_from_invitation(&invitation, &self.resolver_registry).await?
             }

--- a/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
@@ -15,7 +15,7 @@ use aries_vcx::{
         AriesMessage,
     },
     protocols::did_exchange::{
-        resolve_enc_key_from_did, resolve_enc_key_from_did_doc, resolve_enc_key_from_invitation,
+        resolve_enc_key_from_did_doc, resolve_enc_key_from_invitation,
         state_machine::{
             generic::{GenericDidExchange, ThinState},
             helpers::create_peer_did_4,
@@ -27,6 +27,7 @@ use aries_vcx::{
 use aries_vcx_wallet::wallet::base_wallet::BaseWallet;
 use did_resolver_registry::ResolverRegistry;
 use did_resolver_sov::did_resolver::did_doc::schema::did_doc::DidDocument;
+use public_key::{Key, KeyType};
 use url::Url;
 
 use crate::{
@@ -125,7 +126,7 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
     pub async fn handle_msg_request(
         &self,
         request: AnyRequest,
-        request_did: &str,
+        inviter_key: String,
         invitation: Option<OobInvitation>,
     ) -> AgentResult<(String, Option<String>, String, String)> {
         // todo: type the return type
@@ -143,9 +144,11 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
             .thid
             .clone();
 
+        let inviter_key = Key::from_base58(&inviter_key, KeyType::Ed25519)?;
+
         // Todo: "invitation_key" should not be None; see the todo inside this scope
         let invitation_key = match invitation {
-            None => resolve_enc_key_from_did(request_did, &self.resolver_registry).await?,
+            None => inviter_key,
             Some(invitation) => {
                 resolve_enc_key_from_invitation(&invitation, &self.resolver_registry).await?
             }

--- a/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/did_exchange.rs
@@ -146,7 +146,6 @@ impl<T: BaseWallet> DidcommHandlerDidExchange<T> {
 
         let inviter_key = Key::from_base58(&inviter_key, KeyType::Ed25519)?;
 
-        // Todo: "invitation_key" should not be None; see the todo inside this scope
         let invitation_key = match invitation {
             None => inviter_key,
             Some(invitation) => {

--- a/aries/aries_vcx/src/protocols/did_exchange/mod.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/mod.rs
@@ -115,6 +115,27 @@ pub async fn resolve_enc_key_from_invitation(
     }
 }
 
+pub async fn resolve_enc_key_from_did(
+    did: &String,
+    resolver_registry: &Arc<ResolverRegistry>,
+) -> Result<Key, AriesVcxError> {
+    let output = resolver_registry
+        .resolve(&did.clone().try_into()?, &Default::default())
+        .await
+        .map_err(|err| {
+            AriesVcxError::from_msg(
+                AriesVcxErrorKind::InvalidDid,
+                format!("DID resolution failed: {err}"),
+            )
+        })?;
+    info!(
+        "resolve_enc_key_from_did >> Resolved did document {}",
+        output.did_document
+    );
+    let did_doc = output.did_document;
+    resolve_enc_key_from_did_doc(&did_doc)
+}
+
 /// Attempts to resolve a [Key] in the [DidDocument] that can be used for sending encrypted
 /// messages. The approach is:
 /// * check the service for a recipient key,

--- a/aries/aries_vcx/src/protocols/did_exchange/mod.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/mod.rs
@@ -116,11 +116,11 @@ pub async fn resolve_enc_key_from_invitation(
 }
 
 pub async fn resolve_enc_key_from_did(
-    did: &String,
+    did: &str,
     resolver_registry: &Arc<ResolverRegistry>,
 ) -> Result<Key, AriesVcxError> {
     let output = resolver_registry
-        .resolve(&did.clone().try_into()?, &Default::default())
+        .resolve(&did.try_into()?, &Default::default())
         .await
         .map_err(|err| {
             AriesVcxError::from_msg(

--- a/aries/aries_vcx/src/protocols/did_exchange/state_machine/generic/mod.rs
+++ b/aries/aries_vcx/src/protocols/did_exchange/state_machine/generic/mod.rs
@@ -118,7 +118,7 @@ impl GenericDidExchange {
         resolver_registry: &Arc<ResolverRegistry>,
         request: AnyRequest,
         our_peer_did: &PeerDid<Numalgo4>,
-        invitation_key: Option<Key>,
+        invitation_key: Key,
     ) -> Result<(Self, AnyResponse), AriesVcxError> {
         let TransitionResult { state, output } =
             DidExchangeResponder::<ResponseSent>::receive_request(

--- a/aries/aries_vcx/tests/test_did_exchange.rs
+++ b/aries/aries_vcx/tests/test_did_exchange.rs
@@ -135,7 +135,7 @@ async fn did_exchange_test(
         &resolver_registry,
         request,
         &responders_peer_did,
-        Some(invitation_key.clone()),
+        invitation_key.clone(),
     )
     .await
     .unwrap();
@@ -337,7 +337,7 @@ async fn did_exchange_test_with_invalid_rotation_signature() -> Result<(), Box<d
         request,
         &responders_peer_did,
         // sign with NOT the invitation key
-        Some(incorrect_invitation_key),
+        incorrect_invitation_key,
     )
     .await?;
 


### PR DESCRIPTION
This PR introduces a fix for the optional invitation key in DIDExchange handle_request described here in issue [https://github.com/hyperledger/aries-vcx/issues/1245](url).

Closes https://github.com/hyperledger/aries-vcx/issues/1245