### PR TITLE
chore: update actions

### DIFF
--- a/.github/actions/upload-docker-logs/action.yml
+++ b/.github/actions/upload-docker-logs/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: tar cvzf ./logs.tgz ./logs
     - name: "Upload logs to GitHub"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ./logs.tgz


### PR DESCRIPTION
actions/upload-artifact and actions/download-artifact have been deprecated and need updated.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/