### PR TITLE
chore: add openssl vendoring feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.1+3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,6 +3612,7 @@ checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/aries/aries_vcx/Cargo.toml
+++ b/aries/aries_vcx/Cargo.toml
@@ -17,6 +17,7 @@ vdr_proxy_ledger = [
     "test_utils/vdr_proxy_ledger",
 ]
 backtrace_errors = ["backtrace"]
+openssl_vendored = ["aries_vcx_ledger/openssl_vendored", "aries_vcx_anoncreds/openssl_vendored", "anoncreds_types/openssl_vendored"]
 
 # Feature for allowing legacy proof verification
 legacy_proof = ["aries_vcx_anoncreds/legacy_proof"]

--- a/aries/aries_vcx_anoncreds/Cargo.toml
+++ b/aries/aries_vcx_anoncreds/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 anoncreds = ["dep:anoncreds"]
+openssl_vendored = ["anoncreds/vendored", "anoncreds_types/openssl_vendored"]
 legacy_proof = []
 
 [dependencies]

--- a/aries/aries_vcx_ledger/Cargo.toml
+++ b/aries/aries_vcx_ledger/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 [features]
 vdr_proxy_ledger = ["dep:indy-vdr-proxy-client"]
 cheqd = ["dep:did_cheqd", "dep:did_resolver", "dep:url"]
+openssl_vendored = ["indy-ledger-response-parser/openssl_vendored", "anoncreds_types/openssl_vendored"]
 
 [dependencies]
 aries_vcx_wallet = { path = "../aries_vcx_wallet" }

--- a/aries/misc/anoncreds_types/Cargo.toml
+++ b/aries/misc/anoncreds_types/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 messages = []
 ledger = []
 default = ["messages", "ledger"]
+openssl_vendored = ["anoncreds-clsignatures/openssl_vendored"]
 
 [dependencies]
 anoncreds-clsignatures = "0.3.2"

--- a/aries/misc/indy_ledger_response_parser/Cargo.toml
+++ b/aries/misc/indy_ledger_response_parser/Cargo.toml
@@ -3,6 +3,9 @@ name = "indy-ledger-response-parser"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+openssl_vendored = ["anoncreds-clsignatures/openssl_vendored"]
+
 [dependencies]
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"

--- a/aries/wrappers/uniffi-aries-vcx/core/Cargo.toml
+++ b/aries/wrappers/uniffi-aries-vcx/core/Cargo.toml
@@ -15,6 +15,9 @@ path = "uniffi-bindgen.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# TODO: look at how features should be done in regards to UniFFI.
+# TODO: add zmq vendoring and openssl vendoring
+
 [dependencies]
 uniffi = { version = "0.23.0", features = ["cli"] }
 aries_vcx = { path = "../../../aries_vcx", features = [

--- a/did_core/did_methods/did_resolver_sov/Cargo.toml
+++ b/did_core/did_methods/did_resolver_sov/Cargo.toml
@@ -3,6 +3,9 @@ name = "did_resolver_sov"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+openssl_vendored = ["aries_vcx_ledger/openssl_vendored"]
+
 [dependencies]
 did_resolver = { path = "../../did_resolver" }
 aries_vcx_ledger = { path = "../../../aries/aries_vcx_ledger" }


### PR DESCRIPTION
Adds a feature flag for using a vendored version of openssl. This needs to drill down to any packages consuming anoncreds-rs or anoncreds-clsignatures-rs, so it impacts a lot of our crates. I _think_ I got them all.