### PR TITLE
(refactor) Centralise dependencies definitions into workspace version catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,6 @@ dependencies = [
  "aries_vcx_anoncreds",
  "aries_vcx_ledger",
  "aries_vcx_wallet",
- "async-channel",
  "async-trait",
  "backtrace",
  "base64 0.22.1",
@@ -553,7 +552,6 @@ dependencies = [
  "did_resolver_registry",
  "did_resolver_sov",
  "diddoc_legacy",
- "env_logger 0.11.5",
  "futures",
  "lazy_static",
  "log",
@@ -561,7 +559,6 @@ dependencies = [
  "num-bigint",
  "pretty_assertions",
  "public_key",
- "rand",
  "regex",
  "serde",
  "serde_derive",
@@ -586,7 +583,6 @@ dependencies = [
  "anoncreds_types",
  "aries_vcx_wallet",
  "async-trait",
- "bitvec",
  "did_parser_nom",
  "log",
  "serde",
@@ -760,18 +756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,17 +884,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
 ]
 
 [[package]]
@@ -1306,7 +1279,6 @@ name = "client-tui"
 version = "0.1.1"
 dependencies = [
  "aries_vcx_wallet",
- "axum",
  "cursive",
  "futures",
  "log",
@@ -1740,7 +1712,6 @@ dependencies = [
  "native-tls",
  "prost",
  "prost-types",
- "serde",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1757,12 +1728,9 @@ dependencies = [
  "did_key",
  "did_parser_nom",
  "display_as_json",
- "env_logger 0.11.5",
  "hex",
- "log",
  "multibase",
  "pem",
- "pretty_assertions",
  "public_key",
  "serde",
  "serde_json",
@@ -1817,7 +1785,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "bs58",
  "did_doc",
  "did_parser_nom",
  "did_resolver",
@@ -1825,7 +1792,6 @@ dependencies = [
  "env_logger 0.11.5",
  "log",
  "multibase",
- "once_cell",
  "pretty_assertions",
  "public_key",
  "regex",
@@ -1835,7 +1801,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "typed-builder",
- "unsigned-varint",
  "url",
 ]
 
@@ -1883,7 +1848,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -2961,7 +2925,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time",
 ]
 
 [[package]]
@@ -3231,7 +3194,6 @@ dependencies = [
  "aries_vcx_wallet",
  "async-trait",
  "axum",
- "axum-macros",
  "base64-url",
  "chrono",
  "diddoc_legacy",
@@ -5138,7 +5100,6 @@ dependencies = [
  "env_logger 0.11.5",
  "indy-ledger-response-parser",
  "indy-vdr-proxy-client",
- "lazy_static",
  "log",
  "public_key",
  "rand",
@@ -5579,11 +5540,9 @@ dependencies = [
  "aries_vcx_ledger",
  "async-trait",
  "did_parser_nom",
- "diddoc_legacy",
  "indy-vdr",
  "log",
  "once_cell",
- "serde",
  "serde_json",
  "shared",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,73 @@ indy-vdr-proxy-client = { git = "https://github.com/hyperledger/indy-vdr.git", t
 anoncreds = { git = "https://github.com/hyperledger/anoncreds-rs.git", tag = "v0.2.0" }
 aries-askar = { version = "0.3.1" }
 askar-crypto = { version = "0.3.1", default-features = false }
+
+actix-web = "4"
+android_logger = "0.14.1"
+anoncreds-clsignatures = "0.3.2"
+anyhow = "1.0.75"
+async-trait = "0.1.73"
+axum = "0.7.5"
+backtrace = "0.3"
+base64 = "0.22.1"
+base64-url = "3.0.0"
+bitvec = "1.0.1"
+bs58 = "0.5.1"
+bytes = "1.8.0"
+chrono = { version = "0.4.31", default-features = false }
+clap = "4.5.6"
+cursive = "0.20.0"
+darling = "0.20.1"
+derive_builder = "0.20.0"
+derive_more = "0.99.17"
+dotenvy = "0.15"
+env_logger = "0.11.3"
+futures = { version = "0.3.28", default-features = false }
+hex = "0.4.3"
+http-body-util = "0.1.2"
+hyper = "1.5.1"
+hyper-tls = "0.6.0"
+hyper-util = "0.1.10"
+isolang = "2.2.0"
+lazy_static = "1.3"
+log = "0.4.22"
+lru = "0.12.0"
+mockall = "0.13.1"
+multibase = "0.9.1"
+native-tls = "0.2.12"
+nom = "7.1.3"
+num-bigint = "0.4.5"
+once_cell = "1.19.0"
+pem = "3.0.4"
+percent-encoding = "2"
+pretty_assertions = "1.4.0"
+proc-macro2 = "1.0.58"
+prost = { version = "0.13.3", default-features = false }
+prost-types = "0.13.3"
+quote = "1.0.27"
+rand = "0.8.5"
+regex = "1.10.5"
+reqwest = "0.12.5"
+serde = { version = "1.0.203", default-features = false }
+serde_derive = "1.0.97"
+serde_json = "1.0.120"
+serde_test = "1.0.176"
+sha2 = "0.10.8"
+sqlx = "0.7"
+strum = "0.26.3"
+strum_macros = "0.26.4"
+syn = "2.0.72"
+thiserror = "1.0.49"
+time = "0.3.20"
+tokio = { version = "1.38.0", default-features = false }
+tokio-test = "0.4.2"
+tonic = { version = "0.12.3", default-features = false }
+tonic-build = "0.12.3"
+tower-http = "0.5.2"
+transitive = "1.0.1"
+typed-builder = "0.19.1"
+uniffi = "0.23.0"
+uniresid = { version = "0.1.4", default-features = false }
+unsigned-varint = "0.8.0"
+url = { version = "2.4.1", default-features = false }
+uuid = { version = "1.8.0", default-features = false }

--- a/aries/agents/aath-backchannel/Cargo.toml
+++ b/aries/agents/aath-backchannel/Cargo.toml
@@ -6,17 +6,17 @@ authors = ["Absa Group Limited", "Hyperledger Indy Contributors <hyperledger-ind
 description = "Backchannel for aries-vcx"
 
 [dependencies]
-actix-web = "4"
-derive_more = "0.99.14"
-clap = { version = "4.5.6", features = ["derive"] }
-reqwest = { version = "0.12.4", features = ["json", "multipart", "blocking"] }
-rand = "0.8.5"
-serde = "1.0.97"
-serde_json = "1.0.40"
-serde_derive = "1.0.97"
-log = "^0.4.20"
-env_logger = "0.11.3"
-uuid = { version = "1.8.0", features = ["serde", "v4"] }
+actix-web = { workspace = true }
+derive_more = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+reqwest = { workspace = true, features = ["json", "multipart", "blocking"] }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_derive = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
 aries-vcx-agent = { path = "../../../aries/agents/aries-vcx-agent" }
 anoncreds_types = { path = "../../../aries/misc/anoncreds_types" }
 display_as_json = { path = "../../../misc/display_as_json" }

--- a/aries/agents/aries-vcx-agent/Cargo.toml
+++ b/aries/agents/aries-vcx-agent/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-serde = "1.0.145"
+serde = { workspace = true }
 aries_vcx = { path = "../../aries_vcx" }
 aries_vcx_wallet = { path = "../../aries_vcx_wallet", features = [
     "askar_wallet",
@@ -20,10 +20,10 @@ did_resolver_sov = { path = "../../../did_core/did_methods/did_resolver_sov" }
 did_peer = { path = "../../../did_core/did_methods/did_peer" }
 did_key = { path = "../../../did_core/did_methods/did_key" }
 public_key = { path = "../../../did_core/public_key" }
-async-trait = "0.1.64"
-serde_json = "1.0.85"
-log = "0.4.17"
-uuid = "1.2.1"
-thiserror = "1.0.37"
-url = { version = "2.3.1", features = ["serde"] }
+async-trait = { workspace = true }
+serde_json = { workspace = true }
+log = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 display_as_json = { path = "../../../misc/display_as_json" }

--- a/aries/agents/mediator/Cargo.toml
+++ b/aries/agents/mediator/Cargo.toml
@@ -17,7 +17,6 @@ aries_vcx_wallet = { path = "../../aries_vcx_wallet", features = [
 ] }
 async-trait = "0.1.73"
 axum = "0.7.5"
-axum-macros = "0.4.1"
 diddoc_legacy = { path = "../../misc/legacy/diddoc_legacy" }
 dotenvy = "0.15"
 env_logger = "0.11.3"

--- a/aries/agents/mediator/Cargo.toml
+++ b/aries/agents/mediator/Cargo.toml
@@ -10,30 +10,30 @@ default = ["client"]
 client = []
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = { workspace = true }
 aries_vcx = { path = "../../aries_vcx" }
 aries_vcx_wallet = { path = "../../aries_vcx_wallet", features = [
     "askar_wallet",
 ] }
-async-trait = "0.1.73"
-axum = "0.7.5"
+async-trait = { workspace = true }
+axum = { workspace = true }
 diddoc_legacy = { path = "../../misc/legacy/diddoc_legacy" }
-dotenvy = "0.15"
-env_logger = "0.11.3"
-futures = "0.3.28"
-log = "0.4.20"
+dotenvy = { workspace = true }
+env_logger = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
 messages = { path = "../../messages" }
-reqwest = { version = "0.12.5", features = ["json"] }
-serde = "1.0.188"
-serde_json = "1.0.106"
-sqlx = { version = "0.7", features = ["mysql"] }
-thiserror = "1.0.49"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-tower-http = { version = "0.5.2", features = ["catch-panic"] }
-url = "2.4.1"
-uuid = "1.4.1"
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true, features = ["mysql"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tower-http = { workspace = true, features = ["catch-panic"] }
+url = { workspace = true }
+uuid = { workspace = true }
 test_utils = { path = "../../misc/test_utils" }
-base64-url = "3.0.0"
+base64-url = { workspace = true }
 
 [dev-dependencies]
-chrono = "0.4.31"
+chrono = { workspace = true }

--- a/aries/agents/mediator/client-tui/Cargo.toml
+++ b/aries/agents/mediator/client-tui/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 aries_vcx_wallet = { path = "../../../aries_vcx_wallet", features = [
     "askar_wallet",
 ] }
-axum = "0.7.5"
 cursive = { version = "0.20.0", features = ["crossterm-backend"] }
 futures = "0.3.28"
 log = "0.4.20"

--- a/aries/agents/mediator/client-tui/Cargo.toml
+++ b/aries/agents/mediator/client-tui/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2021"
 aries_vcx_wallet = { path = "../../../aries_vcx_wallet", features = [
     "askar_wallet",
 ] }
-cursive = { version = "0.20.0", features = ["crossterm-backend"] }
-futures = "0.3.28"
-log = "0.4.20"
+cursive = { workspace = true, features = ["crossterm-backend"] }
+futures = { workspace = true, features = ["default"] }
+log = { workspace = true }
 mediator = { path = ".." }
 messages = { path = "../../../messages" }
-reqwest = "0.12.5"
-serde_json = "1.0.107"
+reqwest = { workspace = true }
+serde_json = { workspace = true }
 
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/aries/aries_vcx/Cargo.toml
+++ b/aries/aries_vcx/Cargo.toml
@@ -42,31 +42,31 @@ did_key = { path = "../../did_core/did_methods/did_key" }
 public_key = { path = "../../did_core/public_key" }
 did_peer = { path = "../../did_core/did_methods/did_peer" }
 did_resolver_registry = { path = "../../did_core/did_resolver_registry" }
-bs58 = "0.5.0"
-async-trait = "0.1.53"
-log = "0.4.16"
-chrono = "0.4.23"
-time = "0.3.20"
-lazy_static = "1.3"
-serde = "1.0.97"
-serde_json = "1.0.40"
-serde_derive = "1.0.97"
-regex = "1.1.0"
-base64 = "0.22.1"
-sha2 = "0.10.7"
-num-bigint = "0.4.5"
-futures = { version = "0.3", default-features = false }
-uuid = { version = "1.4.1", default-features = false, features = ["v4"] }
-strum = "0.26.3"
-strum_macros = "0.26.4"
-derive_builder = "0.20.0"
-tokio = { version = "1.38.0" }
-thiserror = "1.0.37"
-url = { version = "2.3", features = ["serde"] }
-backtrace = { optional = true, version = "0.3" }
+bs58 = { workspace = true }
+async-trait = { workspace = true }
+log = { workspace = true }
+chrono = { workspace = true }
+time = { workspace = true }
+lazy_static = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_derive = { workspace = true }
+regex = { workspace = true }
+base64 = { workspace = true }
+sha2 = { workspace = true }
+num-bigint = { workspace = true }
+futures = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+derive_builder = { workspace = true }
+tokio = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+backtrace = { workspace = true, optional = true }
 
 [dev-dependencies]
 test_utils = { path = "../misc/test_utils" }
-tokio = { version = "1.38", features = ["rt", "macros", "rt-multi-thread"] }
-pretty_assertions = "1.4.0"
+tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
+pretty_assertions = { workspace = true }
 did_resolver_sov = { path = "../../did_core/did_methods/did_resolver_sov" }

--- a/aries/aries_vcx/Cargo.toml
+++ b/aries/aries_vcx/Cargo.toml
@@ -11,7 +11,11 @@ path = "src/lib.rs"
 doctest = false
 
 [features]
-anoncreds = ["aries_vcx_anoncreds/anoncreds", "test_utils/anoncreds", "test_utils/askar_wallet"]
+anoncreds = [
+    "aries_vcx_anoncreds/anoncreds",
+    "test_utils/anoncreds",
+    "test_utils/askar_wallet",
+]
 vdr_proxy_ledger = [
     "aries_vcx_wallet/askar_wallet",
     "test_utils/vdr_proxy_ledger",
@@ -21,9 +25,7 @@ backtrace_errors = ["backtrace"]
 # Feature for allowing legacy proof verification
 legacy_proof = ["aries_vcx_anoncreds/legacy_proof"]
 
-askar_wallet = [
-    "aries_vcx_wallet/askar_wallet"
-]
+askar_wallet = ["aries_vcx_wallet/askar_wallet"]
 
 [dependencies]
 messages = { path = "../messages" }
@@ -42,12 +44,10 @@ did_peer = { path = "../../did_core/did_methods/did_peer" }
 did_resolver_registry = { path = "../../did_core/did_resolver_registry" }
 bs58 = "0.5.0"
 async-trait = "0.1.53"
-env_logger = "0.11.3"
 log = "0.4.16"
 chrono = "0.4.23"
 time = "0.3.20"
 lazy_static = "1.3"
-rand = "0.8.5"
 serde = "1.0.97"
 serde_json = "1.0.40"
 serde_derive = "1.0.97"
@@ -67,7 +67,6 @@ backtrace = { optional = true, version = "0.3" }
 
 [dev-dependencies]
 test_utils = { path = "../misc/test_utils" }
-async-channel = "2.3.1"
 tokio = { version = "1.38", features = ["rt", "macros", "rt-multi-thread"] }
 pretty_assertions = "1.4.0"
 did_resolver_sov = { path = "../../did_core/did_methods/did_resolver_sov" }

--- a/aries/aries_vcx_anoncreds/Cargo.toml
+++ b/aries/aries_vcx_anoncreds/Cargo.toml
@@ -23,4 +23,3 @@ uuid = { version = "1.3.0", default-features = false, features = ["v4"] }
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 time = "0.3.20"
-bitvec = "1.0.1"

--- a/aries/aries_vcx_anoncreds/Cargo.toml
+++ b/aries/aries_vcx_anoncreds/Cargo.toml
@@ -16,10 +16,10 @@ anoncreds = { workspace = true, optional = true }
 aries_vcx_wallet = { path = "../aries_vcx_wallet" }
 anoncreds_types = { path = "../misc/anoncreds_types" }
 did_parser_nom = { path = "../../did_core/did_parser_nom" }
-async-trait = "0.1.68"
-thiserror = "1.0.40"
-log = "0.4.17"
-uuid = { version = "1.3.0", default-features = false, features = ["v4"] }
-serde = { version = "1.0.159", features = ["derive"] }
-serde_json = "1.0.95"
-time = "0.3.20"
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+log = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+time = { workspace = true }

--- a/aries/aries_vcx_ledger/Cargo.toml
+++ b/aries/aries_vcx_ledger/Cargo.toml
@@ -15,29 +15,26 @@ cheqd = ["dep:did_cheqd", "dep:did_resolver", "dep:url"]
 aries_vcx_wallet = { path = "../aries_vcx_wallet" }
 anoncreds_types = { path = "../misc/anoncreds_types" }
 did_parser_nom = { path = "../../did_core/did_parser_nom" }
-thiserror = "1.0.40"
+thiserror = { workspace = true }
 indy-vdr.workspace = true
 indy-vdr-proxy-client = { workspace = true, optional = true }
 did_cheqd = { path = "../../did_core/did_methods/did_cheqd", optional = true }
 did_resolver = { path = "../../did_core/did_resolver", optional = true }
-url = { version = "2.4.1", optional = true }
-serde_json = "1.0.95"
+url = { workspace = true, optional = true }
+serde_json = { workspace = true }
 public_key = { path = "../../did_core/public_key" }
-async-trait = "0.1.68"
-time = "0.3.20"
+async-trait = { workspace = true }
+time = { workspace = true }
 indy-ledger-response-parser = { path = "../misc/indy_ledger_response_parser" }
-log = "0.4.17"
-serde = { version = "1.0.159", features = ["derive"] }
-lru = { version = "0.12.0" }
-tokio = { version = "1.38" }
-chrono = { version = "0.4", default-features = false, features = ["alloc"] }
-bitvec = "1.0.1"
+log = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+lru = { workspace = true }
+tokio = { workspace = true }
+chrono = { workspace = true, features = ["alloc"] }
+bitvec = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.38.0", default-features = false, features = [
-    "macros",
-    "rt",
-] }
-chrono = { version = "0.4", default-features = true }
-mockall = "0.13.1"
-uuid = { version = "1.4.1", default-features = false, features = ["v4"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
+chrono = { workspace = true }
+mockall = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }

--- a/aries/aries_vcx_wallet/Cargo.toml
+++ b/aries/aries_vcx_wallet/Cargo.toml
@@ -11,20 +11,20 @@ edition.workspace = true
 askar_wallet = ["dep:aries-askar"]
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 aries-askar = { workspace = true, optional = true }
-async-trait = "0.1.68"
-bs58 = { version = "0.5" }
-base64 = "0.22.1"
-log = "0.4.17"
-serde = { version = "1.0.159", features = ["derive"] }
-serde_json = "1.0.95"
+async-trait = { workspace = true }
+bs58 = { workspace = true }
+base64 = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 public_key = { path = "../../did_core/public_key" }
-rand = "0.8.5"
-thiserror = "1.0.40"
-tokio = { version = "1.38" }
-typed-builder = "0.19.1"
-uuid = { version = "1.3.0", default-features = false, features = ["v4"] }
+rand = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+typed-builder = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-tokio = { version = "1.38", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }

--- a/aries/messages/Cargo.toml
+++ b/aries/messages/Cargo.toml
@@ -9,18 +9,18 @@ license.workspace = true
 doctest = false
 
 [dependencies]
-serde = { version = "1.0.167", features = ["derive"] }
-chrono = { version = "0.4.23", features = ["serde"] }
-lazy_static = "1.3"
-serde_json = "1.0.100"
-url = { version = "2.3", features = ["serde"] }
-strum = "0.26.3"
-strum_macros = "0.26.4"
-thiserror = "1.0.37"
-derive_more = "0.99.17"
-transitive = "1.0.1"
-isolang = { version = "2.2.0" }
-typed-builder = "0.19.1"
+serde = { workspace = true, features = ["derive"] }
+chrono = { workspace = true, features = ["serde"] }
+lazy_static = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+thiserror = { workspace = true }
+derive_more = { workspace = true }
+transitive = { workspace = true }
+isolang = { workspace = true }
+typed-builder = { workspace = true }
 messages_macros = { path = "../messages_macros" }
 diddoc_legacy = { path = "../misc/legacy/diddoc_legacy" }
 shared = { path = "../misc/shared" }

--- a/aries/messages_macros/Cargo.toml
+++ b/aries/messages_macros/Cargo.toml
@@ -9,8 +9,8 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "1.0.58"
-quote = "1.0.27"
-syn = "2.0.16"
-darling = "0.20.1"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+darling = { workspace = true }
 shared = { path = "../misc/shared" }

--- a/aries/misc/anoncreds_types/Cargo.toml
+++ b/aries/misc/anoncreds_types/Cargo.toml
@@ -13,14 +13,14 @@ ledger = []
 default = ["messages", "ledger"]
 
 [dependencies]
-anoncreds-clsignatures = "0.3.2"
-bitvec = "1.0.1"
-log = "0.4.22"
-once_cell = "1.19.0"
-regex = "1.10.5"
-serde = { version = "1.0.203", features = ["derive"] }
-serde_json = "1.0.120"
-typed-builder = "0.19.1"
+anoncreds-clsignatures = { workspace = true }
+bitvec = { workspace = true }
+log = { workspace = true }
+once_cell = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+typed-builder = { workspace = true }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = { workspace = true }

--- a/aries/misc/indy_ledger_response_parser/Cargo.toml
+++ b/aries/misc/indy_ledger_response_parser/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 indy-vdr.workspace = true
-thiserror = "1.0.44"
-anoncreds-clsignatures = "0.3.2"
+thiserror = { workspace = true }
+anoncreds-clsignatures = { workspace = true }

--- a/aries/misc/indy_ledger_response_parser/Cargo.toml
+++ b/aries/misc/indy_ledger_response_parser/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
-time = "0.3.20"
 indy-vdr.workspace = true
 thiserror = "1.0.44"
 anoncreds-clsignatures = "0.3.2"

--- a/aries/misc/legacy/diddoc_legacy/Cargo.toml
+++ b/aries/misc/legacy/diddoc_legacy/Cargo.toml
@@ -9,13 +9,13 @@ license.workspace = true
 doctest = false
 
 [dependencies]
-serde = "1.0.97"
-serde_json = "1.0.40"
-serde_derive = "1.0.97"
-url = { version = "2.3", features = ["serde"] }
-thiserror = "1.0.37"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_derive = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+thiserror = { workspace = true }
 shared = { path = "../../shared" }
 display_as_json = { path = "../../../../misc/display_as_json" }
 
 [dev-dependencies]
-serde_json = "1.0.91"
+serde_json = { workspace = true }

--- a/aries/misc/shared/Cargo.toml
+++ b/aries/misc/shared/Cargo.toml
@@ -9,11 +9,11 @@ license.workspace = true
 doctest = false
 
 [dependencies]
-lazy_static = "1.3"
-regex = "1.1.0"
-thiserror = "1.0.37"
-bs58 = "0.5.1"
-serde = { version = "1.0.97", features = ["derive"] }
-serde_json = "1.0.96"
-reqwest = "0.12.5"
-log = "0.4.17"
+lazy_static = { workspace = true }
+regex = { workspace = true }
+thiserror = { workspace = true }
+bs58 = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+log = { workspace = true }

--- a/aries/misc/test_utils/Cargo.toml
+++ b/aries/misc/test_utils/Cargo.toml
@@ -27,7 +27,6 @@ aries_vcx_ledger = { path = "../../aries_vcx_ledger" }
 public_key = { path = "../../../did_core/public_key" }
 indy-ledger-response-parser = { path = "../indy_ledger_response_parser", optional = true }
 indy-vdr-proxy-client = { workspace = true, optional = true }
-lazy_static = "1"
 serde_json = "1"
 rand = "0.8"
 uuid = { version = "1", default-features = false, features = ["v4"] }

--- a/aries/misc/test_utils/Cargo.toml
+++ b/aries/misc/test_utils/Cargo.toml
@@ -27,11 +27,11 @@ aries_vcx_ledger = { path = "../../aries_vcx_ledger" }
 public_key = { path = "../../../did_core/public_key" }
 indy-ledger-response-parser = { path = "../indy_ledger_response_parser", optional = true }
 indy-vdr-proxy-client = { workspace = true, optional = true }
-serde_json = "1"
-rand = "0.8"
-uuid = { version = "1", default-features = false, features = ["v4"] }
-async-trait = "0.1"
-chrono = "0.4"
-env_logger = "0.11.3"
-log = "0.4"
-thiserror = "1.0.40"
+serde_json = { workspace = true }
+rand = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }

--- a/aries/wrappers/uniffi-aries-vcx/core/Cargo.toml
+++ b/aries/wrappers/uniffi-aries-vcx/core/Cargo.toml
@@ -16,7 +16,7 @@ path = "uniffi-bindgen.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uniffi = { version = "0.23.0", features = ["cli"] }
+uniffi = { workspace = true, features = ["cli"] }
 aries_vcx = { path = "../../../aries_vcx", features = [
     "anoncreds",
     "askar_wallet"
@@ -24,16 +24,16 @@ aries_vcx = { path = "../../../aries_vcx", features = [
 aries_vcx_ledger = { path = "../../../aries_vcx_ledger" }
 aries_vcx_anoncreds = { path = "../../../aries_vcx_anoncreds" }
 indy-vdr.workspace = true
-tokio = { version = "1.38.0", features = ["rt-multi-thread"] }
-once_cell = "1.17.0"
-thiserror = "1.0.38"
-serde_json = "1.0.91"
-async-trait = "0.1.64"
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+once_cell = { workspace = true }
+thiserror = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
 did_parser_nom = { path = "../../../../did_core/did_parser_nom" }
 shared = { path = "../../../misc/shared" }
-url = "2.3.1"
-android_logger = "0.14.1"
-log = "0.4.16"
+url = { workspace = true }
+android_logger = { workspace = true }
+log = { workspace = true }
 
 [build-dependencies]
-uniffi = { version = "0.23.0", features = ["build", "cli"] }
+uniffi = { workspace = true, features = ["build", "cli"] }

--- a/aries/wrappers/uniffi-aries-vcx/core/Cargo.toml
+++ b/aries/wrappers/uniffi-aries-vcx/core/Cargo.toml
@@ -28,10 +28,8 @@ tokio = { version = "1.38.0", features = ["rt-multi-thread"] }
 once_cell = "1.17.0"
 thiserror = "1.0.38"
 serde_json = "1.0.91"
-serde = { version = "1.0.188", features = ["derive"] }
 async-trait = "0.1.64"
 did_parser_nom = { path = "../../../../did_core/did_parser_nom" }
-diddoc_legacy = { path = "../../../misc/legacy/diddoc_legacy" }
 shared = { path = "../../../misc/shared" }
 url = "2.3.1"
 android_logger = "0.14.1"

--- a/did_core/did_doc/Cargo.toml
+++ b/did_core/did_doc/Cargo.toml
@@ -22,9 +22,6 @@ display_as_json = { path = "../../misc/display_as_json" }
 did_key = { path = "../did_methods/did_key" }
 thiserror = "1.0.40"
 typed-builder = "0.19.1"
-log = "0.4"
 
 [dev-dependencies]
-pretty_assertions = "1.4.0"
-env_logger = "0.11.3"
 

--- a/did_core/did_doc/Cargo.toml
+++ b/did_core/did_doc/Cargo.toml
@@ -7,21 +7,21 @@ edition = "2021"
 jwk = ["public_key/jwk"]
 
 [dependencies]
-base64 = "0.22.1"
-bs58 = "0.5.0"
+base64 = { workspace = true }
+bs58 = { workspace = true }
 did_parser_nom = { path = "../did_parser_nom" }
 public_key = { path = "../public_key" }
-hex = "0.4.3"
-multibase = "0.9.1"
-pem = "3.0.4"
-serde = { version = "1.0.159", default-features = false, features = ["derive"] }
-serde_json = "1.0.95"
-uniresid = { version = "0.1.4", default-features = false, features = ["serde"] }
-url = { version = "2.3.1", features = ["serde"] }
+hex = { workspace = true }
+multibase = { workspace = true }
+pem = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+uniresid = { workspace = true, features = ["serde"] }
+url = { workspace = true, features = ["serde"] }
 display_as_json = { path = "../../misc/display_as_json" }
 did_key = { path = "../did_methods/did_key" }
-thiserror = "1.0.40"
-typed-builder = "0.19.1"
+thiserror = { workspace = true }
+typed-builder = { workspace = true }
 
 [dev-dependencies]
 

--- a/did_core/did_methods/did_cheqd/Cargo.toml
+++ b/did_core/did_methods/did_cheqd/Cargo.toml
@@ -25,7 +25,6 @@ hyper-util = { version = "0.1.10", features = ["client-legacy", "http2"] }
 http-body-util = "0.1.2"
 async-trait = "0.1.68"
 serde_json = "1.0.96"
-serde = { version = "1.0.160", features = ["derive"] }
 thiserror = "1.0.40"
 tokio = { version = "1.38.0" }
 chrono = { version = "0.4.24", default-features = false, features = ["now"] }

--- a/did_core/did_methods/did_cheqd/Cargo.toml
+++ b/did_core/did_methods/did_cheqd/Cargo.toml
@@ -12,27 +12,20 @@ path = "src/lib.rs"
 
 [dependencies]
 did_resolver = { path = "../../did_resolver" }
-tonic = { version = "0.12.3", default-features = false, features = [
-    "codegen",
-    "prost",
-    "channel",
-] }
-prost = { version = "0.13.3", default-features = false }
-prost-types = "0.13.3"
-native-tls = { version = "0.2.12", features = ["alpn"] }
-hyper-tls = "0.6.0"
-hyper-util = { version = "0.1.10", features = ["client-legacy", "http2"] }
-http-body-util = "0.1.2"
-async-trait = "0.1.68"
-serde_json = "1.0.96"
-thiserror = "1.0.40"
-tokio = { version = "1.38.0" }
-chrono = { version = "0.4.24", default-features = false, features = ["now"] }
-url = { version = "2.3.1", default-features = false }
-bytes = "1.8.0"
+tonic = { workspace = true, features = ["codegen", "prost", "channel"] }
+prost = { workspace = true }
+prost-types = { workspace = true }
+native-tls = { workspace = true, features = ["alpn"] }
+hyper-tls = { workspace = true }
+hyper-util = { workspace = true, features = ["client-legacy", "http2"] }
+http-body-util = { workspace = true }
+async-trait = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+chrono = { workspace = true, features = ["now"] }
+url = { workspace = true }
+bytes = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.38.0", default-features = false, features = [
-    "macros",
-    "rt",
-] }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/did_core/did_methods/did_cheqd/cheqd_proto_gen/Cargo.toml
+++ b/did_core/did_methods/did_cheqd/cheqd_proto_gen/Cargo.toml
@@ -8,4 +8,4 @@ name = "cheqd-proto-gen"
 path = "src/main.rs"
 
 [dependencies]
-tonic-build = "0.12.3"
+tonic-build = { workspace = true }

--- a/did_core/did_methods/did_jwk/Cargo.toml
+++ b/did_core/did_methods/did_jwk/Cargo.toml
@@ -8,11 +8,11 @@ did_parser_nom = { path = "../../did_parser_nom" }
 did_doc = { path = "../../did_doc" }
 did_resolver = { path = "../../did_resolver" }
 public_key = { path = "../../public_key", features = ["jwk"] }
-async-trait = "0.1.68"
-serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
-base64 = "0.22.1"
-thiserror = "1.0.44"
+async-trait = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+base64 = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/did_core/did_methods/did_key/Cargo.toml
+++ b/did_core/did_methods/did_key/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 public_key = { path = "../../public_key" }
 did_parser_nom = { path = "../../did_parser_nom" }
-serde = "1.0.175"
-serde_json = "1.0.103"
-thiserror = "1.0.44"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/did_core/did_methods/did_peer/Cargo.toml
+++ b/did_core/did_methods/did_peer/Cargo.toml
@@ -16,10 +16,7 @@ serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.96"
 async-trait = "0.1.68"
 base64 = "0.22.1"
-bs58 = "0.5.0"
 multibase = "0.9.1"
-unsigned-varint = "0.8.0"
-once_cell = "1.18.0"
 sha2 = "0.10.8"
 log = "0.4.16"
 url = { version = "2.3.1", features = ["serde"] }

--- a/did_core/did_methods/did_peer/Cargo.toml
+++ b/did_core/did_methods/did_peer/Cargo.toml
@@ -10,21 +10,21 @@ did_parser_nom = { path = "../../did_parser_nom" }
 did_doc = { path = "../../did_doc" }
 did_resolver = { path = "../../did_resolver" }
 public_key = { path = "../../public_key" }
-thiserror = "1.0.40"
-regex = "1.8.4"
-serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
-async-trait = "0.1.68"
-base64 = "0.22.1"
-multibase = "0.9.1"
-sha2 = "0.10.8"
-log = "0.4.16"
-url = { version = "2.3.1", features = ["serde"] }
+thiserror = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+multibase = { workspace = true }
+sha2 = { workspace = true }
+log = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 display_as_json = { path = "../../../misc/display_as_json" }
-typed-builder = "0.19.1"
+typed-builder = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt"] }
-pretty_assertions = "1.4.0"
-env_logger = "0.11.3"
-log = "0.4"
+tokio = { workspace = true, features = ["macros", "rt"] }
+pretty_assertions = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }

--- a/did_core/did_methods/did_resolver_sov/Cargo.toml
+++ b/did_core/did_methods/did_resolver_sov/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2021"
 [dependencies]
 did_resolver = { path = "../../did_resolver" }
 aries_vcx_ledger = { path = "../../../aries/aries_vcx_ledger" }
-async-trait = "0.1.68"
-serde_json = "1.0.96"
-serde = { version = "1.0.160", features = ["derive"] }
-chrono = { version = "0.4.24", default-features = false }
-thiserror = "1.0.40"
-url = "2.3.1"
-log = "0.4.16"
-bs58 = "0.5.0" 
+async-trait = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }
+log = { workspace = true }
+bs58 = { workspace = true } 
 
 [dev-dependencies]
-mockall = "0.13.0"
+mockall = { workspace = true }
 aries_vcx = { path = "../../../aries/aries_vcx" }
-tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 test_utils = {path = "../../../aries/misc/test_utils", features = ["askar_wallet"] }
 aries_vcx_wallet = { path = "../../../aries/aries_vcx_wallet" }

--- a/did_core/did_methods/did_resolver_sov/Cargo.toml
+++ b/did_core/did_methods/did_resolver_sov/Cargo.toml
@@ -19,6 +19,5 @@ bs58 = "0.5.0"
 mockall = "0.13.0"
 aries_vcx = { path = "../../../aries/aries_vcx" }
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt"] }
-uuid = "1.3.1"
 test_utils = {path = "../../../aries/misc/test_utils", features = ["askar_wallet"] }
 aries_vcx_wallet = { path = "../../../aries/aries_vcx_wallet" }

--- a/did_core/did_methods/did_resolver_web/Cargo.toml
+++ b/did_core/did_methods/did_resolver_web/Cargo.toml
@@ -7,19 +7,16 @@ edition = "2021"
 
 [dependencies]
 did_resolver = { path = "../../did_resolver" }
-async-trait = "0.1.68"
-serde_json = "1.0.96"
-thiserror = "1.0.40"
-hyper = { version = "1.5.1" }
-hyper-tls = "0.6.0"
-hyper-util = { version = "0.1.10", features = ["client-legacy", "http1", "http2"] }
-http-body-util = "0.1.2"
+async-trait = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+hyper = { workspace = true }
+hyper-tls = { workspace = true }
+hyper-util = { workspace = true, features = ["client-legacy", "http1", "http2"] }
+http-body-util = { workspace = true }
 
 [dev-dependencies]
-hyper = { version = "1.5.1", features = ["server"] }
-hyper-util = { version = "0.1.10", features = ["server"] }
-tokio = { version = "1.38.0", default-features = false, features = [
-    "macros",
-    "rt",
-] }
-tokio-test = "0.4.2"
+hyper = { workspace = true, features = ["server"] }
+hyper-util = { workspace = true, features = ["server"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
+tokio-test = { workspace = true }

--- a/did_core/did_parser_nom/Cargo.toml
+++ b/did_core/did_parser_nom/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nom = "7.1.3"
-serde = "1.0.160"
-log = "0.4.16"
-percent-encoding = "2"
+nom = { workspace = true }
+serde = { workspace = true }
+log = { workspace = true }
+percent-encoding = { workspace = true }
 
 [dev-dependencies]
-serde_test = "1.0.176"
-env_logger = "0.11.3"
+serde_test = { workspace = true }
+env_logger = { workspace = true }

--- a/did_core/did_resolver/Cargo.toml
+++ b/did_core/did_resolver/Cargo.toml
@@ -9,8 +9,8 @@ default = []
 [dependencies]
 did_parser_nom = { path = "../did_parser_nom" }
 did_doc = { path = "../did_doc" }
-async-trait = "0.1.68"
-chrono = { version = "0.4.24", default-features = false, features = ["serde"] }
-serde = { version = "1.0.160", default-features = false, features = ["derive"] }
-serde_json = "1.0.103"
-typed-builder = "0.19.1"
+async-trait = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+typed-builder = { workspace = true }

--- a/did_core/did_resolver_registry/Cargo.toml
+++ b/did_core/did_resolver_registry/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 did_resolver = { path = "../did_resolver" }
-serde_json = "1.0.103"
-serde = "1.0.174"
-async-trait = "0.1.72"
+serde_json = { workspace = true }
+serde = { workspace = true }
+async-trait = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.38.0", default-features = false, features = ["macros", "rt"] }
-mockall = "0.13.0"
-async-trait = "0.1.68"
+tokio = { workspace = true, features = ["macros", "rt"] }
+mockall = { workspace = true }
+async-trait = { workspace = true }

--- a/did_core/public_key/Cargo.toml
+++ b/did_core/public_key/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 jwk = ["dep:askar-crypto"]
 
 [dependencies]
-thiserror = "1.0.40"
-serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
-base64 = "0.22.1"
-bs58 = "0.5.0"
-multibase = "0.9.1"
-unsigned-varint = "0.8.0"
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+base64 = { workspace = true }
+bs58 = { workspace = true }
+multibase = { workspace = true }
+unsigned-varint = { workspace = true }
 # askar-crypto used for jwk conversion. maintain minimal feature set
 askar-crypto = { workspace = true, features = [
     "std",

--- a/misc/display_as_json/Cargo.toml
+++ b/misc/display_as_json/Cargo.toml
@@ -10,10 +10,10 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-syn = "2.0.72"
-quote = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
 
 [dev-dependencies]
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }

--- a/misc/simple_message_relay/Cargo.toml
+++ b/misc/simple_message_relay/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "4"
+actix-web = { workspace = true }


### PR DESCRIPTION
I recall facing a lot of dependency conflicts when adding or updating any dependency. 

This was in part because all our packages define their own dependencies individually, 
and since there's cross dependencies among our crates, there would often be version conflicts. 
For example when adding a new dependency or updating an existing one. 

This PR centralises as many dependencies as possible into the workspace definition. 
So there's one central place to define versions. 
One can always manually use a different version in a package if desired. 

The resulting benefits should be:
* easy upgrade of deps in future 
* may help reduce binary size (as we carry fewer versions of each dep)




