### PR TITLE
[fix] Multibase public key decoding incorrectly

### DIFF
--- a/did_core/did_doc/src/schema/types/jsonwebkey.rs
+++ b/did_core/did_doc/src/schema/types/jsonwebkey.rs
@@ -48,13 +48,6 @@ impl JsonWebKey {
             source: Box::new(err),
         })
     }
-
-    pub fn to_vec(&self) -> Result<Vec<u8>, JsonWebKeyError> {
-        serde_json::to_vec(self).map_err(|err| JsonWebKeyError {
-            reason: "Serializing JWK to vector failed",
-            source: Box::new(err),
-        })
-    }
 }
 
 impl FromStr for JsonWebKey {

--- a/did_core/did_doc/src/schema/verification_method/error.rs
+++ b/did_core/did_doc/src/schema/verification_method/error.rs
@@ -90,3 +90,12 @@ impl From<JsonWebKeyError> for KeyDecodingError {
         }
     }
 }
+
+impl From<public_key::PublicKeyError> for KeyDecodingError {
+    fn from(error: public_key::PublicKeyError) -> Self {
+        KeyDecodingError {
+            reason: "Failed to decode multibase public key",
+            source: Some(Box::new(error)),
+        }
+    }
+}

--- a/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo2/verification_method.rs
+++ b/did_core/did_methods/did_peer/src/peer_did/numalgos/numalgo2/verification_method.rs
@@ -194,11 +194,12 @@ mod tests {
             )
             .unwrap();
             assert_eq!(vms.len(), 1);
-            assert_eq!(
-                vms[0].public_key_field().key_decoded().unwrap(),
-                key.multicodec_prefixed_key()
-            );
-            assert_ne!(vms[0].public_key_field().key_decoded().unwrap(), key.key());
+            let vm = &vms[0];
+            assert!(matches!(
+                vm.public_key_field(),
+                PublicKeyField::Multibase { .. }
+            ));
+            assert_eq!(vm.public_key_field().key_decoded().unwrap(), key.key());
         }
 
         // ... and base58 encoded keys are not
@@ -211,11 +212,12 @@ mod tests {
             )
             .unwrap();
             assert_eq!(vms.len(), 1);
-            assert_ne!(
-                vms[0].public_key_field().key_decoded().unwrap(),
-                key.multicodec_prefixed_key()
-            );
-            assert_eq!(vms[0].public_key_field().key_decoded().unwrap(), key.key());
+            let vm = &vms[0];
+            assert!(matches!(
+                vm.public_key_field(),
+                PublicKeyField::Base58 { .. }
+            ));
+            assert_eq!(vm.public_key_field().key_decoded().unwrap(), key.key());
         }
 
         #[test]


### PR DESCRIPTION
The PublicKeyField::key_decoded (i.e. "give me the raw public key bytes") was returning the wrong bytes for the `publicKeyMultibase` verification method field. Particularly, it was returning the [multikey-type + public key bytes] (i.e. the bytes prefixed with the key type), whereas we want it to just return the public key bytes (to align with what the other PublicKeyField variants decode to).

The unit tests were previously self-fulfilling in testing this, so it was not spotted. An easy way to spot the error is looking at what the `PUBLIC_KEY_HEX` test vector _used_ to be; a **34** byte long array.. when's the last time you've seen a public key that is 34 bytes long! (it's because we were leaving the 2 byte multikey type prefix in there `[236, 1]` (a.k.a. 0xEC: https://github.com/multiformats/multicodec/blob/master/table.csv#L97)).

I also removed the key_decoded solution for JWK, as it was incorrect too; it was just returning the JSON serialized JWK as if it is the public key bytes. IMO the `to_vec` method of the `JsonWebKey` is misleading for this reason, so i removed it (i was expecting it to return the public key bytes..).