### PR TITLE
feat: add additional formats for parsing and outputting Out Of Band Invitations

### DIFF
--- a/aries/agents/aries-vcx-agent/src/handlers/out_of_band.rs
+++ b/aries/agents/aries-vcx-agent/src/handlers/out_of_band.rs
@@ -52,7 +52,7 @@ impl<T: BaseWallet> ServiceOutOfBand<T> {
             GenericOutOfBand::Sender(sender.to_owned()),
         )?;
 
-        Ok(sender.to_aries_message())
+        Ok(sender.invitation_to_aries_message())
     }
 
     pub fn receive_invitation(&self, invitation: AriesMessage) -> AgentResult<String> {

--- a/aries/aries_vcx/src/errors/mapping_others.rs
+++ b/aries/aries_vcx/src/errors/mapping_others.rs
@@ -1,7 +1,9 @@
-use std::{num::ParseIntError, sync::PoisonError};
+use std::{num::ParseIntError, string::FromUtf8Error, sync::PoisonError};
 
+use base64::DecodeError;
 use did_doc::schema::{types::uri::UriWrapperError, utils::error::DidDocumentLookupError};
 use shared::errors::http_error::HttpError;
+use url::ParseError;
 
 use crate::{
     errors::error::{AriesVcxError, AriesVcxErrorKind},
@@ -89,6 +91,24 @@ impl From<UriWrapperError> for AriesVcxError {
 
 impl From<ParseIntError> for AriesVcxError {
     fn from(err: ParseIntError) -> Self {
+        AriesVcxError::from_msg(AriesVcxErrorKind::InvalidInput, err.to_string())
+    }
+}
+
+impl From<DecodeError> for AriesVcxError {
+    fn from(err: DecodeError) -> Self {
+        AriesVcxError::from_msg(AriesVcxErrorKind::InvalidInput, err.to_string())
+    }
+}
+
+impl From<FromUtf8Error> for AriesVcxError {
+    fn from(err: FromUtf8Error) -> Self {
+        AriesVcxError::from_msg(AriesVcxErrorKind::InvalidInput, err.to_string())
+    }
+}
+
+impl From<ParseError> for AriesVcxError {
+    fn from(err: ParseError) -> Self {
         AriesVcxError::from_msg(AriesVcxErrorKind::InvalidInput, err.to_string())
     }
 }

--- a/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
@@ -41,22 +41,28 @@ impl OutOfBandReceiver {
         }
     }
 
-    pub fn from_json_string(oob_json: &str) -> VcxResult<Self> {
+    pub fn create_from_json_encoded_oob(oob_json: &str) -> VcxResult<Self> {
         Ok(Self {
-            oob: from_json_string(oob_json)?,
+            oob: extract_encoded_invitation_from_json_string(oob_json)?,
         })
     }
 
-    pub fn from_base64_url(base64_url_encoded_oob: &str) -> VcxResult<Self> {
+    fn create_from_base64_url_encoded_oob(base64_url_encoded_oob: &str) -> VcxResult<Self> {
         Ok(Self {
-            oob: from_json_string(&from_base64_url(base64_url_encoded_oob)?)?,
+            oob: extract_encoded_invitation_from_json_string(
+                &extract_encoded_invitation_from_base64_url(base64_url_encoded_oob)?,
+            )?,
         })
     }
 
-    pub fn from_url(oob_url_string: &str) -> VcxResult<Self> {
+    pub fn create_from_url_encoded_oob(oob_url_string: &str) -> VcxResult<Self> {
         // TODO - URL Shortening
         Ok(Self {
-            oob: from_json_string(&from_base64_url(&from_url(oob_url_string)?)?)?,
+            oob: extract_encoded_invitation_from_json_string(
+                &extract_encoded_invitation_from_base64_url(&extract_encoded_invitation_from_url(
+                    oob_url_string,
+                )?)?,
+            )?,
         })
     }
 
@@ -80,37 +86,37 @@ impl OutOfBandReceiver {
         }
     }
 
-    pub fn to_aries_message(&self) -> AriesMessage {
+    pub fn invitation_to_aries_message(&self) -> AriesMessage {
         self.oob.clone().into()
     }
 
-    pub fn to_json_string(&self) -> String {
-        self.to_aries_message().to_string()
+    pub fn invitation_to_json_string(&self) -> String {
+        self.invitation_to_aries_message().to_string()
     }
 
-    pub fn to_base64_url(&self) -> String {
-        BASE64_URL_SAFE.encode(self.to_json_string())
+    fn invitation_to_base64_url(&self) -> String {
+        BASE64_URL_SAFE.encode(self.invitation_to_json_string())
     }
 
-    pub fn to_url(&self, domain_path: &str) -> VcxResult<Url> {
+    pub fn invitation_to_url(&self, domain_path: &str) -> VcxResult<Url> {
         let mut oob_url = Url::parse(domain_path)?;
-        let oob_query = "oob=".to_owned() + &self.to_base64_url();
+        let oob_query = "oob=".to_owned() + &self.invitation_to_base64_url();
         oob_url.set_query(Some(&oob_query));
         Ok(oob_url)
     }
 }
 
-fn from_json_string(oob_json: &str) -> VcxResult<Invitation> {
+fn extract_encoded_invitation_from_json_string(oob_json: &str) -> VcxResult<Invitation> {
     Ok(serde_json::from_str(oob_json)?)
 }
 
-fn from_base64_url(base64_url_encoded_oob: &str) -> VcxResult<String> {
+fn extract_encoded_invitation_from_base64_url(base64_url_encoded_oob: &str) -> VcxResult<String> {
     Ok(String::from_utf8(
         URL_SAFE_LENIENT.decode(base64_url_encoded_oob)?,
     )?)
 }
 
-fn from_url(oob_url_string: &str) -> VcxResult<String> {
+fn extract_encoded_invitation_from_url(oob_url_string: &str) -> VcxResult<String> {
     let oob_url = Url::parse(oob_url_string)?;
     let (_oob_query, base64_url_encoded_oob) = oob_url
         .query_pairs()
@@ -222,6 +228,7 @@ mod tests {
       }"#;
     const JSON_OOB_INVITE_NO_WHITESPACE: &str = r#"{"@type":"https://didcomm.org/out-of-band/1.1/invitation","@id":"69212a3a-d068-4f9d-a2dd-4741bca89af3","label":"Faber College","goal_code":"issue-vc","goal":"To issue a Faber College Graduate credential","handshake_protocols":["https://didcomm.org/didexchange/1.0","https://didcomm.org/connections/1.0"],"services":["did:sov:LjgpST2rjsoxYegQDRm7EL"]}"#;
     const OOB_BASE64_URL_ENCODED: &str = "eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
+    const OOB_BASE64_URL_ENCODED_NO_PADDING: &str = "eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0";
     const OOB_URL: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
 
     // Params mimic example invitation in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
@@ -258,7 +265,7 @@ mod tests {
     #[test]
     fn receive_invitation_by_json() {
         let base_invite = _create_invitation();
-        let parsed_invite = OutOfBandReceiver::from_json_string(JSON_OOB_INVITE)
+        let parsed_invite = OutOfBandReceiver::create_from_json_encoded_oob(JSON_OOB_INVITE)
             .unwrap()
             .oob;
         assert_eq!(base_invite, parsed_invite);
@@ -267,52 +274,70 @@ mod tests {
     #[test]
     fn receive_invitation_by_json_no_whitespace() {
         let base_invite = _create_invitation();
-        let parsed_invite = OutOfBandReceiver::from_json_string(JSON_OOB_INVITE_NO_WHITESPACE)
-            .unwrap()
-            .oob;
+        let parsed_invite =
+            OutOfBandReceiver::create_from_json_encoded_oob(JSON_OOB_INVITE_NO_WHITESPACE)
+                .unwrap()
+                .oob;
         assert_eq!(base_invite, parsed_invite);
     }
 
     #[test]
     fn receive_invitation_by_base64_url() {
         let base_invite = _create_invitation();
-        let parsed_invite = OutOfBandReceiver::from_base64_url(OOB_BASE64_URL_ENCODED)
-            .unwrap()
-            .oob;
+        let parsed_invite =
+            OutOfBandReceiver::create_from_base64_url_encoded_oob(OOB_BASE64_URL_ENCODED)
+                .unwrap()
+                .oob;
+        assert_eq!(base_invite, parsed_invite);
+    }
+
+    #[test]
+    fn receive_invitation_by_base64_url_no_padding() {
+        let base_invite = _create_invitation();
+        let parsed_invite = OutOfBandReceiver::create_from_base64_url_encoded_oob(
+            OOB_BASE64_URL_ENCODED_NO_PADDING,
+        )
+        .unwrap()
+        .oob;
         assert_eq!(base_invite, parsed_invite);
     }
 
     #[test]
     fn receive_invitation_by_url() {
         let base_invite = _create_invitation();
-        let parsed_invite = OutOfBandReceiver::from_url(OOB_URL).unwrap().oob;
+        let parsed_invite = OutOfBandReceiver::create_from_url_encoded_oob(OOB_URL)
+            .unwrap()
+            .oob;
         assert_eq!(base_invite, parsed_invite);
     }
 
     #[test]
     fn invitation_to_json() {
-        let out_of_band_receiver = OutOfBandReceiver::from_json_string(JSON_OOB_INVITE).unwrap();
+        let out_of_band_receiver =
+            OutOfBandReceiver::create_from_json_encoded_oob(JSON_OOB_INVITE).unwrap();
 
-        let json_invite = out_of_band_receiver.to_json_string();
+        let json_invite = out_of_band_receiver.invitation_to_json_string();
 
         assert_eq!(JSON_OOB_INVITE_NO_WHITESPACE, json_invite);
     }
 
     #[test]
     fn invitation_to_base64_url() {
-        let out_of_band_receiver = OutOfBandReceiver::from_json_string(JSON_OOB_INVITE).unwrap();
+        let out_of_band_receiver =
+            OutOfBandReceiver::create_from_json_encoded_oob(JSON_OOB_INVITE).unwrap();
 
-        let base64_url_invite = out_of_band_receiver.to_base64_url();
+        let base64_url_invite = out_of_band_receiver.invitation_to_base64_url();
 
         assert_eq!(OOB_BASE64_URL_ENCODED, base64_url_invite);
     }
 
     #[test]
     fn invitation_to_url() {
-        let out_of_band_receiver = OutOfBandReceiver::from_json_string(JSON_OOB_INVITE).unwrap();
+        let out_of_band_receiver =
+            OutOfBandReceiver::create_from_json_encoded_oob(JSON_OOB_INVITE).unwrap();
 
         let oob_url = out_of_band_receiver
-            .to_url("http://example.com/ssi")
+            .invitation_to_url("http://example.com/ssi")
             .unwrap()
             .to_string();
 

--- a/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
@@ -83,6 +83,21 @@ impl OutOfBandReceiver {
     pub fn to_aries_message(&self) -> AriesMessage {
         self.oob.clone().into()
     }
+
+    pub fn to_json_string(&self) -> VcxResult<String> {
+        Ok(serde_json::to_string(&self.oob)?)
+    }
+
+    pub fn to_base64_url(&self) -> String {
+        URL_SAFE_LENIENT.encode(self.oob.to_string())
+    }
+
+    pub fn to_url(&self, domain_path: &str) -> VcxResult<Url> {
+        let mut oob_url = Url::parse(&(domain_path.to_owned() + &self.oob.to_string()))?;
+        let oob_query = "oob=".to_owned() + &self.to_base64_url();
+        oob_url.set_query(Some(&oob_query));
+        Ok(oob_url)
+    }
 }
 
 fn from_json_string(oob_json: &str) -> VcxResult<Invitation> {

--- a/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
@@ -47,6 +47,8 @@ impl OutOfBandReceiver {
         })
     }
 
+    // This is here to help facilitate testing
+    #[allow(dead_code)]
     fn create_from_base64_url_encoded_oob(base64_url_encoded_oob: &str) -> VcxResult<Self> {
         Ok(Self {
             oob: extract_encoded_invitation_from_json_string(

--- a/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
@@ -93,7 +93,7 @@ impl OutOfBandReceiver {
     }
 
     pub fn to_url(&self, domain_path: &str) -> VcxResult<Url> {
-        let mut oob_url = Url::parse(&domain_path.to_owned())?;
+        let mut oob_url = Url::parse(&domain_path)?;
         let oob_query = "oob=".to_owned() + &self.to_base64_url();
         oob_url.set_query(Some(&oob_query));
         Ok(oob_url)
@@ -114,7 +114,7 @@ fn from_url(oob_url_string: &str) -> VcxResult<String> {
     let oob_url = Url::parse(oob_url_string)?;
     let (_oob_query, base64_url_encoded_oob) = oob_url
         .query_pairs()
-        .find(|(name, _value)| name == &"oob")
+        .find(|(name, _value)| name == "oob")
         .ok_or_else(|| {
             AriesVcxError::from_msg(
                 AriesVcxErrorKind::InvalidInput,
@@ -195,7 +195,6 @@ fn attachment_to_aries_message(attach: &Attachment) -> VcxResult<Option<AriesMes
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use messages::{
         msg_fields::protocols::out_of_band::{
             invitation::{Invitation, InvitationContent, InvitationDecorators, OobService},
@@ -208,6 +207,8 @@ mod tests {
         },
     };
     use shared::maybe_known::MaybeKnown;
+
+    use super::*;
 
     // Example invite formats referenced (with change to use OOB 1.1) from example invite in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
     const JSON_OOB_INVITE: &str = r#"{

--- a/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
@@ -93,7 +93,7 @@ impl OutOfBandReceiver {
     }
 
     pub fn to_url(&self, domain_path: &str) -> VcxResult<Url> {
-        let mut oob_url = Url::parse(&domain_path)?;
+        let mut oob_url = Url::parse(domain_path)?;
         let oob_query = "oob=".to_owned() + &self.to_base64_url();
         oob_url.set_query(Some(&oob_query));
         Ok(oob_url)

--- a/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
@@ -101,9 +101,11 @@ impl OutOfBandReceiver {
     }
 
     pub fn invitation_to_url(&self, domain_path: &str) -> VcxResult<Url> {
-        let mut oob_url = Url::parse(domain_path)?;
-        let oob_query = "oob=".to_owned() + &self.invitation_to_base64_url();
-        oob_url.set_query(Some(&oob_query));
+        let oob_url = Url::parse(domain_path)?
+            .query_pairs_mut()
+            .append_pair("oob", &self.invitation_to_base64_url())
+            .finish()
+            .to_owned();
         Ok(oob_url)
     }
 }
@@ -231,7 +233,8 @@ mod tests {
     const JSON_OOB_INVITE_NO_WHITESPACE: &str = r#"{"@type":"https://didcomm.org/out-of-band/1.1/invitation","@id":"69212a3a-d068-4f9d-a2dd-4741bca89af3","label":"Faber College","goal_code":"issue-vc","goal":"To issue a Faber College Graduate credential","handshake_protocols":["https://didcomm.org/didexchange/1.0","https://didcomm.org/connections/1.0"],"services":["did:sov:LjgpST2rjsoxYegQDRm7EL"]}"#;
     const OOB_BASE64_URL_ENCODED: &str = "eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
     const OOB_BASE64_URL_ENCODED_NO_PADDING: &str = "eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0";
-    const OOB_URL: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
+    const OOB_URL: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0%3D";
+    const OOB_URL_NOT_PERCENT_ENCODED: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
 
     // Params mimic example invitation in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
     fn _create_invitation() -> Invitation {
@@ -310,6 +313,16 @@ mod tests {
         let parsed_invite = OutOfBandReceiver::create_from_url_encoded_oob(OOB_URL)
             .unwrap()
             .oob;
+        assert_eq!(base_invite, parsed_invite);
+    }
+
+    #[test]
+    fn receive_invitation_by_url_no_percent_encoding() {
+        let base_invite = _create_invitation();
+        let parsed_invite =
+            OutOfBandReceiver::create_from_url_encoded_oob(OOB_URL_NOT_PERCENT_ENCODED)
+                .unwrap()
+                .oob;
         assert_eq!(base_invite, parsed_invite);
     }
 

--- a/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/receiver.rs
@@ -195,6 +195,7 @@ fn attachment_to_aries_message(attach: &Attachment) -> VcxResult<Option<AriesMes
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use messages::{
         msg_fields::protocols::out_of_band::{
             invitation::{Invitation, InvitationContent, InvitationDecorators, OobService},
@@ -208,8 +209,6 @@ mod tests {
     };
     use shared::maybe_known::MaybeKnown;
 
-    use crate::handlers::out_of_band::receiver::OutOfBandReceiver;
-
     // Example invite formats referenced (with change to use OOB 1.1) from example invite in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
     const JSON_OOB_INVITE: &str = r#"{
         "@type": "https://didcomm.org/out-of-band/1.1/invitation",
@@ -221,9 +220,7 @@ mod tests {
         "services": ["did:sov:LjgpST2rjsoxYegQDRm7EL"]
       }"#;
     const JSON_OOB_INVITE_NO_WHITESPACE: &str = r#"{"@type":"https://didcomm.org/out-of-band/1.1/invitation","@id":"69212a3a-d068-4f9d-a2dd-4741bca89af3","label":"Faber College","goal_code":"issue-vc","goal":"To issue a Faber College Graduate credential","handshake_protocols":["https://didcomm.org/didexchange/1.0","https://didcomm.org/connections/1.0"],"services":["did:sov:LjgpST2rjsoxYegQDRm7EL"]}"#;
-
     const OOB_BASE64_URL_ENCODED: &str = "eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
-
     const OOB_URL: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
 
     // Params mimic example invitation in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband

--- a/aries/aries_vcx/src/handlers/out_of_band/sender.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/sender.rs
@@ -130,21 +130,21 @@ impl OutOfBandSender {
         Ok(self)
     }
 
-    pub fn to_aries_message(&self) -> AriesMessage {
+    pub fn invitation_to_aries_message(&self) -> AriesMessage {
         self.oob.clone().into()
     }
 
-    pub fn to_json_string(&self) -> String {
-        self.to_aries_message().to_string()
+    pub fn invitation_to_json_string(&self) -> String {
+        self.invitation_to_aries_message().to_string()
     }
 
-    pub fn to_base64_url(&self) -> String {
-        BASE64_URL_SAFE.encode(self.to_json_string())
+    fn invitation_to_base64_url(&self) -> String {
+        BASE64_URL_SAFE.encode(self.invitation_to_json_string())
     }
 
-    pub fn to_url(&self, domain_path: &str) -> VcxResult<Url> {
+    pub fn invitation_to_url(&self, domain_path: &str) -> VcxResult<Url> {
         let mut oob_url = Url::parse(domain_path)?;
-        let oob_query = "oob=".to_owned() + &self.to_base64_url();
+        let oob_query = "oob=".to_owned() + &self.invitation_to_base64_url();
         oob_url.set_query(Some(&oob_query));
         Ok(oob_url)
     }
@@ -213,7 +213,7 @@ mod tests {
     fn invitation_to_json() {
         let out_of_band_sender = OutOfBandSender::create_from_invitation(_create_invitation());
 
-        let json_invite = out_of_band_sender.to_json_string();
+        let json_invite = out_of_band_sender.invitation_to_json_string();
 
         assert_eq!(JSON_OOB_INVITE_NO_WHITESPACE, json_invite);
     }
@@ -222,7 +222,7 @@ mod tests {
     fn invitation_to_base64_url() {
         let out_of_band_sender = OutOfBandSender::create_from_invitation(_create_invitation());
 
-        let base64_url_invite = out_of_band_sender.to_base64_url();
+        let base64_url_invite = out_of_band_sender.invitation_to_base64_url();
 
         assert_eq!(OOB_BASE64_URL_ENCODED, base64_url_invite);
     }
@@ -232,7 +232,7 @@ mod tests {
         let out_of_band_sender = OutOfBandSender::create_from_invitation(_create_invitation());
 
         let oob_url = out_of_band_sender
-            .to_url("http://example.com/ssi")
+            .invitation_to_url("http://example.com/ssi")
             .unwrap()
             .to_string();
 

--- a/aries/aries_vcx/src/handlers/out_of_band/sender.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/sender.rs
@@ -143,7 +143,7 @@ impl OutOfBandSender {
     }
 
     pub fn to_url(&self, domain_path: &str) -> VcxResult<Url> {
-        let mut oob_url = Url::parse(&domain_path)?;
+        let mut oob_url = Url::parse(domain_path)?;
         let oob_query = "oob=".to_owned() + &self.to_base64_url();
         oob_url.set_query(Some(&oob_query));
         Ok(oob_url)

--- a/aries/aries_vcx/src/handlers/out_of_band/sender.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/sender.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use base64::{prelude::BASE64_URL_SAFE, Engine};
+use base64::Engine;
 use messages::{
     msg_fields::protocols::{
         cred_issuance::{v1::CredentialIssuanceV1, CredentialIssuance},
@@ -20,6 +20,7 @@ use uuid::Uuid;
 use crate::{
     errors::error::prelude::*,
     handlers::util::{make_attach_from_str, AttachmentId},
+    utils::base64::URL_SAFE_LENIENT,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -139,7 +140,7 @@ impl OutOfBandSender {
     }
 
     fn invitation_to_base64_url(&self) -> String {
-        BASE64_URL_SAFE.encode(self.invitation_to_json_string())
+        URL_SAFE_LENIENT.encode(self.invitation_to_json_string())
     }
 
     pub fn invitation_to_url(&self, domain_path: &str) -> VcxResult<Url> {
@@ -177,8 +178,8 @@ mod tests {
 
     // Example invite formats referenced (with change to use OOB 1.1) from example invite in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
     const JSON_OOB_INVITE_NO_WHITESPACE: &str = r#"{"@type":"https://didcomm.org/out-of-band/1.1/invitation","@id":"69212a3a-d068-4f9d-a2dd-4741bca89af3","label":"Faber College","goal_code":"issue-vc","goal":"To issue a Faber College Graduate credential","handshake_protocols":["https://didcomm.org/didexchange/1.0","https://didcomm.org/connections/1.0"],"services":["did:sov:LjgpST2rjsoxYegQDRm7EL"]}"#;
-    const OOB_BASE64_URL_ENCODED: &str = "eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
-    const OOB_URL: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0%3D";
+    const OOB_BASE64_URL_ENCODED: &str = "eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0";
+    const OOB_URL: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0";
 
     // Params mimic example invitation in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
     fn _create_invitation() -> Invitation {

--- a/aries/aries_vcx/src/handlers/out_of_band/sender.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/sender.rs
@@ -143,9 +143,11 @@ impl OutOfBandSender {
     }
 
     pub fn invitation_to_url(&self, domain_path: &str) -> VcxResult<Url> {
-        let mut oob_url = Url::parse(domain_path)?;
-        let oob_query = "oob=".to_owned() + &self.invitation_to_base64_url();
-        oob_url.set_query(Some(&oob_query));
+        let oob_url = Url::parse(domain_path)?
+            .query_pairs_mut()
+            .append_pair("oob", &self.invitation_to_base64_url())
+            .finish()
+            .to_owned();
         Ok(oob_url)
     }
 }
@@ -176,7 +178,7 @@ mod tests {
     // Example invite formats referenced (with change to use OOB 1.1) from example invite in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
     const JSON_OOB_INVITE_NO_WHITESPACE: &str = r#"{"@type":"https://didcomm.org/out-of-band/1.1/invitation","@id":"69212a3a-d068-4f9d-a2dd-4741bca89af3","label":"Faber College","goal_code":"issue-vc","goal":"To issue a Faber College Graduate credential","handshake_protocols":["https://didcomm.org/didexchange/1.0","https://didcomm.org/connections/1.0"],"services":["did:sov:LjgpST2rjsoxYegQDRm7EL"]}"#;
     const OOB_BASE64_URL_ENCODED: &str = "eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
-    const OOB_URL: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
+    const OOB_URL: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0%3D";
 
     // Params mimic example invitation in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
     fn _create_invitation() -> Invitation {

--- a/aries/aries_vcx/src/handlers/out_of_band/sender.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/sender.rs
@@ -143,7 +143,7 @@ impl OutOfBandSender {
     }
 
     pub fn to_url(&self, domain_path: &str) -> VcxResult<Url> {
-        let mut oob_url = Url::parse(&domain_path.to_owned())?;
+        let mut oob_url = Url::parse(&domain_path)?;
         let oob_query = "oob=".to_owned() + &self.to_base64_url();
         oob_url.set_query(Some(&oob_query));
         Ok(oob_url)
@@ -158,7 +158,6 @@ impl Display for OutOfBandSender {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use messages::{
         msg_fields::protocols::out_of_band::{
             invitation::{Invitation, InvitationContent, InvitationDecorators, OobService},
@@ -171,6 +170,8 @@ mod tests {
         },
     };
     use shared::maybe_known::MaybeKnown;
+
+    use super::*;
 
     // Example invite formats referenced (with change to use OOB 1.1) from example invite in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
     const JSON_OOB_INVITE_NO_WHITESPACE: &str = r#"{"@type":"https://didcomm.org/out-of-band/1.1/invitation","@id":"69212a3a-d068-4f9d-a2dd-4741bca89af3","label":"Faber College","goal_code":"issue-vc","goal":"To issue a Faber College Graduate credential","handshake_protocols":["https://didcomm.org/didexchange/1.0","https://didcomm.org/connections/1.0"],"services":["did:sov:LjgpST2rjsoxYegQDRm7EL"]}"#;

--- a/aries/aries_vcx/src/handlers/out_of_band/sender.rs
+++ b/aries/aries_vcx/src/handlers/out_of_band/sender.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use base64::{prelude::BASE64_URL_SAFE, Engine};
 use messages::{
     msg_fields::protocols::{
         cred_issuance::{v1::CredentialIssuanceV1, CredentialIssuance},
@@ -13,6 +14,7 @@ use messages::{
     AriesMessage,
 };
 use shared::maybe_known::MaybeKnown;
+use url::Url;
 use uuid::Uuid;
 
 use crate::{
@@ -38,6 +40,10 @@ impl OutOfBandSender {
                 .decorators(decorators)
                 .build(),
         }
+    }
+
+    pub fn create_from_invitation(invitation: Invitation) -> Self {
+        Self { oob: invitation }
     }
 
     pub fn set_label(mut self, label: &str) -> Self {
@@ -128,16 +134,108 @@ impl OutOfBandSender {
         self.oob.clone().into()
     }
 
-    pub fn from_string(oob_data: &str) -> VcxResult<Self> {
-        Ok(Self {
-            oob: serde_json::from_str(oob_data)?,
-        })
+    pub fn to_json_string(&self) -> String {
+        self.to_aries_message().to_string()
+    }
+
+    pub fn to_base64_url(&self) -> String {
+        BASE64_URL_SAFE.encode(self.to_json_string())
+    }
+
+    pub fn to_url(&self, domain_path: &str) -> VcxResult<Url> {
+        let mut oob_url = Url::parse(&domain_path.to_owned())?;
+        let oob_query = "oob=".to_owned() + &self.to_base64_url();
+        oob_url.set_query(Some(&oob_query));
+        Ok(oob_url)
     }
 }
 
 impl Display for OutOfBandSender {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", json!(AriesMessage::from(self.oob.clone())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use messages::{
+        msg_fields::protocols::out_of_band::{
+            invitation::{Invitation, InvitationContent, InvitationDecorators, OobService},
+            OobGoalCode,
+        },
+        msg_types::{
+            connection::{ConnectionType, ConnectionTypeV1},
+            protocols::did_exchange::{DidExchangeType, DidExchangeTypeV1},
+            Protocol,
+        },
+    };
+    use shared::maybe_known::MaybeKnown;
+
+    // Example invite formats referenced (with change to use OOB 1.1) from example invite in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
+    const JSON_OOB_INVITE_NO_WHITESPACE: &str = r#"{"@type":"https://didcomm.org/out-of-band/1.1/invitation","@id":"69212a3a-d068-4f9d-a2dd-4741bca89af3","label":"Faber College","goal_code":"issue-vc","goal":"To issue a Faber College Graduate credential","handshake_protocols":["https://didcomm.org/didexchange/1.0","https://didcomm.org/connections/1.0"],"services":["did:sov:LjgpST2rjsoxYegQDRm7EL"]}"#;
+    const OOB_BASE64_URL_ENCODED: &str = "eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
+    const OOB_URL: &str = "http://example.com/ssi?oob=eyJAdHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMS4xL2ludml0YXRpb24iLCJAaWQiOiI2OTIxMmEzYS1kMDY4LTRmOWQtYTJkZC00NzQxYmNhODlhZjMiLCJsYWJlbCI6IkZhYmVyIENvbGxlZ2UiLCJnb2FsX2NvZGUiOiJpc3N1ZS12YyIsImdvYWwiOiJUbyBpc3N1ZSBhIEZhYmVyIENvbGxlZ2UgR3JhZHVhdGUgY3JlZGVudGlhbCIsImhhbmRzaGFrZV9wcm90b2NvbHMiOlsiaHR0cHM6Ly9kaWRjb21tLm9yZy9kaWRleGNoYW5nZS8xLjAiLCJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMCJdLCJzZXJ2aWNlcyI6WyJkaWQ6c292OkxqZ3BTVDJyanNveFllZ1FEUm03RUwiXX0=";
+
+    // Params mimic example invitation in RFC 0434 - https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband
+    fn _create_invitation() -> Invitation {
+        let id = "69212a3a-d068-4f9d-a2dd-4741bca89af3";
+        let did = "did:sov:LjgpST2rjsoxYegQDRm7EL";
+        let service = OobService::Did(did.to_string());
+        let handshake_protocols = vec![
+            MaybeKnown::Known(Protocol::DidExchangeType(DidExchangeType::V1(
+                DidExchangeTypeV1::new_v1_0(),
+            ))),
+            MaybeKnown::Known(Protocol::ConnectionType(ConnectionType::V1(
+                ConnectionTypeV1::new_v1_0(),
+            ))),
+        ];
+        let content = InvitationContent::builder()
+            .services(vec![service])
+            .goal("To issue a Faber College Graduate credential".to_string())
+            .goal_code(MaybeKnown::Known(OobGoalCode::IssueVC))
+            .label("Faber College".to_string())
+            .handshake_protocols(handshake_protocols)
+            .build();
+        let decorators = InvitationDecorators::default();
+
+        let invitation: Invitation = Invitation::builder()
+            .id(id.to_string())
+            .content(content)
+            .decorators(decorators)
+            .build();
+
+        invitation
+    }
+
+    #[test]
+    fn invitation_to_json() {
+        let out_of_band_sender = OutOfBandSender::create_from_invitation(_create_invitation());
+
+        let json_invite = out_of_band_sender.to_json_string();
+
+        assert_eq!(JSON_OOB_INVITE_NO_WHITESPACE, json_invite);
+    }
+
+    #[test]
+    fn invitation_to_base64_url() {
+        let out_of_band_sender = OutOfBandSender::create_from_invitation(_create_invitation());
+
+        let base64_url_invite = out_of_band_sender.to_base64_url();
+
+        assert_eq!(OOB_BASE64_URL_ENCODED, base64_url_invite);
+    }
+
+    #[test]
+    fn invitation_to_url() {
+        let out_of_band_sender = OutOfBandSender::create_from_invitation(_create_invitation());
+
+        let oob_url = out_of_band_sender
+            .to_url("http://example.com/ssi")
+            .unwrap()
+            .to_string();
+
+        assert_eq!(OOB_URL, oob_url);
     }
 }
 


### PR DESCRIPTION
Adds the ability to parse from and output to additional formats for the `OutOfBandReceiver`:
- JSON
- Base64URL
- URL

Additionally, adds parsing from the same formats to the `OutOfBandSender`, as new invites should always be created as `Invitation` or `AriesMessage` or with a builder. Consequently I've also removed the unused `from_string()` method from `OutOfBandSender`.

Adds tests for these methods (some repetition between the files, so I can see if I can consolidate if there's too much repeated during review). 

Does not include behavior for handling shortened URLs. I will create a followup GH issue for this item. 