### PR TITLE
(fix) Return IndyVdr based CredentialDefinition schemaId as full schemaId (not sequence number)

### DIFF
--- a/aries/aries_vcx_ledger/src/ledger/indy_vdr_ledger.rs
+++ b/aries/aries_vcx_ledger/src/ledger/indy_vdr_ledger.rs
@@ -529,7 +529,7 @@ where
             .response_parser
             .parse_get_cred_def_response(&response, None)?;
 
-        // extract a map seqNo -> schemaId if required
+        // extract and map seqNo -> schemaId if required
         let IndyVdrCredentialDefinition::CredentialDefinitionV1(mut cred_def) = cred_def;
         if let Ok(seq_no) = cred_def.schema_id.0.parse::<i32>() {
             cred_def.schema_id = self

--- a/aries/aries_vcx_ledger/src/ledger/indy_vdr_ledger.rs
+++ b/aries/aries_vcx_ledger/src/ledger/indy_vdr_ledger.rs
@@ -22,10 +22,17 @@ pub use indy_ledger_response_parser::GetTxnAuthorAgreementData;
 use indy_ledger_response_parser::{
     ResponseParser, RevocationRegistryDeltaInfo, RevocationRegistryInfo,
 };
-use indy_vdr as vdr;
+use indy_vdr::{
+    self as vdr,
+    ledger::{
+        identifiers::SchemaId as IndyVdrSchemaId,
+        requests::cred_def::CredentialDefinition as IndyVdrCredentialDefinition,
+    },
+    utils::{did::DidValue, Validatable},
+};
 use log::{debug, trace};
 use public_key::Key;
-use serde_json::Value;
+use serde_json::{json, Value};
 use time::OffsetDateTime;
 use vdr::{
     config::PoolConfig,
@@ -161,6 +168,40 @@ where
         };
         trace!("submit_request << ledger response (is from cache: {is_from_cache}): {response}");
         Ok(response)
+    }
+
+    async fn resolve_schema_id_from_seq_no(
+        &self,
+        seq_no: i32,
+        submitter_did: Option<&Did>,
+    ) -> VcxLedgerResult<IndyVdrSchemaId> {
+        let response = self.get_ledger_txn(seq_no, submitter_did).await?;
+        let mut txn_response = self.response_parser.parse_get_txn_response(&response)?;
+        let txn = txn_response["txn"].take();
+
+        // mimic acapy & credo-ts behaviour - assumes node protocol >= 1.4
+
+        // check correct tx
+        if txn["type"] != json!("101") {
+            return Err(VcxLedgerError::InvalidLedgerResponse);
+        }
+
+        // pull schema identifier parts
+        let schema_did = &txn["metadata"]["from"];
+        let schema_name = &txn["data"]["data"]["name"];
+        let schema_version = &txn["data"]["data"]["version"];
+        let (Value::String(did), Value::String(name), Value::String(ver)) =
+            (schema_did, schema_name, schema_version)
+        else {
+            return Err(VcxLedgerError::InvalidLedgerResponse);
+        };
+
+        // construct indy schema ID from parts
+        let did = DidValue::new(did, None);
+        did.validate()?;
+        let schema_id = IndyVdrSchemaId::new(&did, name, ver);
+        schema_id.validate()?;
+        Ok(schema_id)
     }
 }
 
@@ -487,7 +528,18 @@ where
         let cred_def = self
             .response_parser
             .parse_get_cred_def_response(&response, None)?;
-        Ok(cred_def.convert(())?)
+
+        // extract a map seqNo -> schemaId if required
+        let IndyVdrCredentialDefinition::CredentialDefinitionV1(mut cred_def) = cred_def;
+        if let Ok(seq_no) = cred_def.schema_id.0.parse::<i32>() {
+            cred_def.schema_id = self
+                .resolve_schema_id_from_seq_no(seq_no, submitter_did)
+                .await?;
+        }
+
+        let cred_def = IndyVdrCredentialDefinition::CredentialDefinitionV1(cred_def).convert(())?;
+
+        Ok(cred_def)
     }
 
     async fn get_rev_reg_def_json(

--- a/aries/aries_vcx_ledger/src/ledger/type_conversion.rs
+++ b/aries/aries_vcx_ledger/src/ledger/type_conversion.rs
@@ -145,26 +145,25 @@ impl Convert for IndyVdrCredentialDefinition {
     fn convert(self, (): Self::Args) -> Result<Self::Target, Self::Error> {
         match self {
             IndyVdrCredentialDefinition::CredentialDefinitionV1(cred_def) => {
-                if let Some((_method, issuer_id, _sig_type, _schema_id, _tag)) = cred_def.id.parts()
-                {
-                    Ok(OurCredentialDefinition {
-                        id: OurCredentialDefinitionId::new(cred_def.id.to_string())?,
-                        schema_id: OurSchemaId::new_unchecked(cred_def.schema_id.to_string()),
-                        signature_type: OurSignatureType::CL,
-                        tag: cred_def.tag,
-                        value: OurCredentialDefinitionData {
-                            primary: serde_json::from_value(cred_def.value.primary)?,
-                            revocation: cred_def
-                                .value
-                                .revocation
-                                .map(serde_json::from_value)
-                                .transpose()?,
-                        },
-                        issuer_id: IssuerId::new(issuer_id.to_string())?,
-                    })
-                } else {
-                    todo!()
-                }
+                let id = &cred_def.id;
+                let Some((_method, issuer_id, _sig_type, _schema_id, _tag)) = id.parts() else {
+                    return Err(format!("cred def ID is malformed. cannot convert. {}", id).into());
+                };
+                Ok(OurCredentialDefinition {
+                    id: OurCredentialDefinitionId::new(id.to_string())?,
+                    schema_id: OurSchemaId::new(cred_def.schema_id.to_string())?,
+                    signature_type: OurSignatureType::CL,
+                    tag: cred_def.tag,
+                    value: OurCredentialDefinitionData {
+                        primary: serde_json::from_value(cred_def.value.primary)?,
+                        revocation: cred_def
+                            .value
+                            .revocation
+                            .map(serde_json::from_value)
+                            .transpose()?,
+                    },
+                    issuer_id: IssuerId::new(issuer_id.to_string())?,
+                })
             }
         }
     }

--- a/aries/misc/indy_ledger_response_parser/src/domain/constants.rs
+++ b/aries/misc/indy_ledger_response_parser/src/domain/constants.rs
@@ -5,3 +5,4 @@ pub const GET_REVOC_REG_DEF: &str = "115";
 pub const GET_REVOC_REG: &str = "116";
 pub const GET_REVOC_REG_DELTA: &str = "117";
 pub const GET_TXN_AUTHR_AGRMT: &str = "6";
+pub const GET_TXN: &str = "3";

--- a/aries/misc/indy_ledger_response_parser/src/domain/mod.rs
+++ b/aries/misc/indy_ledger_response_parser/src/domain/mod.rs
@@ -7,3 +7,4 @@ pub mod response;
 pub mod rev_reg;
 pub mod rev_reg_def;
 pub mod schema;
+pub mod txn;

--- a/aries/misc/indy_ledger_response_parser/src/domain/txn.rs
+++ b/aries/misc/indy_ledger_response_parser/src/domain/txn.rs
@@ -1,0 +1,19 @@
+use serde_json::Value;
+
+use super::{
+    constants::GET_TXN,
+    response::{GetReplyResultV0, GetReplyResultV1, ReplyType},
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum GetTxnReplyResult {
+    GetTxnReplyResultV0(GetReplyResultV0<Value>),
+    GetTxnReplyResultV1(GetReplyResultV1<Value>),
+}
+
+impl ReplyType for GetTxnReplyResult {
+    fn get_type<'a>() -> &'a str {
+        GET_TXN
+    }
+}

--- a/aries/misc/indy_ledger_response_parser/src/lib.rs
+++ b/aries/misc/indy_ledger_response_parser/src/lib.rs
@@ -8,7 +8,7 @@ pub mod error;
 
 use anoncreds_clsignatures::RevocationRegistryDelta as ClRevocationRegistryDelta;
 pub use domain::author_agreement::GetTxnAuthorAgreementData;
-use domain::author_agreement::GetTxnAuthorAgreementResult;
+use domain::{author_agreement::GetTxnAuthorAgreementResult, txn::GetTxnReplyResult};
 use error::LedgerResponseParserError;
 use indy_vdr::{
     ledger::{
@@ -234,6 +234,22 @@ impl ResponseParser {
             revoc_reg_def_id,
             timestamp: revoc_reg.value.accum_to.txn_time,
         })
+    }
+
+    // https://github.com/hyperledger/indy-node/blob/main/docs/source/requests.md#get_txn
+    pub fn parse_get_txn_response(
+        &self,
+        get_txn_response: &str,
+    ) -> Result<serde_json::Value, LedgerResponseParserError> {
+        let reply: Reply<GetTxnReplyResult> = Self::parse_response(get_txn_response)?;
+
+        let data = match reply.result() {
+            GetTxnReplyResult::GetTxnReplyResultV0(res) => {
+                res.data.unwrap_or(serde_json::Value::Null)
+            }
+            GetTxnReplyResult::GetTxnReplyResultV1(res) => res.txn.data,
+        };
+        Ok(data)
     }
 
     pub fn parse_response<T>(response: &str) -> Result<Reply<T>, LedgerResponseParserError>


### PR DESCRIPTION
indy ledgers will return creddef.schemaId as seqNo sometimes (see related https://github.com/openwallet-foundation/acapy/issues/220 older acapy discussion), this is not a valid anoncreds schemaId, and is not consumer friendly.

This fix adds an extra ledger call (if necessary) to convert from schema seqNo to schemaId by resolving the raw txn and extracting the data. This matches acapy & credo's strategy:

credo-ts:
* https://github.com/openwallet-foundation/credo-ts/blob/main/packages/indy-vdr/src/anoncreds/IndyVdrAnonCredsRegistry.ts#L274
* https://github.com/openwallet-foundation/credo-ts/blob/main/packages/indy-vdr/src/anoncreds/IndyVdrAnonCredsRegistry.ts#L981

acapy:
* i believe acapy does still have the behaviour i'm trying to resolve here, but acapy does support resolving schema by it's seqNo: https://github.com/openwallet-foundation/acapy/blob/main/acapy_agent/ledger/indy_vdr.py#L496