### PR TITLE
(fix) fix aath publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,9 +146,12 @@ jobs:
 
   # todo: move to indy-vdr repo
   build-docker-vdrproxy:
+    runs-on: ubuntu-20.04
+    permissions:
+      content: read
+      packages: write
     needs: [ workflow-setup ]
     if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
-    runs-on: ubuntu-20.04
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_VDRPROXY }}
       BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
@@ -176,9 +179,12 @@ jobs:
 
   # builds and publishes main branch AATH backchannels
   build-docker-aath-backchannel:
-    needs: [ workflow-setup ]
-    if: ${{ needs.workflow-setup.outputs.IS_MAIN_BRANCH == 'true' }}
     runs-on: ubuntu-20.04
+    permissions:
+      content: read
+      packages: write
+    needs: [ workflow-setup ]
+    # if: ${{ needs.workflow-setup.outputs.IS_MAIN_BRANCH == 'true' }}
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_AATH }}
       BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}
@@ -209,6 +215,9 @@ jobs:
 
   publish-docker-vdrproxy:
     runs-on: ubuntu-20.04
+    permissions:
+      content: read
+      packages: write
     needs: [ workflow-setup, build-docker-vdrproxy ]
     if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
     env:
@@ -237,6 +246,9 @@ jobs:
   # additional publish of the AATH backchannel image with tagged versions for tags
   publish-docker-aath-backchannel:
     runs-on: ubuntu-20.04
+    permissions:
+      content: read
+      packages: write
     needs: [ workflow-setup, build-docker-aath-backchannel ]
     if: ${{ needs.workflow-setup.outputs.RELEASE == 'true' || needs.workflow-setup.outputs.PRERELEASE == 'true' }}
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,6 @@ on:
     branches:
       - "**"
 
-permissions:
-  contents: read
-  packages: write
-
 env:
   DOCKER_BUILDKIT: 1
   MAIN_BRANCH: main
@@ -188,7 +184,7 @@ jobs:
       contents: read
       packages: write
     needs: [ workflow-setup ]
-    # if: ${{ needs.workflow-setup.outputs.IS_MAIN_BRANCH == 'true' }}
+    if: ${{ needs.workflow-setup.outputs.IS_MAIN_BRANCH == 'true' }}
     env:
       DOCKER_IMG_CACHED: ${{ needs.workflow-setup.outputs.DOCKER_IMG_CACHED_AATH }}
       BRANCH_NAME: ${{ needs.workflow-setup.outputs.BRANCH_NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
   build-docker-vdrproxy:
     runs-on: ubuntu-20.04
     permissions:
-      content: read
+      contents: read
       packages: write
     needs: [ workflow-setup ]
     if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
@@ -181,7 +181,7 @@ jobs:
   build-docker-aath-backchannel:
     runs-on: ubuntu-20.04
     permissions:
-      content: read
+      contents: read
       packages: write
     needs: [ workflow-setup ]
     # if: ${{ needs.workflow-setup.outputs.IS_MAIN_BRANCH == 'true' }}
@@ -216,7 +216,7 @@ jobs:
   publish-docker-vdrproxy:
     runs-on: ubuntu-20.04
     permissions:
-      content: read
+      contents: read
       packages: write
     needs: [ workflow-setup, build-docker-vdrproxy ]
     if: ${{ needs.workflow-setup.outputs.SKIP_CI != 'true' }}
@@ -247,7 +247,7 @@ jobs:
   publish-docker-aath-backchannel:
     runs-on: ubuntu-20.04
     permissions:
-      content: read
+      contents: read
       packages: write
     needs: [ workflow-setup, build-docker-aath-backchannel ]
     if: ${{ needs.workflow-setup.outputs.RELEASE == 'true' || needs.workflow-setup.outputs.PRERELEASE == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   DOCKER_BUILDKIT: 1
   MAIN_BRANCH: main

--- a/aries/agents/aath-backchannel/src/main.rs
+++ b/aries/agents/aath-backchannel/src/main.rs
@@ -141,7 +141,7 @@ async fn main() -> std::io::Result<()> {
             .service(web::scope("/didcomm").route("", web::post().to(didcomm::receive_message)))
     })
     .keep_alive(std::time::Duration::from_secs(30))
-    .client_request_timeout(std::time::Duration::from_secs(32))
+    .client_request_timeout(std::time::Duration::from_secs(31))
     .workers(1)
     .bind(format!("{}:{}", host, opts.port))?
     .run()

--- a/aries/agents/aath-backchannel/src/main.rs
+++ b/aries/agents/aath-backchannel/src/main.rs
@@ -141,7 +141,7 @@ async fn main() -> std::io::Result<()> {
             .service(web::scope("/didcomm").route("", web::post().to(didcomm::receive_message)))
     })
     .keep_alive(std::time::Duration::from_secs(30))
-    .client_request_timeout(std::time::Duration::from_secs(31))
+    .client_request_timeout(std::time::Duration::from_secs(30))
     .workers(1)
     .bind(format!("{}:{}", host, opts.port))?
     .run()

--- a/aries/agents/aath-backchannel/src/main.rs
+++ b/aries/agents/aath-backchannel/src/main.rs
@@ -141,7 +141,7 @@ async fn main() -> std::io::Result<()> {
             .service(web::scope("/didcomm").route("", web::post().to(didcomm::receive_message)))
     })
     .keep_alive(std::time::Duration::from_secs(30))
-    .client_request_timeout(std::time::Duration::from_secs(30))
+    .client_request_timeout(std::time::Duration::from_secs(32))
     .workers(1)
     .bind(format!("{}:{}", host, opts.port))?
     .run()


### PR DESCRIPTION
Something changed last week where the default permissions for GITHUB_TOKEN was demoted. This meant our package publishing stopped working. This is why our backchannel image hasn't been updating.

After scavenging thru hyperledger discord, adding explicit permissions seems to fix the issue. 

related discord thread: https://discord.com/channels/905194001349627914/905205991073804308/1272872860494467093

related docs: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token