### PR TITLE
[fix] fix some AATH flow where a connection does not yet exist

### DIFF
--- a/aries/agents/aath-backchannel/src/controllers/did_exchange.rs
+++ b/aries/agents/aath-backchannel/src/controllers/did_exchange.rs
@@ -60,8 +60,26 @@ impl HarnessAgent {
         .to_string())
     }
 
-    pub fn queue_didexchange_request(&self, request: AnyRequest) -> HarnessResult<()> {
-        info!("queue_didexchange_request >> request: {:?}", request);
+    pub fn queue_didexchange_request(
+        &self,
+        request: AnyRequest,
+        recipient_verkey: String,
+    ) -> HarnessResult<()> {
+        info!(
+            "queue_didexchange_request >> request: {:?} for recipient {}",
+            request, recipient_verkey
+        );
+
+        let thid = request
+            .inner()
+            .decorators
+            .thread
+            .clone()
+            .ok_or(HarnessError::from_msg(
+                HarnessErrorType::InvalidState,
+                "DID Exchange request is missing a thread",
+            ))?;
+
         let mut msg_buffer = self.didx_msg_buffer.write().map_err(|_| {
             HarnessError::from_msg(
                 HarnessErrorType::InvalidState,
@@ -70,6 +88,19 @@ impl HarnessAgent {
         })?;
         let m = AriesMessage::from(request);
         msg_buffer.push(m);
+
+        let mut recipients = self
+            .didx_thid_to_request_recipient_verkey
+            .lock()
+            .map_err(|_| {
+                HarnessError::from_msg(
+                    HarnessErrorType::InvalidState,
+                    "Failed to lock DIDExchange ",
+                )
+            })?;
+
+        recipients.insert(thid.thid, recipient_verkey);
+
         Ok(())
     }
 
@@ -178,9 +209,15 @@ impl HarnessAgent {
 
         let request_thread = &request.inner().decorators.thread;
 
-        let inviter_key = request_thread
+        let recipient_key = request_thread
             .as_ref()
-            .and_then(|th| self.inviter_keys.read().unwrap().get(&th.thid).cloned())
+            .and_then(|th| {
+                self.didx_thid_to_request_recipient_verkey
+                    .lock()
+                    .unwrap()
+                    .get(&th.thid)
+                    .cloned()
+            })
             .ok_or_else(|| {
                 HarnessError::from_msg(HarnessErrorType::InvalidState, "Inviter key not found")
             })?;
@@ -195,7 +232,7 @@ impl HarnessAgent {
         let (thid, pthid, my_did, their_did) = self
             .aries_agent
             .did_exchange()
-            .handle_msg_request(request, inviter_key, opt_invitation)
+            .handle_msg_request(request, recipient_key, opt_invitation)
             .await?;
 
         if let Some(pthid) = pthid {

--- a/aries/agents/aath-backchannel/src/main.rs
+++ b/aries/agents/aath-backchannel/src/main.rs
@@ -75,7 +75,8 @@ pub struct HarnessAgent {
     // todo: extra didx specific AATH service
     didx_msg_buffer: RwLock<Vec<AriesMessage>>,
     didx_pthid_to_thid: Mutex<HashMap<String, String>>,
-    inviter_keys: RwLock<HashMap<String, String>>,
+    // A map of DIDExchange thread IDs to the intended recipient
+    didx_thid_to_request_recipient_verkey: Mutex<HashMap<String, String>>,
 }
 
 #[macro_export]
@@ -121,8 +122,8 @@ async fn main() -> std::io::Result<()> {
                 aries_agent: aries_agent.clone(),
                 status: Status::Active,
                 didx_msg_buffer: Default::default(),
-                didx_pthid_to_thid: Mutex::new(Default::default()),
-                inviter_keys: RwLock::new(HashMap::new()),
+                didx_pthid_to_thid: Default::default(),
+                didx_thid_to_request_recipient_verkey: Default::default(),
             })))
             .app_data(web::Data::new(RwLock::new(Vec::<AriesMessage>::new())))
             .service(


### PR DESCRIPTION
continues from changes in #1278, with a small change to not use the "get connection by sender" API, since the connection may not exist in some contexts.

This should fix the recent AATH issue being reported by @nodlesh :
```
riesVCX Error: Error: Error: POST failed due to non-success HTTP status: 500 Internal Server Error, response body: Error: AgentError: Invalid state: Found no connections by sender's verkey 4rBrKy5znEKSvePtLjsv8ws2ERteF6vjcdabb1PxtrkL
  
[90m[[0m2024-08-05T03:14:02Z [1m[31mERROR[0m aries_vcx_backchannel::error[90m][0m Error: AgentError: AriesVCX error: AriesVCX Error: Error: Error: POST failed due to non-success HTTP status: 500 Internal Server Error, response body: Error: AgentError: Invalid state: Found no connections by sender's verkey 4rBrKy5znEKSvePtLjsv8ws2ERteF6vjcdabb1PxtrkL
```